### PR TITLE
Add MCPHub config to scanner

### DIFF
--- a/src/mcp_scan/cli.py
+++ b/src/mcp_scan/cli.py
@@ -65,6 +65,7 @@ if sys.platform == "linux" or sys.platform == "linux2":
         "~/.cursor/mcp.json",  # cursor
         "~/.vscode/mcp.json",  # vscode
         "~/.config/Code/User/settings.json",  # vscode linux
+        "~/.config/mcphub/servers.json", # MCPHub
     ]
 elif sys.platform == "darwin":
     # OS X
@@ -74,6 +75,7 @@ elif sys.platform == "darwin":
         "~/Library/Application Support/Claude/claude_desktop_config.json",  # Claude Desktop mac
         "~/.vscode/mcp.json",  # vscode
         "~/Library/Application Support/Code/User/settings.json",  # vscode mac
+        "~/.config/mcphub/servers.json", # MCPHub
     ]
 elif sys.platform == "win32":
     WELL_KNOWN_MCP_PATHS = [
@@ -82,6 +84,7 @@ elif sys.platform == "win32":
         "~/AppData/Roaming/Claude/claude_desktop_config.json",  # Claude Desktop windows
         "~/.vscode/mcp.json",  # vscode
         "~/AppData/Roaming/Code/User/settings.json",  # vscode windows
+        "~/.config/mcphub/servers.json", # MCPHub
     ]
 else:
     WELL_KNOWN_MCP_PATHS = []


### PR DESCRIPTION
This is an addtion to the default scan locations. 

The added path is for the default MCP servers configuration for MCPHub. [MCP Hub](https://www.npmjs.com/package/mcp-hub) acts as a central coordinator between clients and multiple MCP servers, making it easy to utilize capabilities from multiple servers through a single interface. Implements [MCP 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26) specification. 

There is a Neovim plugin [mcphub.nvim](https://github.com/ravitemer/mcphub.nvim). 