### PR TITLE
fix: hostname on windows

### DIFF
--- a/src/agent_scan/upload.py
+++ b/src/agent_scan/upload.py
@@ -20,11 +20,10 @@ def get_hostname() -> str:
     ci_hostname = os.getenv("AGENT_SCAN_CI_HOSTNAME")
     if get_environment() == "ci" and ci_hostname:
         return ci_hostname
-    else:
-        try:
-            return platform.node()
-        except Exception:
-            return "unknown"
+    try:
+        return platform.node() or "unknown"
+    except Exception:
+        return "unknown"
 
 
 def get_username() -> str:

--- a/src/agent_scan/upload.py
+++ b/src/agent_scan/upload.py
@@ -2,6 +2,7 @@ import asyncio
 import getpass
 import logging
 import os
+import platform
 
 import aiohttp
 import rich
@@ -21,7 +22,7 @@ def get_hostname() -> str:
         return ci_hostname
     else:
         try:
-            return os.uname().nodename
+            return platform.node()
         except Exception:
             return "unknown"
 

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -1,0 +1,23 @@
+import os
+from unittest.mock import patch
+
+from agent_scan.upload import get_hostname
+
+
+def test_get_hostname_returns_valid_string():
+    """Test that get_hostname returns a valid, non-unknown string on all platforms."""
+    # Ensure we bypass the CI environment override to test the actual platform.node() call
+    with patch("agent_scan.upload.get_environment", return_value="local"):
+        hostname = get_hostname()
+
+        assert isinstance(hostname, str)
+        assert len(hostname) > 0
+        assert hostname != "unknown", "get_hostname() returned 'unknown', which means platform.node() failed"
+
+
+def test_get_hostname_ci_override():
+    """Test that the CI environment variable override works."""
+    with patch("agent_scan.upload.get_environment", return_value="ci"):
+        with patch.dict(os.environ, {"AGENT_SCAN_CI_HOSTNAME": "test-ci-host"}):
+            hostname = get_hostname()
+            assert hostname == "test-ci-host"

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -15,6 +15,14 @@ def test_get_hostname_returns_valid_string():
         assert hostname != "unknown", "get_hostname() returned 'unknown', which means platform.node() failed"
 
 
+def test_get_hostname_empty_fallback():
+    """Test that get_hostname falls back to 'unknown' if platform.node() returns an empty string."""
+    with patch("agent_scan.upload.get_environment", return_value="local"):
+        with patch("platform.node", return_value=""):
+            hostname = get_hostname()
+            assert hostname == "unknown"
+
+
 def test_get_hostname_ci_override():
     """Test that the CI environment variable override works."""
     with patch("agent_scan.upload.get_environment", return_value="ci"):

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
-[options]
-exclude-newer = "2026-03-31T12:02:31.838597Z"
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -1953,7 +1949,7 @@ wheels = [
 
 [[package]]
 name = "snyk-agent-scan"
-version = "0.4.14"
+version = "0.4.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
On windows, we observed: 

```
>>> import os ; print(os.name().nodename)
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    import os ; print(os.name().nodename)
                      ~~~~~~~^^
TypeError: 'str' object is not callable
```

`platform.node()` is the recommended way per python docs:
https://docs.python.org/3/library/platform.html#platform.node
```Returns the computer’s network name (may not be fully qualified!). An empty string is returned if the value cannot be determined.```