### PR TITLE
fix: ui improvment

### DIFF
--- a/src/mcp_scan/printer.py
+++ b/src/mcp_scan/printer.py
@@ -164,7 +164,7 @@ def format_global_issue(result: ScanPathResult, issue: Issue, show_all: bool = F
     tree = Tree(f"[yellow]\n⚠️ [{issue.code}]: {issue.message}[/yellow]")
 
     def _format_tool_kind_name(tool_kind_name: str) -> str:
-        return " ".join(tool_kind_name.split("_")[:-1]).capitalize()
+        return " ".join(tool_kind_name.split("_")).title()
 
     def _format_tool_name(server_name: str, tool_name: str, value: float) -> str:
         tool_string = f"{server_name}/{tool_name}"


### PR DESCRIPTION
Now it looks like
```
├── Public Sink Tool
│   ├── supabase/deploy_edge_function  High
│   ├── supabase/get_advisors          Low
│   └── supabase/search_docs           Low
├── Untrusted Content Tool
│   ├── supabase/list_branches         High
│   ├── supabase/list_extensions       High
│   ├── supabase/list_migrations       High
│   └── ... and 8 more tools (to see all, use --full-toxic-flows)
└── Private Data Tool
    ├── supabase/execute_sql           High
    ├── supabase/get_logs              High
    ├── supabase/list_branches         Low
    └── ... and 2 more tools (to see all, use --full-toxic-flows)
```
Instead of 
```
├── Public sink
│   ├── supabase/deploy_edge_function  High
│   ├── supabase/get_advisors          Low
│   └── supabase/search_docs           Low
├── Untrusted content
│   ├── supabase/list_branches         High
│   ├── supabase/list_extensions       High
│   ├── supabase/list_migrations       High
│   └── ... and 8 more tools (to see all, use --full-toxic-flows)
└── Private data
    ├── supabase/execute_sql           High
    ├── supabase/get_logs              High
    ├── supabase/list_branches         Low
    └── ... and 2 more tools (to see all, use --full-toxic-flows)
```
Namely:
* Added `Tool`
* Capitalize better