### PR TITLE
fix: resolve per-user binary dirs against config owner's home under --all-users

### DIFF
--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -111,7 +111,7 @@ async def get_mcp_config_per_home_directory(
             server_configs_by_name = mcp_config.get_servers()
             for server_config in server_configs_by_name.values():
                 if isinstance(server_config, StdioServer):
-                    server_config = check_server_signature(server_config)
+                    server_config = check_server_signature(server_config, home_directory=home_directory)
             mcp_configs[mcp_config_path_expanded.as_posix()] = [
                 (server_name, server) for server_name, server in server_configs_by_name.items()
             ]
@@ -137,6 +137,7 @@ async def get_mcp_config_per_home_directory(
     return ClientToInspect(
         name=client.name,
         client_path=client_path,
+        home_directory=home_directory,
         mcp_configs=mcp_configs,
         skills_dirs=skills_dirs,
     )
@@ -160,6 +161,7 @@ async def inspect_extension(
     *,
     config_path: str | None = None,
     stream_stderr: bool = False,
+    home_directory: Path | None = None,
 ) -> InspectedExtensions:
     """
     Scan an extension (MCP server or skill) and return a InspectedExtensions object.
@@ -179,6 +181,7 @@ async def inspect_extension(
                 server_name=name,
                 config_path=config_path,
                 stream_stderr=stream_stderr,
+                home_directory=home_directory,
             )
             return InspectedExtensions(name=name, config=config, signature_or_error=signature)
         except Exception as e:
@@ -299,6 +302,7 @@ async def inspect_client(
                 find_relevant_token(tokens, name),
                 config_path=mcp_config_path,
                 stream_stderr=stream_stderr,
+                home_directory=client.home_directory,
             )
             extensions_for_mcp_config.append(extension)
         extensions[mcp_config_path] = extensions_for_mcp_config

--- a/src/agent_scan/mcp_client.py
+++ b/src/agent_scan/mcp_client.py
@@ -4,6 +4,7 @@ import os
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -82,6 +83,7 @@ async def get_client(
     server_name: str | None = None,
     config_path: str | None = None,
     stream_stderr: bool = False,
+    home_directory: Path | None = None,
 ) -> AsyncIterator[tuple]:
     """
     Create an MCP client for the given server config.
@@ -113,7 +115,7 @@ async def get_client(
     elif isinstance(server_config, StdioServer):
         logger.debug("Creating stdio client")
 
-        command, args = resolve_command_and_args(server_config)
+        command, args = resolve_command_and_args(server_config, home_directory=home_directory)
         server_params = StdioServerParameters(
             command=command,
             args=args,
@@ -159,6 +161,7 @@ async def _check_server_pass(
     server_name: str | None = None,
     config_path: str | None = None,
     stream_stderr: bool = False,
+    home_directory: Path | None = None,
 ) -> ServerSignature:
     async def _check_server() -> ServerSignature:
         async with get_client(
@@ -169,6 +172,7 @@ async def _check_server_pass(
             server_name=server_name,
             config_path=config_path,
             stream_stderr=stream_stderr,
+            home_directory=home_directory,
         ) as (
             read,
             write,
@@ -236,6 +240,7 @@ async def check_server(
     server_name: str | None = None,
     config_path: str | None = None,
     stream_stderr: bool = False,
+    home_directory: Path | None = None,
 ) -> tuple[ServerSignature, StdioServer | RemoteServer]:
     logger.debug("Checking server with timeout: %s seconds", timeout)
 
@@ -248,6 +253,7 @@ async def check_server(
                 server_name=server_name,
                 config_path=config_path,
                 stream_stderr=stream_stderr,
+                home_directory=home_directory,
             ),
             timeout,
         )

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from itertools import chain
+from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
 from lark import Lark
@@ -538,6 +539,7 @@ class ClientToInspect(BaseModel):
     name: str
     client_path: str
     username: str | None = None
+    home_directory: Path | None = None
     mcp_configs: dict[
         str,
         list[tuple[str, StdioServer | RemoteServer]]

--- a/src/agent_scan/signed_binary.py
+++ b/src/agent_scan/signed_binary.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 from agent_scan.models import StdioServer
 from agent_scan.utils import resolve_command_and_args
@@ -32,13 +33,13 @@ def _is_code_launcher(command: str) -> bool:
     return any(p.match(basename) for p in _CODE_LAUNCHER_PATTERNS)
 
 
-def check_server_signature(server: StdioServer) -> StdioServer:
+def check_server_signature(server: StdioServer, home_directory: Path | None = None) -> StdioServer:
     """Get detailed code signing information."""
     if sys.platform != "darwin":
         logger.info(f"Binary signature check not supported on {sys.platform}. Only supported on macOS.")
         return server
     try:
-        command, _ = resolve_command_and_args(server)
+        command, _ = resolve_command_and_args(server, home_directory=home_directory)
 
         if _is_code_launcher(command):
             logger.info(

--- a/src/agent_scan/utils.py
+++ b/src/agent_scan/utils.py
@@ -82,9 +82,56 @@ def check_executable_exists(command: str) -> bool:
     return path.exists() or shutil.which(command) is not None
 
 
-def resolve_command_and_args(server_config: StdioServer) -> tuple[str, list[str] | None]:
+def _user_specific_dirs(home: str) -> list[str]:
+    """Return the list of per-user well-known binary directories for a given home path."""
+    nvm_pattern = os.path.join(home, ".nvm", "versions", "node", "*", "bin")
+    nvm_dirs = sorted(glob.glob(nvm_pattern), reverse=True)
+    return [
+        # node / npx
+        *nvm_dirs,
+        os.path.join(home, ".npm-global", "bin"),
+        os.path.join(home, ".yarn", "bin"),
+        os.path.join(home, ".local", "share", "pnpm"),
+        os.path.join(home, ".config", "yarn", "global", "node_modules", ".bin"),
+        # python / uvx
+        os.path.join(home, ".cargo", "bin"),
+        os.path.join(home, ".pyenv", "shims"),
+        # user local paths
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".bin"),
+        os.path.join(home, "bin"),
+    ]
+
+
+_SYSTEM_DIRS: list[str] = [
+    # package manager paths
+    "/opt/homebrew/bin",
+    "/opt/local/bin",
+    "/snap/bin",
+    # system paths
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+    # docker path
+    "/Applications/Docker.app/Contents/Resources/bin",
+]
+
+
+def resolve_command_and_args(
+    server_config: StdioServer,
+    home_directory: Path | None = None,
+) -> tuple[str, list[str] | None]:
     """
     Resolve the command and arguments for a StdioServer.
+
+    When ``home_directory`` is supplied (e.g. the home dir of the user whose
+    MCP config file is being scanned), its per-user binary directories are
+    searched *before* those of the current process owner.  This is important
+    when ``--all-users`` is active: a ``uv`` binary installed in
+    ``/home/bob/.local/bin`` would otherwise never be found when the scanner
+    is running as a different user.
     """
     # check if command points to an executable and whether it exists absolute or on the path
     if check_executable_exists(server_config.command):
@@ -95,37 +142,18 @@ def resolve_command_and_args(server_config: StdioServer) -> tuple[str, list[str]
         logger.warning(f"Path does not exist: {command}")
         raise ValueError(f"Path does not exist: {command}")
 
-    # attempt to find the command in well-known directories
-    # npx via nvm - look for node versions directory
-    nvm_pattern = os.path.expanduser("~/.nvm/versions/node/*/bin")
-    nvm_dirs = sorted(glob.glob(nvm_pattern), reverse=True)
-    fallback_dirs = [
-        # node / npx
-        *nvm_dirs,
-        os.path.expanduser("~/.npm-global/bin"),
-        os.path.expanduser("~/.yarn/bin"),
-        os.path.expanduser("~/.local/share/pnpm"),
-        os.path.expanduser("~/.config/yarn/global/node_modules/.bin"),
-        # python / uvx
-        os.path.expanduser("~/.cargo/bin"),
-        os.path.expanduser("~/.pyenv/shims"),
-        # user local paths
-        os.path.expanduser("~/.local/bin"),
-        os.path.expanduser("~/.bin"),
-        os.path.expanduser("~/bin"),
-        # package manager paths
-        "/opt/homebrew/bin",
-        "/opt/local/bin",
-        "/snap/bin",
-        # system paths
-        "/usr/local/bin",
-        "/usr/bin",
-        "/bin",
-        "/usr/sbin",
-        "/sbin",
-        # docker path
-        "/Applications/Docker.app/Contents/Resources/bin",
-    ]
+    # Build the ordered list of fallback directories.
+    # 1. Per-user dirs for the config owner (when different from the current user).
+    # 2. Per-user dirs for the current process owner (always searched as fallback).
+    # 3. System-wide dirs.
+    current_home = os.path.expanduser("~")
+    fallback_dirs: list[str] = []
+    if home_directory is not None:
+        owner_home = str(home_directory)
+        if owner_home != current_home:
+            fallback_dirs.extend(_user_specific_dirs(owner_home))
+    fallback_dirs.extend(_user_specific_dirs(current_home))
+    fallback_dirs.extend(_SYSTEM_DIRS)
 
     for d in fallback_dirs:
         potential_path = os.path.join(d, command)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 import io
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -141,3 +142,136 @@ class TestSuppressStdout:
 
         # Only the final print should appear
         assert captured_output.getvalue() == "Final line\n"
+
+
+class TestResolveCommandAndArgs:
+    """Tests for the home_directory parameter of resolve_command_and_args."""
+
+    def _make_executable(self, path: Path) -> None:
+        """Create a file and make it executable."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+        path.chmod(0o755)
+
+    def test_resolve_command_and_args_no_home_directory_searches_current_user_dirs(self, tmp_path):
+        """When home_directory=None, a command in ~/.local/bin is found via the current user's dirs."""
+        from unittest.mock import patch
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        local_bin = tmp_path / ".local" / "bin"
+        executable = local_bin / "mycommand"
+        self._make_executable(executable)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(tmp_path)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=None)
+
+        # Assert
+        assert resolved_command == str(executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []
+
+    def test_resolve_command_and_args_with_home_directory_searches_owner_home_first(self, tmp_path):
+        """When home_directory differs from current home, the owner's dirs are searched first."""
+        from unittest.mock import patch
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        owner_home = tmp_path / "owner"
+        current_home = tmp_path / "current"
+
+        owner_local_bin = owner_home / ".local" / "bin"
+        owner_executable = owner_local_bin / "mycommand"
+        self._make_executable(owner_executable)
+
+        # mycommand does NOT exist in current user's dirs
+        (current_home / ".local" / "bin").mkdir(parents=True, exist_ok=True)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(current_home)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=owner_home)
+
+        # Assert
+        assert resolved_command == str(owner_executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []
+
+    def test_resolve_command_and_args_with_home_directory_same_as_current_user_no_duplication(self, tmp_path):
+        """When home_directory equals the current user's home, dirs are searched once and command is found."""
+        from unittest.mock import patch
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        local_bin = tmp_path / ".local" / "bin"
+        executable = local_bin / "mycommand"
+        self._make_executable(executable)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act — home_directory is the same Path as the mocked current home
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(tmp_path)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=tmp_path)
+
+        # Assert — command is found exactly once, no error raised
+        assert resolved_command == str(executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []
+
+    def test_resolve_command_and_args_with_home_directory_falls_back_to_current_user_dirs(self, tmp_path):
+        """When command is absent from owner's dirs but present in current user's dirs, it is still found."""
+        from unittest.mock import patch
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        owner_home = tmp_path / "owner"
+        current_home = tmp_path / "current"
+
+        # mycommand only exists in the current user's .local/bin
+        current_local_bin = current_home / ".local" / "bin"
+        current_executable = current_local_bin / "mycommand"
+        self._make_executable(current_executable)
+
+        # Owner's .local/bin exists but does NOT contain mycommand
+        (owner_home / ".local" / "bin").mkdir(parents=True, exist_ok=True)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(current_home)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=owner_home)
+
+        # Assert — falls back to current user's path
+        assert resolved_command == str(current_executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []
+
+    def test_resolve_command_and_args_raises_when_not_found_anywhere(self, tmp_path):
+        """When home_directory is provided but the command doesn't exist anywhere, ValueError is raised."""
+        from unittest.mock import patch
+
+        import pytest
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        owner_home = tmp_path / "owner"
+        current_home = tmp_path / "current"
+        owner_home.mkdir(parents=True, exist_ok=True)
+        current_home.mkdir(parents=True, exist_ok=True)
+
+        server_config = StdioServer(command="nonexistentcommand")
+
+        # Act & Assert
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(current_home)):
+            with pytest.raises(ValueError, match="not found"):
+                resolve_command_and_args(server_config, home_directory=owner_home)


### PR DESCRIPTION
## Problem

When `--all-users` is active, `resolve_command_and_args` previously always searched only the current process owner's home (`~`) for per-user binary directories like `~/.local/bin` and `~/.cargo/bin`. This meant that if a scanned MCP config belonged to user `bob`, a `uv`/`uvx` binary installed in `/home/bob/.local/bin` would never be found, causing false-negative results for those users.

## Solution

- Adds `home_directory: Path | None = None` to `ClientToInspect` (set to the config owner's home at discovery time)
- Threads `home_directory` through `inspect_client` → `inspect_extension` → `check_server` / `check_server_signature` → `resolve_command_and_args`
- In `resolve_command_and_args`, when `home_directory` differs from `~`, the owner's per-user dirs are searched first, then the scanner's own per-user dirs, then system paths
- Adds 5 unit tests covering the new lookup ordering

## Verification

- 387 unit tests pass
- pre-commit checks are clean