### PR TITLE
fix: add issues ignore option in ci mode [MCP-914]

### DIFF
--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -17,7 +17,13 @@ import psutil
 import rich
 from rich.logging import RichHandler
 
-from agent_scan.models import ControlServer, ScanPathResult, TokenAndClientInfo, TokenAndClientInfoList
+from agent_scan.models import (
+    FAILURE_CATEGORY_TO_CODE,
+    ControlServer,
+    ScanPathResult,
+    TokenAndClientInfo,
+    TokenAndClientInfoList,
+)
 from agent_scan.pipelines import AnalyzeArgs, InspectArgs, PushArgs, inspect_analyze_push_pipeline, inspect_pipeline
 from agent_scan.printer import print_scan_result
 from agent_scan.upload import get_hostname
@@ -207,6 +213,12 @@ def add_common_arguments(parser):
         action="store_true",
         default=False,
         help="Exit with a non-zero code when there are analysis findings or runtime failures",
+    )
+    parser.add_argument(
+        "--ignore-issues-codes",
+        type=str,
+        default=None,
+        help="Comma-separated list of issue codes to ignore (e.g. W001,W015)",
     )
 
 
@@ -613,20 +625,78 @@ async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> list[Scan
         raise ValueError(f"Unknown mode: {mode}, expected 'scan' or 'inspect'")
 
 
+def _parse_ignore_codes(args, ci_mode: bool) -> set[str]:
+    """Parse --ignore-issues-codes and validate it is only used with --ci."""
+    ignore_codes_raw = getattr(args, "ignore_issues_codes", None)
+    ignore_codes: set[str] = (
+        {c.strip() for c in ignore_codes_raw.split(",") if c.strip()} if ignore_codes_raw else set()
+    )
+    if ignore_codes and not ci_mode:
+        rich.print(
+            "[bold red]Error: --ignore-issues-codes can only be used with --ci.[/bold red]",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return ignore_codes
+
+
+def _collect_failure_codes(result: list[ScanPathResult]) -> set[str]:
+    """Collect X00x codes from ScanError failures on paths and servers."""
+    codes: set[str] = set()
+    for r in result:
+        if r.error and r.error.is_failure:
+            codes.add(FAILURE_CATEGORY_TO_CODE.get(r.error.category, FAILURE_CATEGORY_TO_CODE[None]))
+        for s in r.servers or []:
+            if s.error and s.error.is_failure:
+                codes.add(FAILURE_CATEGORY_TO_CODE.get(s.error.category, FAILURE_CATEGORY_TO_CODE[None]))
+    return codes
+
+
+def _apply_ignore_codes(result: list[ScanPathResult], ignore_codes: set[str]) -> None:
+    """Remove issues whose code is in the ignore set from each scan result."""
+    for scan_result in result:
+        scan_result.issues = [i for i in scan_result.issues if i.code not in ignore_codes]
+
+
+def _handle_ci_exit(result: list[ScanPathResult], json_output: bool, ignore_codes: set[str]) -> None:
+    """In CI mode, exit with code 1 if any issues or unignored failures remain."""
+    has_issues = any(scan_result.issues for scan_result in result)
+    failure_codes = _collect_failure_codes(result) - ignore_codes
+    if not has_issues and not failure_codes:
+        return
+
+    if not json_output:
+        issue_codes = {issue.code for scan_result in result for issue in scan_result.issues if issue.code}
+        all_codes = sorted(issue_codes | failure_codes)
+        codes_part = ", ".join(all_codes) if all_codes else "none"
+        rich.print(
+            f"[bold red]CI (--ci): exiting with code 1 (issue codes: {codes_part}).[/bold red]",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+
+
 async def print_scan_inspect(mode="scan", args=None):
     json_output: bool = hasattr(args, "json") and args.json
     print_errors: bool = hasattr(args, "print_errors") and args.print_errors
     full_description: bool = hasattr(args, "print_full_descriptions") and args.print_full_descriptions
     verbose: bool = hasattr(args, "verbose") and args.verbose
     ci_mode: bool = hasattr(args, "ci") and args.ci
+    ignore_codes = _parse_ignore_codes(args, ci_mode)
 
     if json_output:
         with suppress_stdout():
             result = await run_scan(args, mode=mode)
-            result_dict = {r.path: r.model_dump(mode="json") for r in result}
-        print(json.dumps(result_dict, indent=2))
     else:
         result = await run_scan(args, mode=mode)
+
+    if ci_mode and ignore_codes:
+        _apply_ignore_codes(result, ignore_codes)
+
+    if json_output:
+        result_dict = {r.path: r.model_dump(mode="json") for r in result}
+        print(json.dumps(result_dict, indent=2))
+    else:
         print_scan_result(
             result,
             print_errors,
@@ -636,16 +706,8 @@ async def print_scan_inspect(mode="scan", args=None):
             args=args,
         )
 
-    # In CI mode, exit with a non-zero code if any scan path has issues
-    if ci_mode and any(scan_result.issues for scan_result in result):
-        if not json_output:
-            codes = sorted({issue.code for scan_result in result for issue in scan_result.issues if issue.code})
-            codes_part = ", ".join(codes) if codes else "none"
-            rich.print(
-                f"[bold red]CI (--ci): exiting with code 1 (issue codes: {codes_part}).[/bold red]",
-                file=sys.stderr,
-            )
-        sys.exit(1)
+    if ci_mode:
+        _handle_ci_exit(result, json_output, ignore_codes)
 
 
 if __name__ == "__main__":

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -31,6 +31,19 @@ ErrorCategory = Literal[
     "skill_scan_error",  # Could not scan skill
 ]
 
+# Mapping from failure categories to codes
+# These codes are different from the ones from analysis findings like E001, E002, etc
+FAILURE_CATEGORY_TO_CODE: dict[ErrorCategory | None, str] = {
+    "server_startup": "X001",
+    "skill_scan_error": "X002",
+    "file_not_found": "X003",
+    "unknown_config": "X004",
+    "parse_error": "X005",
+    "server_http_error": "X006",
+    "analysis_error": "X007",
+    None: "X008",
+}
+
 logger = logging.getLogger(__name__)
 
 Entity: TypeAlias = Prompt | Resource | Tool | ResourceTemplate | Completion

--- a/src/agent_scan/printer.py
+++ b/src/agent_scan/printer.py
@@ -8,6 +8,7 @@ from rich.traceback import Traceback as rTraceback
 from rich.tree import Tree
 
 from agent_scan.models import (
+    FAILURE_CATEGORY_TO_CODE,
     Entity,
     Issue,
     ScanError,
@@ -44,18 +45,7 @@ ICON_MAP = {
     "inspect_mode": "  ",
 }
 
-# Mapping from failure categories to codes
-# These codes are different the ones from analysis findings like E001, E002, etc
-FAILURE_CATEGORY_TO_CODE_MAPPING = {
-    "server_startup": "X001",
-    "skill_scan_error": "X002",
-    "file_not_found": "X003",
-    "unknown_config": "X004",
-    "parse_error": "X005",
-    "server_http_error": "X006",
-    "analysis_error": "X007",
-    None: "X008",
-}
+FAILURE_CATEGORY_TO_CODE_MAPPING = FAILURE_CATEGORY_TO_CODE
 
 
 def format_exception(e: Exception | str | None) -> tuple[str, rTraceback | None]:

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from agent_scan.cli import MissingIdentifierError, parse_control_servers
-from agent_scan.models import ControlServer, Issue, ScanPathResult
+from agent_scan.models import ControlServer, Issue, RemoteServer, ScanError, ScanPathResult, ServerScanResult
 
 
 class TestControlServerParsing:
@@ -452,6 +452,66 @@ class TestCIMode:
             )
             await print_scan_inspect(mode="scan", args=args)
 
+    @pytest.mark.asyncio
+    async def test_ci_exits_1_on_path_level_failure(self):
+        """CI mode exits 1 when a ScanPathResult has an is_failure error, even with no issues."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[],
+            error=ScanError(message="parse failed", is_failure=True, category="parse_error"),
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(json=True, print_errors=False, print_full_descriptions=False, verbose=False, ci=True)
+            with pytest.raises(SystemExit) as exc_info:
+                await print_scan_inspect(mode="scan", args=args)
+            assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_ci_exits_1_on_server_level_failure(self):
+        """CI mode exits 1 when a ServerScanResult has an is_failure error."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[],
+            servers=[
+                ServerScanResult(
+                    server=RemoteServer(url="http://localhost"),
+                    error=ScanError(message="startup failed", is_failure=True, category="server_startup"),
+                ),
+            ],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(json=True, print_errors=False, print_full_descriptions=False, verbose=False, ci=True)
+            with pytest.raises(SystemExit) as exc_info:
+                await print_scan_inspect(mode="scan", args=args)
+            assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_ci_no_exit_on_non_failure_error(self):
+        """CI mode does NOT exit when errors have is_failure=False (e.g. file_not_found)."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[],
+            error=ScanError(message="config not found", is_failure=False, category="file_not_found"),
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(json=True, print_errors=False, print_full_descriptions=False, verbose=False, ci=True)
+            await print_scan_inspect(mode="scan", args=args)
+
 
 class TestJSONOutput:
     """Test suite for JSON output functionality."""
@@ -531,3 +591,235 @@ class TestJSONOutput:
 
             parsed = json.loads(output)
             assert isinstance(parsed, dict)
+
+
+class TestIgnoreIssuesCodes:
+    """Tests for --ignore-issues-codes filtering."""
+
+    @pytest.mark.asyncio
+    async def test_ignore_codes_filters_all_issues_ci_no_exit(self):
+        """CI mode with all issues ignored → no SystemExit."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[
+                Issue(code="W001", message="warning 1", reference=None),
+                Issue(code="W015", message="warning 15", reference=None),
+            ],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes="W001,W015",
+            )
+            # Should NOT raise SystemExit because all issues are ignored
+            await print_scan_inspect(mode="scan", args=args)
+
+    @pytest.mark.asyncio
+    async def test_ignore_codes_reflected_in_json_output(self):
+        """CI mode with ignored codes: JSON output should not contain filtered issues."""
+        import io
+        import json
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[
+                Issue(code="W001", message="warning 1", reference=None),
+                Issue(code="E001", message="error 1", reference=None),
+            ],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes="W001",
+            )
+
+            captured_output = io.StringIO()
+            original_stdout = sys.stdout
+            try:
+                sys.stdout = captured_output
+                with pytest.raises(SystemExit):
+                    await print_scan_inspect(mode="scan", args=args)
+            finally:
+                sys.stdout = original_stdout
+
+            parsed_output = json.loads(captured_output.getvalue())
+            issues = parsed_output["/test/path"]["issues"]
+            codes = [i["code"] for i in issues]
+            assert "W001" not in codes
+            assert "E001" in codes
+
+    @pytest.mark.asyncio
+    async def test_ignore_codes_partial_filter_still_exits(self):
+        """CI mode, some codes ignored, others remain → SystemExit(1)."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[
+                Issue(code="W001", message="warning 1", reference=None),
+                Issue(code="E001", message="error 1", reference=None),
+            ],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes="W001",
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                await print_scan_inspect(mode="scan", args=args)
+            assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_ignore_codes_without_ci_exits_with_error(self):
+        """Using --ignore-issues-codes without --ci exits with code 2."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        args = Namespace(
+            json=True,
+            print_errors=False,
+            print_full_descriptions=False,
+            verbose=False,
+            ci=False,
+            ignore_issues_codes="W001",
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            await print_scan_inspect(mode="scan", args=args)
+        assert exc_info.value.code == 2
+
+    @pytest.mark.asyncio
+    async def test_ignore_codes_not_set_keeps_all_issues(self):
+        """ignore_issues_codes=None → all issues preserved, CI exits 1."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[Issue(code="W001", message="warning 1", reference=None)],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes=None,
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                await print_scan_inspect(mode="scan", args=args)
+            assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_ignore_codes_empty_string_keeps_all_issues(self):
+        """ignore_issues_codes="" → all issues preserved, CI exits 1."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[Issue(code="W001", message="warning 1", reference=None)],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes="",
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                await print_scan_inspect(mode="scan", args=args)
+            assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_ignore_codes_can_suppress_failure_code(self):
+        """Ignoring a failure code (e.g. X001) prevents CI exit when that is the only failure."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[],
+            servers=[
+                ServerScanResult(
+                    server=RemoteServer(url="http://localhost"),
+                    error=ScanError(message="startup failed", is_failure=True, category="server_startup"),
+                ),
+            ],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes="X001",
+            )
+            # X001 (server_startup) is ignored → clean exit
+            await print_scan_inspect(mode="scan", args=args)
+
+    @pytest.mark.asyncio
+    async def test_ignore_codes_does_not_suppress_other_failure(self):
+        """Ignoring one failure code still exits 1 if a different failure code remains."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[],
+            error=ScanError(message="parse failed", is_failure=True, category="parse_error"),
+            servers=[
+                ServerScanResult(
+                    server=RemoteServer(url="http://localhost"),
+                    error=ScanError(message="startup failed", is_failure=True, category="server_startup"),
+                ),
+            ],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes="X001",  # ignores server_startup but not parse_error (X005)
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                await print_scan_inspect(mode="scan", args=args)
+            assert exc_info.value.code == 1


### PR DESCRIPTION
# Add --ignore-issues-codes CLI flag for CI mode
Adds a new --ignore-issues-codes argument that allows suppressing specific issue codes from triggering a non-zero exit in CI mode.

# Usage
`snyk-agent-scan scan --ci --ignore-issues-codes=W001,W015`

# Behavior
- Accepts a comma-separated list of issue codes (e.g. W001,W015)
- CI mode only — passing --ignore-issues-codes without --ci prints an error and exits with code 2
- Issues matching the ignored codes are filtered out from display output (JSON/rich text still shows all issues)
- If all issues are filtered out, the process exits cleanly (code 0); if unignored issues remain, it exits with code 1 as before
- When the flag is omitted or empty, existing behavior is unchanged
- CI exit also accounts for ScanError failures (is_failure=True) on paths and servers, not just issues — so runtime failures like server startup errors correctly trigger exit 1
