### PR TITLE
fix: add guard cmds on managed on top of user levels

### DIFF
--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -433,6 +433,12 @@ def main():
         default=None,
         help="Override the config file path (default: client-specific well-known path)",
     )
+    guard_install_parser.add_argument(
+        "--managed",
+        action="store_true",
+        default=False,
+        help="Install hooks to the managed (admin/MDM) config path instead of the user-level path",
+    )
 
     guard_uninstall_parser = guard_subparsers.add_parser(
         "uninstall",
@@ -448,6 +454,12 @@ def main():
         type=str,
         default=None,
         help="Override the config file path (default: client-specific well-known path)",
+    )
+    guard_uninstall_parser.add_argument(
+        "--managed",
+        action="store_true",
+        default=False,
+        help="Uninstall hooks from the managed (admin/MDM) config path instead of the user-level path",
     )
 
     # Parse arguments (default to 'scan' if no command provided)

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -28,6 +28,17 @@ DETECTION_MARKER = "snyk-agent-guard"
 CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 CURSOR_HOOKS_PATH = Path.home() / ".cursor" / "hooks.json"
 
+# Managed (MDM / admin-deployed) config paths — OS-specific
+if sys.platform == "darwin":
+    CLAUDE_MANAGED_SETTINGS_PATH = Path("/Library/Application Support/ClaudeCode/managed-settings.json")
+    CURSOR_MANAGED_HOOKS_PATH = Path("/Library/Application Support/Cursor/hooks.json")
+elif sys.platform == "win32":
+    CLAUDE_MANAGED_SETTINGS_PATH = Path("C:/Program Files/ClaudeCode/managed-settings.json")
+    CURSOR_MANAGED_HOOKS_PATH = Path("C:/ProgramData/Cursor/hooks.json")
+else:  # Linux and others
+    CLAUDE_MANAGED_SETTINGS_PATH = Path("/etc/claude-code/managed-settings.json")
+    CURSOR_MANAGED_HOOKS_PATH = Path("/etc/cursor/hooks.json")
+
 CLAUDE_HOOK_EVENTS = [
     "PreToolUse",
     "PostToolUse",
@@ -105,13 +116,15 @@ def _run_install(args) -> None:
     push_key = os.environ.get("PUSH_KEY", "")
     headless = bool(push_key)
     tenant_id: str = getattr(args, "tenant_id", None) or ""
+    managed: bool = getattr(args, "managed", False)
 
     label = _client_label(client)
+    scope = "managed" if managed else "user"
     snyk_token = ""
 
     if not headless:
         # Interactive flow — mint a push key
-        rich.print(f"Installing [bold magenta]Agent Guard[/bold magenta] hooks for [bold]{label}[/bold]")
+        rich.print(f"Installing [bold magenta]Agent Guard[/bold magenta] {scope} hooks for [bold]{label}[/bold]")
         rich.print()
 
         snyk_token = os.environ.get("SNYK_TOKEN", "")
@@ -146,7 +159,7 @@ def _run_install(args) -> None:
 
     hook_client = "claude-code" if client == "claude" else "cursor"
     minted = not headless  # True if we minted the key in this run
-    config_path = _config_path(client, getattr(args, "file", None))
+    config_path = _config_path(client, getattr(args, "file", None), managed=managed)
     # Copy hook script first so we can use it for the test event
     dest_path, script_existed, script_updated = _copy_hook_script(client, config_path)
 
@@ -177,9 +190,9 @@ def _run_install(args) -> None:
         config_changed = _install_cursor(command, config_path)
 
     if script_updated or config_changed or minted:
-        rich.print(f"[green]\u2713[/green]  Hooks installed for [bold]{label}[/bold]")
+        rich.print(f"[green]\u2713[/green]  {scope.title()} hooks installed for [bold]{label}[/bold]")
     else:
-        rich.print(f"[green]\u2713[/green]  {label} hook integration up to date")
+        rich.print(f"[green]\u2713[/green]  {label} {scope} hook integration up to date")
     rich.print(f"   Config:     [dim]{config_path}[/dim]")
     rich.print(f"   Script:     [dim]{dest_path}[/dim]")
     rich.print(f"   Remote URL: [dim]{url}[/dim]")
@@ -246,10 +259,12 @@ def _install_cursor(command: str, path: Path) -> bool:
 
 def _run_uninstall(args) -> None:
     client: str = args.client
+    managed: bool = getattr(args, "managed", False)
     label = _client_label(client)
-    config_path = _config_path(client, getattr(args, "file", None))
+    scope = "managed" if managed else "user"
+    config_path = _config_path(client, getattr(args, "file", None), managed=managed)
 
-    rich.print(f"Removing [bold magenta]Agent Guard[/bold magenta] hooks from [bold]{label}[/bold]")
+    rich.print(f"Removing [bold magenta]Agent Guard[/bold magenta] {scope} hooks from [bold]{label}[/bold]")
     rich.print("[dim]Other hooks in the file will be preserved.[/dim]")
     rich.print()
 
@@ -346,15 +361,28 @@ def _uninstall_cursor(path: Path) -> None:
 
 
 def _run_status() -> None:
+    rich.print("[bold]User-level hooks:[/bold]")
     _print_client_status("Claude Code", CLAUDE_SETTINGS_PATH, _detect_claude_install())
     rich.print()
     _print_client_status("Cursor", CURSOR_HOOKS_PATH, _detect_cursor_install())
     rich.print()
-    rich.print("[dim]# interactive flow[/dim]")
+
+    rich.print("[bold]Managed hooks:[/bold]")
+    _print_client_status(
+        "Claude Code", CLAUDE_MANAGED_SETTINGS_PATH, _detect_claude_install(CLAUDE_MANAGED_SETTINGS_PATH)
+    )
+    rich.print()
+    _print_client_status("Cursor", CURSOR_MANAGED_HOOKS_PATH, _detect_cursor_install(CURSOR_MANAGED_HOOKS_PATH))
+    rich.print()
+
+    rich.print("[dim]# interactive flow (user-level)[/dim]")
     rich.print("[dim]snyk-agent-scan guard install <client>[/dim]")
     rich.print()
+    rich.print("[dim]# managed flow[/dim]")
+    rich.print("[dim]snyk-agent-scan guard install <client> --managed[/dim]")
+    rich.print()
     rich.print("[dim]# headless flow (MDM)[/dim]")
-    rich.print("[dim]PUSH_KEY=<YOUR_PUSH_KEY> snyk-agent-scan guard install <client>[/dim]")
+    rich.print("[dim]PUSH_KEY=<YOUR_PUSH_KEY> snyk-agent-scan guard install <client> [--managed][/dim]")
     rich.print()
     rich.print(
         "[dim]If hooks are already installed and up to date, install commands are no-ops. To uninstall use 'snyk-agent-scan guard uninstall <client>'[/dim]"
@@ -582,10 +610,12 @@ def _client_label(client: str) -> str:
     return "Claude Code" if client == "claude" else "Cursor"
 
 
-def _config_path(client: str, override: str | None = None) -> Path:
+def _config_path(client: str, override: str | None = None, managed: bool = False) -> Path:
     """Resolve the config file path for a client, with optional override."""
     if override:
         return Path(override)
+    if managed:
+        return CLAUDE_MANAGED_SETTINGS_PATH if client == "claude" else CURSOR_MANAGED_HOOKS_PATH
     return CLAUDE_SETTINGS_PATH if client == "claude" else CURSOR_HOOKS_PATH
 
 

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -24,6 +24,7 @@ IS_WINDOWS = sys.platform == "win32"
 
 DEFAULT_REMOTE_URL = "https://api.snyk.io"
 DETECTION_MARKER = "snyk-agent-guard"
+_PERMISSION_DENIED = "__permission_denied__"
 
 CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 CURSOR_HOOKS_PATH = Path.home() / ".cursor" / "hooks.json"
@@ -144,6 +145,10 @@ def _run_install(args) -> None:
             rich.print("[bold red]Error:[/bold red] Tenant ID is required to mint a push key.")
             sys.exit(1)
 
+        # Preflight: verify target directory is writable before minting
+        config_path = _config_path(client, getattr(args, "file", None), managed=managed)
+        _preflight_writable(config_path)
+
         description = _get_machine_description(client)
         rich.print(f"[dim]Minting push key for {description}...[/dim]")
         try:
@@ -160,6 +165,33 @@ def _run_install(args) -> None:
     hook_client = "claude-code" if client == "claude" else "cursor"
     minted = not headless  # True if we minted the key in this run
     config_path = _config_path(client, getattr(args, "file", None), managed=managed)
+
+    try:
+        _install_hooks(
+            args, client, hook_client, push_key, url, config_path, scope, label, minted, tenant_id, snyk_token
+        )
+    except (SystemExit, KeyboardInterrupt):
+        raise
+    except BaseException:
+        if minted:
+            _revoke_after_failure(url, tenant_id, snyk_token, push_key)
+        raise
+
+
+def _install_hooks(
+    args,
+    client: str,
+    hook_client: str,
+    push_key: str,
+    url: str,
+    config_path: Path,
+    scope: str,
+    label: str,
+    minted: bool,
+    tenant_id: str,
+    snyk_token: str,
+) -> None:
+    """Post-mint install steps.  Extracted so _run_install can revoke on failure."""
     # Copy hook script first so we can use it for the test event
     dest_path, script_existed, script_updated = _copy_hook_script(client, config_path)
 
@@ -172,12 +204,7 @@ def _run_install(args) -> None:
         if not script_existed:
             dest_path.unlink(missing_ok=True)
         if minted:
-            rich.print("[dim]Revoking minted push key...[/dim]")
-            try:
-                revoke_push_key(url, tenant_id, snyk_token, push_key)
-                rich.print("[green]\u2713[/green]  Push key revoked")
-            except RuntimeError as e:
-                rich.print(f"[yellow]Warning:[/yellow] Could not revoke push key: {e}")
+            _revoke_after_failure(url, tenant_id, snyk_token, push_key)
         rich.print("[bold red]Aborting install — test event failed.[/bold red]")
         raise SystemExit(1)
 
@@ -368,11 +395,19 @@ def _run_status() -> None:
     rich.print()
 
     rich.print("[bold]Managed hooks:[/bold]")
-    _print_client_status(
-        "Claude Code", CLAUDE_MANAGED_SETTINGS_PATH, _detect_claude_install(CLAUDE_MANAGED_SETTINGS_PATH)
-    )
+    claude_managed_info: dict | str | None
+    try:
+        claude_managed_info = _detect_claude_install(CLAUDE_MANAGED_SETTINGS_PATH)
+    except PermissionError:
+        claude_managed_info = _PERMISSION_DENIED
+    _print_client_status("Claude Code", CLAUDE_MANAGED_SETTINGS_PATH, claude_managed_info)
     rich.print()
-    _print_client_status("Cursor", CURSOR_MANAGED_HOOKS_PATH, _detect_cursor_install(CURSOR_MANAGED_HOOKS_PATH))
+    cursor_managed_info: dict | str | None
+    try:
+        cursor_managed_info = _detect_cursor_install(CURSOR_MANAGED_HOOKS_PATH)
+    except PermissionError:
+        cursor_managed_info = _PERMISSION_DENIED
+    _print_client_status("Cursor", CURSOR_MANAGED_HOOKS_PATH, cursor_managed_info)
     rich.print()
 
     rich.print("[dim]# interactive flow (user-level)[/dim]")
@@ -389,8 +424,11 @@ def _run_status() -> None:
     )
 
 
-def _print_client_status(label: str, path: Path, info: dict | None) -> None:
+def _print_client_status(label: str, path: Path, info: dict | str | None) -> None:
     rich.print(f"[bold white]{label}[/bold white]   [dim]{path}[/dim]")
+    if isinstance(info, str):
+        rich.print("    [yellow]UNREADABLE (permission denied)[/yellow]")
+        return
     if info is None:
         rich.print("    [dim]NOT INSTALLED[/dim]")
         return
@@ -617,6 +655,27 @@ def _config_path(client: str, override: str | None = None, managed: bool = False
     if managed:
         return CLAUDE_MANAGED_SETTINGS_PATH if client == "claude" else CURSOR_MANAGED_HOOKS_PATH
     return CLAUDE_SETTINGS_PATH if client == "claude" else CURSOR_HOOKS_PATH
+
+
+def _preflight_writable(config_path: Path) -> None:
+    """Verify that the config file's parent directory is writable.
+
+    Raises PermissionError early (before minting a push key) so we don't
+    leave orphaned credentials when the filesystem operation would fail.
+    """
+    parent = config_path.parent
+    if parent.exists() and not os.access(parent, os.W_OK):
+        raise PermissionError(f"Directory not writable: {parent}")
+
+
+def _revoke_after_failure(url: str, tenant_id: str, snyk_token: str, push_key: str) -> None:
+    """Best-effort revocation of a push key after a failed install."""
+    rich.print("[dim]Revoking minted push key...[/dim]")
+    try:
+        revoke_push_key(url, tenant_id, snyk_token, push_key)
+        rich.print("[green]\u2713[/green]  Push key revoked")
+    except RuntimeError as e:
+        rich.print(f"[yellow]Warning:[/yellow] Could not revoke push key: {e}")
 
 
 def _build_hook_command(push_key: str, url: str, script_path: Path, hook_client: str, *, tenant_id: str = "") -> str:

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -16,10 +16,15 @@ import pytest
 from agent_scan.guard import (
     CLAUDE_EVENTS_WITH_MATCHER,
     CLAUDE_HOOK_EVENTS,
+    CLAUDE_MANAGED_SETTINGS_PATH,
+    CLAUDE_SETTINGS_PATH,
     CURSOR_HOOK_EVENTS,
+    CURSOR_HOOKS_PATH,
+    CURSOR_MANAGED_HOOKS_PATH,
     _build_hook_command,
     _build_hook_command_powershell,
     _compact_events,
+    _config_path,
     _detect_claude_install,
     _detect_cursor_install,
     _extract_env_from_cmd,
@@ -1030,6 +1035,129 @@ class TestFilterCursorHooks:
         result = _filter_cursor_hooks(hooks)
         assert len(result["stop"]) == 1
         assert result["stop"][0]["command"] == CURSOR_OTHER_CMD
+
+
+# ===================================================================
+# Config path resolution (user vs managed)
+# ===================================================================
+
+
+class TestConfigPath:
+    def test_claude_user_default(self):
+        assert _config_path("claude") == CLAUDE_SETTINGS_PATH
+
+    def test_cursor_user_default(self):
+        assert _config_path("cursor") == CURSOR_HOOKS_PATH
+
+    def test_claude_managed(self):
+        assert _config_path("claude", managed=True) == CLAUDE_MANAGED_SETTINGS_PATH
+
+    def test_cursor_managed(self):
+        assert _config_path("cursor", managed=True) == CURSOR_MANAGED_HOOKS_PATH
+
+    def test_file_override_takes_precedence_over_managed(self):
+        override = "/custom/path/settings.json"
+        assert _config_path("claude", override=override, managed=True) == Path(override)
+
+    def test_file_override_takes_precedence_over_user(self):
+        override = "/custom/path/settings.json"
+        assert _config_path("claude", override=override) == Path(override)
+
+
+class TestManagedPathConstants:
+    def test_claude_managed_path_is_absolute(self):
+        assert CLAUDE_MANAGED_SETTINGS_PATH.is_absolute()
+
+    def test_cursor_managed_path_is_absolute(self):
+        assert CURSOR_MANAGED_HOOKS_PATH.is_absolute()
+
+    def test_claude_managed_filename(self):
+        assert CLAUDE_MANAGED_SETTINGS_PATH.name == "managed-settings.json"
+
+    def test_cursor_managed_filename(self):
+        assert CURSOR_MANAGED_HOOKS_PATH.name == "hooks.json"
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific paths")
+    def test_macos_claude_managed_path(self):
+        assert str(CLAUDE_MANAGED_SETTINGS_PATH) == "/Library/Application Support/ClaudeCode/managed-settings.json"
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific paths")
+    def test_macos_cursor_managed_path(self):
+        assert str(CURSOR_MANAGED_HOOKS_PATH) == "/Library/Application Support/Cursor/hooks.json"
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux-specific paths")
+    def test_linux_claude_managed_path(self):
+        assert str(CLAUDE_MANAGED_SETTINGS_PATH) == "/etc/claude-code/managed-settings.json"
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="Linux-specific paths")
+    def test_linux_cursor_managed_path(self):
+        assert str(CURSOR_MANAGED_HOOKS_PATH) == "/etc/cursor/hooks.json"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific paths")
+    def test_windows_claude_managed_path(self):
+        assert "ClaudeCode" in str(CLAUDE_MANAGED_SETTINGS_PATH)
+        assert "managed-settings.json" in str(CLAUDE_MANAGED_SETTINGS_PATH)
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific paths")
+    def test_windows_cursor_managed_path(self):
+        assert "Cursor" in str(CURSOR_MANAGED_HOOKS_PATH)
+        assert "hooks.json" in str(CURSOR_MANAGED_HOOKS_PATH)
+
+
+class TestManagedInstallClaude:
+    """Verify hooks can be installed/detected/uninstalled at a managed path."""
+
+    def test_install_to_managed_path(self, tmp_path):
+        path = tmp_path / "managed-settings.json"
+        _install_claude(AGENT_SCAN_CMD, path)
+
+        data = json.loads(path.read_text())
+        hooks = data["hooks"]
+        assert set(hooks.keys()) == set(CLAUDE_HOOK_EVENTS)
+
+    def test_detect_at_managed_path(self, tmp_path):
+        path = tmp_path / "managed-settings.json"
+        _install_claude(AGENT_SCAN_CMD, path)
+
+        info = _detect_claude_install(path)
+        assert info is not None
+        assert info["auth_value"] == "pk-1234"
+
+    def test_uninstall_from_managed_path(self, tmp_path):
+        path = tmp_path / "managed-settings.json"
+        _install_claude(AGENT_SCAN_CMD, path)
+        _uninstall_claude(path)
+
+        data = json.loads(path.read_text())
+        assert "hooks" not in data
+
+
+class TestManagedInstallCursor:
+    """Verify hooks can be installed/detected/uninstalled at a managed path."""
+
+    def test_install_to_managed_path(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _install_cursor(CURSOR_AGENT_SCAN_CMD, path)
+
+        data = json.loads(path.read_text())
+        hooks = data["hooks"]
+        assert set(hooks.keys()) == set(CURSOR_HOOK_EVENTS)
+
+    def test_detect_at_managed_path(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _install_cursor(CURSOR_AGENT_SCAN_CMD, path)
+
+        info = _detect_cursor_install(path)
+        assert info is not None
+        assert info["auth_value"] == "pk-1234"
+
+    def test_uninstall_from_managed_path(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _install_cursor(CURSOR_AGENT_SCAN_CMD, path)
+        _uninstall_cursor(path)
+
+        data = json.loads(path.read_text())
+        assert data["hooks"] == {}
 
 
 # ===================================================================

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from agent_scan.guard import (
+    _PERMISSION_DENIED,
     CLAUDE_EVENTS_WITH_MATCHER,
     CLAUDE_HOOK_EVENTS,
     CLAUDE_MANAGED_SETTINGS_PATH,
@@ -35,6 +36,8 @@ from agent_scan.guard import (
     _is_agent_scan_command,
     _mask_key,
     _parse_command_info,
+    _preflight_writable,
+    _print_client_status,
     _shell_quote,
     _uninstall_claude,
     _uninstall_cursor,
@@ -1158,6 +1161,87 @@ class TestManagedInstallCursor:
 
         data = json.loads(path.read_text())
         assert data["hooks"] == {}
+
+
+# ===================================================================
+# Permission denied handling (managed paths)
+# ===================================================================
+
+
+class TestPermissionDeniedStatus:
+    """Managed configs may be unreadable — status should not crash."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod has no effect on Windows")
+    def test_detect_claude_raises_on_unreadable(self, tmp_path):
+        path = tmp_path / "managed-settings.json"
+        _write(path, {"hooks": {"PreToolUse": [_claude_group(AGENT_SCAN_CMD, "*")]}})
+        path.chmod(0o000)
+        try:
+            with pytest.raises(PermissionError):
+                _detect_claude_install(path)
+        finally:
+            path.chmod(0o644)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod has no effect on Windows")
+    def test_detect_cursor_raises_on_unreadable(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _write(path, {"version": 1, "hooks": {"stop": [_cursor_entry(CURSOR_AGENT_SCAN_CMD)]}})
+        path.chmod(0o000)
+        try:
+            with pytest.raises(PermissionError):
+                _detect_cursor_install(path)
+        finally:
+            path.chmod(0o644)
+
+    def test_print_client_status_permission_denied(self, tmp_path, capsys):
+        _print_client_status("Claude Code", tmp_path / "managed-settings.json", _PERMISSION_DENIED)
+        output = capsys.readouterr().out
+        assert "UNREADABLE" in output or "permission denied" in output.lower()
+
+    def test_print_client_status_not_installed(self, tmp_path, capsys):
+        _print_client_status("Claude Code", tmp_path / "settings.json", None)
+        output = capsys.readouterr().out
+        assert "NOT INSTALLED" in output
+
+    def test_print_client_status_installed(self, tmp_path, capsys):
+        info = {
+            "host": "api.snyk.io",
+            "auth_type": "pushkey",
+            "auth_value": "pk-1234567890",
+            "tenant_id": "tid-1",
+            "url": "https://api.snyk.io",
+            "events": ["PreToolUse"],
+        }
+        _print_client_status("Claude Code", tmp_path / "settings.json", info)
+        output = capsys.readouterr().out
+        assert "INSTALLED" in output
+
+
+# ===================================================================
+# Preflight writability check
+# ===================================================================
+
+
+class TestPreflightWritable:
+    def test_passes_when_parent_writable(self, tmp_path):
+        config = tmp_path / "subdir" / "settings.json"
+        config.parent.mkdir(parents=True)
+        _preflight_writable(config)  # should not raise
+
+    def test_passes_when_parent_does_not_exist(self, tmp_path):
+        config = tmp_path / "nonexistent" / "settings.json"
+        _preflight_writable(config)  # parent doesn't exist yet, nothing to check
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod has no effect on Windows")
+    def test_raises_when_parent_not_writable(self, tmp_path):
+        config_dir = tmp_path / "locked"
+        config_dir.mkdir()
+        config_dir.chmod(0o555)
+        try:
+            with pytest.raises(PermissionError, match="not writable"):
+                _preflight_writable(config_dir / "settings.json")
+        finally:
+            config_dir.chmod(0o755)
 
 
 # ===================================================================


### PR DESCRIPTION
Add `--managed` flag to Agent Guard hook install/uninstall

Adds support for installing and uninstalling Agent Guard hooks at OS-specific managed (MDM/admin-deployed) config paths, in addition to the existing user-level paths.