### PR TITLE
fix: coerce StdioServer args None/missing to empty list

### DIFF
--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -115,15 +115,6 @@ class RemoteServer(BaseModel):
     headers: dict[str, str] = Field(default_factory=dict)
 
 
-# [REVIEW-COMMENT]
-# Production bug: when a user MCP config omits "args" (or sets it to null) and
-# the command is an absolute path that exists on disk, the resulting
-# StdioServer carried args=None all the way down to mcp.StdioServerParameters,
-# whose `args: list[str]` field rejects None with a Pydantic ValidationError.
-# We use a BeforeValidator (rather than just a default_factory) so that an
-# explicit `"args": null` in the user JSON is also coerced to [] before
-# Pydantic enforces the list[str] type on StdioServer.args itself.
-# [/REVIEW-COMMENT]
 def _coerce_none_to_empty_list(v: Any) -> Any:
     """Coerce None to [] before Pydantic type-checks the args field.
 
@@ -137,14 +128,6 @@ def _coerce_none_to_empty_list(v: Any) -> Any:
 class StdioServer(BaseModel):
     model_config = ConfigDict()
     command: str
-    # [REVIEW-COMMENT]
-    # Was: `args: list[str] | None = None`. The Optional shape let None flow
-    # through the model and break downstream consumers (mcp.StdioServerParameters
-    # rejects None). It is now non-optional with a default_factory of list and a
-    # BeforeValidator that coerces explicit JSON `null` to []. Net effect: args
-    # is always a `list[str]` after model validation, regardless of whether the
-    # user omitted the key, supplied null, an empty list, or a populated list.
-    # [/REVIEW-COMMENT]
     args: Annotated[list[str], BeforeValidator(_coerce_none_to_empty_list)] = Field(default_factory=list)
     type: Literal["stdio"] | None = "stdio"
     env: dict[str, str] | None = None

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 from itertools import chain
-from typing import Any, Literal, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias
 
 from lark import Lark
 from mcp.client.auth import TokenStorage
@@ -11,6 +11,7 @@ from mcp.types import Completion, InitializeResult, Prompt, Resource, ResourceTe
 from pydantic import (
     AliasChoices,
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     RootModel,
@@ -114,10 +115,37 @@ class RemoteServer(BaseModel):
     headers: dict[str, str] = Field(default_factory=dict)
 
 
+# [REVIEW-COMMENT]
+# Production bug: when a user MCP config omits "args" (or sets it to null) and
+# the command is an absolute path that exists on disk, the resulting
+# StdioServer carried args=None all the way down to mcp.StdioServerParameters,
+# whose `args: list[str]` field rejects None with a Pydantic ValidationError.
+# We use a BeforeValidator (rather than just a default_factory) so that an
+# explicit `"args": null` in the user JSON is also coerced to [] before
+# Pydantic enforces the list[str] type on StdioServer.args itself.
+# [/REVIEW-COMMENT]
+def _coerce_none_to_empty_list(v: Any) -> Any:
+    """Coerce None to [] before Pydantic type-checks the args field.
+
+    Used as a BeforeValidator so user JSON containing `"args": null` (or
+    omitting `args` entirely) is normalized to an empty list rather than
+    rejected by the `list[str]` type check on StdioServer.args.
+    """
+    return [] if v is None else v
+
+
 class StdioServer(BaseModel):
     model_config = ConfigDict()
     command: str
-    args: list[str] | None = None
+    # [REVIEW-COMMENT]
+    # Was: `args: list[str] | None = None`. The Optional shape let None flow
+    # through the model and break downstream consumers (mcp.StdioServerParameters
+    # rejects None). It is now non-optional with a default_factory of list and a
+    # BeforeValidator that coerces explicit JSON `null` to []. Net effect: args
+    # is always a `list[str]` after model validation, regardless of whether the
+    # user omitted the key, supplied null, an empty list, or a populated list.
+    # [/REVIEW-COMMENT]
+    args: Annotated[list[str], BeforeValidator(_coerce_none_to_empty_list)] = Field(default_factory=list)
     type: Literal["stdio"] | None = "stdio"
     env: dict[str, str] | None = None
     binary_identifier: str | None = None

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -69,18 +69,6 @@ def _is_path(arg: str) -> bool:
     return len(arg) >= 3 and arg[1] == ":" and arg[2] in "/\\"
 
 
-# [REVIEW-COMMENT]
-# Signature tightened from `(args: list[str] | None) -> list[str] | None` to
-# `(args: list[str]) -> list[str]`. This is a cascade from StdioServer.args
-# moving from `list[str] | None` to `list[str]` (see spec at
-# /Users/cristian/prod_scans_analysis/requirement_args_none_fix.md): the
-# assignment `server_scan_result.server.args = redact_args(...)` in
-# redact_server below would otherwise be a mypy assignment error.
-# The function body is intentionally unchanged — the falsy early-return
-# (`if not args: return args`) still handles None at runtime, so the
-# existing `test_redact_args_none` test continues to pass even though the
-# static type now disallows None.
-# [/REVIEW-COMMENT]
 def redact_args(args: list[str]) -> list[str]:
     """
     Redact values of key-value arguments in a command line argument list.

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -69,7 +69,19 @@ def _is_path(arg: str) -> bool:
     return len(arg) >= 3 and arg[1] == ":" and arg[2] in "/\\"
 
 
-def redact_args(args: list[str] | None) -> list[str] | None:
+# [REVIEW-COMMENT]
+# Signature tightened from `(args: list[str] | None) -> list[str] | None` to
+# `(args: list[str]) -> list[str]`. This is a cascade from StdioServer.args
+# moving from `list[str] | None` to `list[str]` (see spec at
+# /Users/cristian/prod_scans_analysis/requirement_args_none_fix.md): the
+# assignment `server_scan_result.server.args = redact_args(...)` in
+# redact_server below would otherwise be a mypy assignment error.
+# The function body is intentionally unchanged — the falsy early-return
+# (`if not args: return args`) still handles None at runtime, so the
+# existing `test_redact_args_none` test continues to pass even though the
+# static type now disallows None.
+# [/REVIEW-COMMENT]
+def redact_args(args: list[str]) -> list[str]:
     """
     Redact values of key-value arguments in a command line argument list.
 

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -85,7 +85,7 @@ def redact_args(args: list[str]) -> list[str]:
         List of arguments with values redacted
     """
     if not args:
-        return args
+        return []
 
     redacted: list[str] = []
     i = 0

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -91,10 +91,10 @@ def redact_args(args: list[str]) -> list[str]:
     Also redacts file paths (arguments starting with /, ~/, or drive letters).
 
     Args:
-        args: List of command line arguments, or None
+        args: List of command line arguments
 
     Returns:
-        List of arguments with values redacted, or None if input was None
+        List of arguments with values redacted
     """
     if not args:
         return args

--- a/src/agent_scan/utils.py
+++ b/src/agent_scan/utils.py
@@ -82,7 +82,14 @@ def check_executable_exists(command: str) -> bool:
     return path.exists() or shutil.which(command) is not None
 
 
-def resolve_command_and_args(server_config: StdioServer) -> tuple[str, list[str] | None]:
+# [REVIEW-COMMENT]
+# Return type tightened from `tuple[str, list[str] | None]` to
+# `tuple[str, list[str]]`. StdioServer.args is now guaranteed to be a
+# `list[str]` at the model layer (via BeforeValidator + default_factory),
+# so callers no longer need to handle the `None` arm. Function body is
+# unchanged.
+# [/REVIEW-COMMENT]
+def resolve_command_and_args(server_config: StdioServer) -> tuple[str, list[str]]:
     """
     Resolve the command and arguments for a StdioServer.
     """

--- a/src/agent_scan/utils.py
+++ b/src/agent_scan/utils.py
@@ -82,13 +82,6 @@ def check_executable_exists(command: str) -> bool:
     return path.exists() or shutil.which(command) is not None
 
 
-# [REVIEW-COMMENT]
-# Return type tightened from `tuple[str, list[str] | None]` to
-# `tuple[str, list[str]]`. StdioServer.args is now guaranteed to be a
-# `list[str]` at the model layer (via BeforeValidator + default_factory),
-# so callers no longer need to handle the `None` arm. Function body is
-# unchanged.
-# [/REVIEW-COMMENT]
 def resolve_command_and_args(server_config: StdioServer) -> tuple[str, list[str]]:
     """
     Resolve the command and arguments for a StdioServer.

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from mcp import StdioServerParameters
 from mcp.types import (
     Implementation,
     InitializeResult,
@@ -18,6 +19,7 @@ from pytest_lazy_fixtures import lf
 
 from agent_scan.mcp_client import _check_server_pass, check_server, scan_mcp_config_file
 from agent_scan.models import StdioServer
+from agent_scan.utils import resolve_command_and_args
 
 
 @pytest.mark.parametrize(
@@ -169,3 +171,21 @@ def remote_mcp_server_just_url():
 @pytest.mark.asyncio
 async def test_parse_server():
     pass
+
+
+class TestResolveCommandAndArgsRegression:
+    """Regression: resolve_command_and_args must return list[str] for omitted args."""
+
+    def test_resolve_returns_list_for_omitted_args_and_stdio_params_accepts_it(self, tmp_path):
+        script = tmp_path / "run.sh"
+        script.write_text("#!/bin/sh\necho hi\n")
+        script.chmod(0o755)
+
+        server = StdioServer.model_validate({"command": str(script)})
+        command, args = resolve_command_and_args(server)
+        params = StdioServerParameters(command=command, args=args)
+
+        assert isinstance(args, list) is True
+        assert args == []
+        assert command == str(script)
+        assert params.args == []

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -160,3 +160,50 @@ class TestStdioServerRebalance:
         """Test that whitespace-only commands raise an error."""
         with pytest.raises(CommandParsingError):
             StdioServer(command="   ", args=None)
+
+
+class TestStdioServerArgsCoercion:
+    """args=None / missing args must coerce to [] regardless of command shape."""
+
+    def test_args_omitted(self):
+        s = StdioServer.model_validate({"command": "npx"})
+        assert s.args == []
+
+    def test_args_explicit_null(self):
+        s = StdioServer.model_validate({"command": "npx", "args": None})
+        assert s.args == []
+
+    def test_args_empty_list_preserved(self):
+        s = StdioServer.model_validate({"command": "npx", "args": []})
+        assert s.args == []
+
+    def test_args_populated_preserved(self):
+        s = StdioServer.model_validate({"command": "npx", "args": ["-y", "pkg"]})
+        assert s.args == ["-y", "pkg"]
+
+    def test_existing_absolute_path_with_no_args(self, tmp_path):
+        """Reproduces the production failure mode: run.sh wrapper, no args."""
+        script = tmp_path / "run.sh"
+        script.write_text("#!/bin/sh\necho hi\n")
+        script.chmod(0o755)
+        s = StdioServer.model_validate({"command": str(script)})
+        assert s.command == str(script)
+        assert s.args == []
+
+    def test_existing_absolute_path_with_explicit_null_args(self, tmp_path):
+        """Explicit null args on an existing-path command must coerce to []."""
+        script = tmp_path / "run.sh"
+        script.write_text("#!/bin/sh\necho hi\n")
+        script.chmod(0o755)
+        s = StdioServer.model_validate({"command": str(script), "args": None})
+        assert s.command == str(script)
+        assert s.args == []
+
+    def test_existing_absolute_path_with_populated_args_preserved(self, tmp_path):
+        """Populated args on an existing-path command must be preserved verbatim."""
+        script = tmp_path / "run.sh"
+        script.write_text("#!/bin/sh\necho hi\n")
+        script.chmod(0o755)
+        s = StdioServer.model_validate({"command": str(script), "args": ["--foo", "bar"]})
+        assert s.command == str(script)
+        assert s.args == ["--foo", "bar"]

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -43,10 +43,6 @@ class TestRedactAbsolutePaths:
 class TestRedactArgs:
     """Unit tests for redact_args function."""
 
-    def test_redact_args_none(self):
-        """Test that None input returns None."""
-        assert redact_args(None) is None
-
     def test_redact_args_empty(self):
         """Test that empty list returns empty list."""
         assert redact_args([]) == []


### PR DESCRIPTION
## Summary
Fix production crash when MCP configs omit `args` or set `"args": null` on stdio servers . Coerces `args` to `[]` at the `StdioServer` model via `BeforeValidator` + `default_factory=list`. Tightens downstream return types to match the new invariant.