### PR TITLE
fix: default to 'scan' if only config file provided

### DIFF
--- a/src/mcp_scan/cli.py
+++ b/src/mcp_scan/cli.py
@@ -376,7 +376,12 @@ def main():
     add_install_arguments(proxy_parser)
 
     # Parse arguments (default to 'scan' if no command provided)
-    args = parser.parse_args(["scan"] if len(sys.argv) == 1 else None)
+    if len(sys.argv) == 1:
+        args = parser.parse_args(["scan"])
+    elif len(sys.argv) == 2 and sys.argv[1] not in subparsers.choices:
+        args = parser.parse_args(["scan", sys.argv[1]])
+    else:
+        args = parser.parse_args()
 
     # postprocess the files argument (if shorthands are used)
     if hasattr(args, "files") and args.files is None:


### PR DESCRIPTION
Make `mcp-scan ~/custom/config.json` work.