### PR TITLE
Fix: Improve error handling and Docker timeout processing

### DIFF
--- a/src/mcp_scan/mcp_client.py
+++ b/src/mcp_scan/mcp_client.py
@@ -88,23 +88,35 @@ async def check_server(
                     try:
                         prompts = (await session.list_prompts()).prompts
                         logger.debug("Found %d prompts", len(prompts))
-                    except Exception:
-                        logger.exception("Failed to list prompts")
+                    except Exception as e:
+                        logger.debug("Failed to list prompts: %s", str(e))
+                        if "prompts not supported" in str(e) or "Method not found" in str(e):
+                            logger.debug("Server does not support prompts capability or method, skipping")
+                        else:
+                            logger.exception("Failed to list prompts")
 
                 if isinstance(server_config, StdioServer) or meta.capabilities.resources:
                     logger.debug("Fetching resources")
                     try:
                         resources = (await session.list_resources()).resources
                         logger.debug("Found %d resources", len(resources))
-                    except Exception:
-                        logger.exception("Failed to list resources")
+                    except Exception as e:
+                        logger.debug("Failed to list resources: %s", str(e))
+                        if "resources not supported" in str(e) or "Method not found" in str(e):
+                            logger.debug("Server does not support resources capability or method, skipping")
+                        else:
+                            logger.exception("Failed to list resources")
                 if isinstance(server_config, StdioServer) or meta.capabilities.tools:
                     logger.debug("Fetching tools")
                     try:
                         tools = (await session.list_tools()).tools
                         logger.debug("Found %d tools", len(tools))
-                    except Exception:
-                        logger.exception("Failed to list tools")
+                    except Exception as e:
+                        logger.debug("Failed to list tools: %s", str(e))
+                        if "tools not supported" in str(e) or "Method not found" in str(e):
+                            logger.debug("Server does not support tools capability or method, skipping")
+                        else:
+                            logger.exception("Failed to list tools")
                 logger.info("Server check completed successfully")
                 return ServerSignature(
                     metadata=meta,


### PR DESCRIPTION
## Summary
This PR addresses several issues related to error handling and timeout processing in the MCP scanning process:

1. **Better error handling for unsupported methods**: Properly handle "Method not found" and similar errors when scanning MCP servers that don't support certain capabilities.
2. **Empty data handling**: Add validation to prevent failures when encountering empty data sets during scanning.
3. **Docker timeout improvements**: Implement special timeout handling for Docker commands to ensure scans can continue even when Docker processes don't respond correctly.

## Problem
Previously, the scanner could get stuck or fail in several scenarios:
- When encountering servers that don't support certain MCP methods
- When working with empty data sets during verification
- When Docker commands didn't respond within the timeout period

## Solution
1. Added better error handling in `mcp_client.py` to gracefully handle "Method not found" errors
2. Modified `verify_api.py` to handle empty payloads and tools lists
3. Implemented specialized timeout handling for Docker commands in `MCPScanner.py` with proper task cancellation

## Test plan
- Test with servers that don't support all MCP methods
- Test with configurations that would previously lead to empty data sets
- Test with Docker-based MCP servers that may hang or time out

This PR fixes the issue where scanning results wouldn't display due to these errors.