### PR TITLE
fix: use different pypi token variable name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ shiv: build
 	uv run shiv -c agent-scan -o dist/agent-scan.pyz --python "/usr/bin/env python3" dist/*.whl
 
 publish-pypi: build
-	uv publish --token ${PYPI_TOKEN}
+	uv publish --token ${AGENT_SCAN_PYPI_TOKEN}
 
 publish: publish-pypi
 


### PR DESCRIPTION
User a different token variable name for our release pipelines.