### PR TITLE
fix: skip cross-ref check for single server

### DIFF
--- a/src/mcp_scan/MCPScanner.py
+++ b/src/mcp_scan/MCPScanner.py
@@ -198,10 +198,13 @@ class MCPScanner:
 
     async def check_cross_references(self, path_result: ScanPathResult) -> CrossRefResult:
         logger.info("Checking cross references for path: %s", path_result.path)
+        cross_ref_result = CrossRefResult(found=False)
         if sum(len(server.entities) for server in path_result.servers) < 2:
             logger.debug("Not enough entities to check cross references")
-            return CrossRefResult(found=False)
-        cross_ref_result = CrossRefResult(found=False)
+            return cross_ref_result
+        if len(path_result.servers) < 2:
+            logger.debug("Not enough servers to check cross references")
+            return cross_ref_result
         for server in path_result.servers:
             other_servers = [s for s in path_result.servers if s != server]
             other_server_names = [s.name for s in other_servers]

--- a/tests/e2e/test_full_scan_flow.py
+++ b/tests/e2e/test_full_scan_flow.py
@@ -36,7 +36,15 @@ class TestFullScanFlow:
         except json.JSONDecodeError:
             pytest.fail("Failed to parse JSON output")
 
-    def test_scan(self):
+    @pytest.mark.parametrize(
+        "path, server_names",
+        [
+            ("tests/mcp_servers/configs_files/weather_config.json", ["Weather"]),
+            ("tests/mcp_servers/configs_files/math_config.json", ["Math"]),
+            ("tests/mcp_servers/configs_files/all_config.json", ["Weather", "Math"]),
+        ],
+    )
+    def test_scan(self, path, server_names):
         path = "tests/mcp_servers/configs_files/all_config.json"
         result = subprocess.run(
             ["uv", "run", "-m", "src.mcp_scan.run", "scan", "--json", path],
@@ -53,20 +61,24 @@ class TestFullScanFlow:
             with open(f"tests/mcp_servers/signatures/{server['name'].lower()}_server_signature.json") as f:
                 assert server["signature"] == json.load(f), f"Signature mismatch for {server['name']} server"
         
-        assert results["Weather"] == [{
-            'changed': None,
-            'messages': [],
-            'status': None,
-            'verified': True,
-            'whitelisted': None,
-        }]
-        assert results["Math"] == [{
-            'changed': None,
-            'messages': [],
-            'status': None,
-            'verified': True,
-            'whitelisted': None,
-        }] * 4
+        expected_results = {
+            "Weather": [{
+                    'changed': None,
+                    'messages': [],
+                    'status': None,
+                    'verified': True,
+                    'whitelisted': None,
+                }],
+            "Math": [{
+                    'changed': None,
+                    'messages': [],
+                    'status': None,
+                    'verified': True,
+                    'whitelisted': None,
+                }] * 4,
+        }
+        for server_name in server_names:
+            assert results[server_name] == expected_results[server_name], f"Results mismatch for {server_name} server"
 
     def test_inspect(self):
         path = "tests/mcp_servers/configs_files/all_config.json"


### PR DESCRIPTION
You don't need to `check_cross_references` when there's just one server. Otherwise, you'll get an IndexError [here](https://github.com/invariantlabs-ai/mcp-scan/blob/3efc674db22bcde664dd27363fbe59b7287afef8/src/mcp_scan/MCPScanner.py#L214).