### PR TITLE
Add AgentAudit security badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="https://pypi.python.org/pypi/mcp-scan"><img src="https://img.shields.io/pypi/v/mcp-scan.svg" alt="mcp-scan"/></a>
   <a href="https://pypi.python.org/pypi/mcp-scan"><img src="https://img.shields.io/pypi/l/mcp-scan.svg" alt="mcp-scan license"/></a>
   <a href="https://pypi.python.org/pypi/mcp-scan"><img src="https://img.shields.io/pypi/pyversions/mcp-scan.svg" alt="mcp-scan python version requirements"/></a>
+  <a href="https://agentaudit.dev/packages/mcp-scan"><img src="https://agentaudit.dev/api/badge/mcp-scan" alt="AgentAudit Security"/></a>
 </p>
 
 <div align="center">


### PR DESCRIPTION
## Summary

Adds an [AgentAudit](https://agentaudit.dev) security badge to the README, showing the current trust score for the `mcp-scan` package.

**Current Trust Score: 95/100** — No significant security findings detected across multiple independent AI-powered audits.

[![AgentAudit Security](https://agentaudit.dev/api/badge/mcp-scan)](https://agentaudit.dev/packages/mcp-scan)

## What is AgentAudit?

[AgentAudit](https://agentaudit.dev) is an open security registry for AI agent packages (MCP servers, skills, npm/pip packages). It provides:

- Multi-model security audits (Claude, GPT-4o, Gemini, etc.)
- Consensus-based trust scoring
- Standardized vulnerability IDs (ASF-IDs)

The badge auto-updates as new audits are submitted. Full audit details: https://agentaudit.dev/packages/mcp-scan