### PR TITLE
fix: retry when backend is timing out

### DIFF
--- a/src/mcp_scan/verify_api.py
+++ b/src/mcp_scan/verify_api.py
@@ -218,10 +218,8 @@ async def analyze_machine(
                         return scan_paths  # Success - exit the function
 
         except TimeoutError as e:
-            logger.warning(
-                f"Timeout while sending found servers (attempt {attempt + 1}/{max_retries}): {e} to analysis server."
-            )
-            error_text = f"Timeout while sending found servers to analysis server: {e}"
+            logger.warning(f"API timeout while scanning discovered servers (attempt {attempt + 1}/{max_retries}): {e}.")
+            error_text = f"API timeout while scanning discovered servers: {e}"
 
         except aiohttp.ClientResponseError as e:
             error_text = f"Could not reach analysis server: {e.status} - {e.message}"


### PR DESCRIPTION
Retry when mcp-scan backend is timing out