### PR TITLE
Fix IndexError in cross-reference logic during MCP inspection

### DIFF
--- a/src/mcp_scan/MCPScanner.py
+++ b/src/mcp_scan/MCPScanner.py
@@ -211,7 +211,10 @@ class MCPScanner:
             for entity in server.entities:
                 tokens = (entity.description or "").lower().split()
                 for token in tokens:
-                    best_distance = calculate_distance(reference=token, responses=list(flagged_names))[0]
+                    distances = calculate_distance(reference=token, responses=list(flagged_names))
+                    if not distances:
+                        continue  # Skip if there are no flagged names to compare
+                    best_distance = distances[0]
                     if ((best_distance[1] <= 2) and (len(token) >= 5)) or (token in flagged_names):
                         logger.warning("Cross-reference found: %s with token %s", entity.name, token)
                         cross_ref_result.found = True

--- a/src/mcp_scan/mcp_client.py
+++ b/src/mcp_scan/mcp_client.py
@@ -65,25 +65,36 @@ async def check_server(
                 if not isinstance(server_config, SSEServer) or meta.capabilities.prompts:
                     logger.debug("Fetching prompts")
                     try:
-                        prompts = (await session.list_prompts()).prompts
+                        result = await session.list_prompts()
+                        prompts = result.prompts if result else []
                         logger.debug("Found %d prompts", len(prompts))
-                    except Exception:
-                        logger.exception("Failed to list prompts")
-
+                    except Exception as e:
+                        if "Method not found" in str(e):
+                            logger.debug("Prompts not supported by this server")
+                        else:
+                            logger.exception("Failed to list prompts")
                 if not isinstance(server_config, SSEServer) or meta.capabilities.resources:
                     logger.debug("Fetching resources")
                     try:
-                        resources = (await session.list_resources()).resources
+                        result = await session.list_resources()
+                        resources = result.resources if result else []
                         logger.debug("Found %d resources", len(resources))
-                    except Exception:
-                        logger.exception("Failed to list resources")
+                    except Exception as e:
+                        if "Method not found" in str(e):
+                            logger.debug("Resources not supported by this server")
+                        else:
+                            logger.exception("Failed to list resources")
                 if not isinstance(server_config, SSEServer) or meta.capabilities.tools:
                     logger.debug("Fetching tools")
                     try:
-                        tools = (await session.list_tools()).tools
+                        result = await session.list_tools()
+                        tools = result.tools if result else []
                         logger.debug("Found %d tools", len(tools))
-                    except Exception:
-                        logger.exception("Failed to list tools")
+                    except Exception as e:
+                        if "Method not found" in str(e):
+                            logger.debug("Tools not supported by this server")
+                        else:
+                            logger.exception("Failed to list tools")
                 logger.info("Server check completed successfully")
                 return ServerSignature(
                     metadata=meta,


### PR DESCRIPTION
This patch prevents mcp-scan from crashing during cross-reference similarity checks when there are no other servers or entities to compare against.

The core issue was caused by calculate_distance(...) returning an empty list, and the code assuming at least one result existed.

Now, if no distances are found, the token is skipped. This makes inspection safe for minimal MCP configs with just one server or sparse descriptions.