### PR TITLE
For VerifyServerRequest, do server.signature.model_dump() instead of server.signature directly. There is some pydantic issue here and we get failures otherwise.

### DIFF
--- a/src/mcp_scan/verify_api.py
+++ b/src/mcp_scan/verify_api.py
@@ -1,14 +1,12 @@
 import logging
 
 import aiohttp
-import rich
 
 from .identity import IdentityManager
 from .models import (
     AnalysisServerResponse,
     Issue,
     ScanPathResult,
-    ServerSignature,
     VerifyServerRequest,
 )
 


### PR DESCRIPTION
The error stack: 

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/hemang/McpScan/mcp-scan/src/mcp_scan/cli.py", line 534, in <module>
    main()
  File "/Users/hemang/McpScan/mcp-scan/src/mcp_scan/cli.py", line 485, in main
    asyncio.run(run_scan_inspect(args=args))
  File "/Users/hemang/.pyenv/versions/3.12.2/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/hemang/.pyenv/versions/3.12.2/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hemang/.pyenv/versions/3.12.2/lib/python3.12/asyncio/base_events.py", line 685, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/hemang/McpScan/mcp-scan/src/mcp_scan/cli.py", line 509, in run_scan_inspect
    result = await scanner.scan()
             ^^^^^^^^^^^^^^^^^^^^
  File "/Users/hemang/McpScan/mcp-scan/src/mcp_scan/MCPScanner.py", line 217, in scan
    result_awaited = await asyncio.gather(*result)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hemang/McpScan/mcp-scan/src/mcp_scan/MCPScanner.py", line 198, in scan_path
    path_result = await analyze_scan_path(
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hemang/McpScan/mcp-scan/src/mcp_scan/verify_api.py", line 31, in analyze_scan_path
    payload = VerifyServerRequest(root=[server.signature for server in scan_path.servers])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hemang/.pyenv/versions/3.12.2/envs/.platform_venv/lib/python3.12/site-packages/pydantic/root_model.py", line 71, in __init__
    self.__pydantic_validator__.validate_python(root, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 2 validation errors for VerifyServerRequest
0
  Input should be a valid dictionary or instance of ServerSignature [type=model_type, input_value=ServerSignature(metadata=...t'}, annotations=None)]), input_type=ServerSignature]
    For further information visit https://errors.pydantic.dev/2.11/v/model_type
1
  Input should be a valid dictionary or instance of ServerSignature [type=model_type, input_value=ServerSignature(metadata=...']}, annotations=None)]), input_type=ServerSignature]
    For further information visit https://errors.pydantic.dev/2.11/v/model_type
```

This issue is not reproducible for everyone but @knielsen404 and I have encountered this. Discussed with @mmilanta  and for now we decided to do the workaround. We can investigate the underlying issue later.