### PR TITLE
feat: extend uv binary lookup for --scan-all-users

### DIFF
--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -134,9 +134,17 @@ async def get_mcp_config_per_home_directory(
                 message=f"Skills dir {skills_dir_path_expanded.as_posix()} does not exist"
             )
 
+    # [REVIEW-COMMENT]
+    # Pass `home_directory` through to `ClientToInspect` so downstream code
+    # (inspect_extension → check_server → get_client → resolve_command_and_args)
+    # can locate binaries in the config-file owner's per-user directories even
+    # when the scan runs as a different user. When `home_directory` is None the
+    # behaviour is unchanged from before.
+    # [/REVIEW-COMMENT]
     return ClientToInspect(
         name=client.name,
         client_path=client_path,
+        home_directory=home_directory,
         mcp_configs=mcp_configs,
         skills_dirs=skills_dirs,
     )
@@ -152,6 +160,13 @@ def find_relevant_token(tokens: list[TokenAndClientInfo], name: str) -> TokenAnd
     return None
 
 
+# [REVIEW-COMMENT]
+# Added `home_directory` keyword parameter to `inspect_extension` so the
+# config-file owner's home directory can be passed all the way down to
+# `resolve_command_and_args` via `check_server`. This is part of the chain:
+#   inspect_client → inspect_extension → check_server → get_client → resolve_command_and_args
+# Defaults to None to preserve existing call-sites that don't need it.
+# [/REVIEW-COMMENT]
 async def inspect_extension(
     name: str,
     config: StdioServer | RemoteServer | SkillServer,
@@ -160,6 +175,7 @@ async def inspect_extension(
     *,
     config_path: str | None = None,
     stream_stderr: bool = False,
+    home_directory: Path | None = None,
 ) -> InspectedExtensions:
     """
     Scan an extension (MCP server or skill) and return a InspectedExtensions object.
@@ -179,6 +195,7 @@ async def inspect_extension(
                 server_name=name,
                 config_path=config_path,
                 stream_stderr=stream_stderr,
+                home_directory=home_directory,
             )
             return InspectedExtensions(name=name, config=config, signature_or_error=signature)
         except Exception as e:
@@ -292,6 +309,11 @@ async def inspect_client(
                     )
                 )
                 continue
+            # [REVIEW-COMMENT]
+            # Pass `client.home_directory` to `inspect_extension` so that the
+            # owner's per-user binary directories are searched when resolving
+            # the server command for stdio servers belonging to another user.
+            # [/REVIEW-COMMENT]
             extension = await inspect_extension(
                 name,
                 server,
@@ -299,6 +321,7 @@ async def inspect_client(
                 find_relevant_token(tokens, name),
                 config_path=mcp_config_path,
                 stream_stderr=stream_stderr,
+                home_directory=client.home_directory,
             )
             extensions_for_mcp_config.append(extension)
         extensions[mcp_config_path] = extensions_for_mcp_config

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -111,7 +111,15 @@ async def get_mcp_config_per_home_directory(
             server_configs_by_name = mcp_config.get_servers()
             for server_config in server_configs_by_name.values():
                 if isinstance(server_config, StdioServer):
-                    server_config = check_server_signature(server_config)
+                    # [REVIEW-COMMENT]
+                    # home_directory must be forwarded to check_server_signature so
+                    # that resolve_command_and_args searches the server owner's home
+                    # directory first (e.g. when scanning another user's config).
+                    # Previously this argument was omitted, causing the function to
+                    # always resolve commands relative to the current user's home,
+                    # which is incorrect when home_directory != current user home.
+                    # [/REVIEW-COMMENT]
+                    server_config = check_server_signature(server_config, home_directory=home_directory)
             mcp_configs[mcp_config_path_expanded.as_posix()] = [
                 (server_name, server) for server_name, server in server_configs_by_name.items()
             ]

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -111,14 +111,6 @@ async def get_mcp_config_per_home_directory(
             server_configs_by_name = mcp_config.get_servers()
             for server_config in server_configs_by_name.values():
                 if isinstance(server_config, StdioServer):
-                    # [REVIEW-COMMENT]
-                    # home_directory must be forwarded to check_server_signature so
-                    # that resolve_command_and_args searches the server owner's home
-                    # directory first (e.g. when scanning another user's config).
-                    # Previously this argument was omitted, causing the function to
-                    # always resolve commands relative to the current user's home,
-                    # which is incorrect when home_directory != current user home.
-                    # [/REVIEW-COMMENT]
                     server_config = check_server_signature(server_config, home_directory=home_directory)
             mcp_configs[mcp_config_path_expanded.as_posix()] = [
                 (server_name, server) for server_name, server in server_configs_by_name.items()
@@ -142,13 +134,6 @@ async def get_mcp_config_per_home_directory(
                 message=f"Skills dir {skills_dir_path_expanded.as_posix()} does not exist"
             )
 
-    # [REVIEW-COMMENT]
-    # Pass `home_directory` through to `ClientToInspect` so downstream code
-    # (inspect_extension → check_server → get_client → resolve_command_and_args)
-    # can locate binaries in the config-file owner's per-user directories even
-    # when the scan runs as a different user. When `home_directory` is None the
-    # behaviour is unchanged from before.
-    # [/REVIEW-COMMENT]
     return ClientToInspect(
         name=client.name,
         client_path=client_path,
@@ -168,13 +153,6 @@ def find_relevant_token(tokens: list[TokenAndClientInfo], name: str) -> TokenAnd
     return None
 
 
-# [REVIEW-COMMENT]
-# Added `home_directory` keyword parameter to `inspect_extension` so the
-# config-file owner's home directory can be passed all the way down to
-# `resolve_command_and_args` via `check_server`. This is part of the chain:
-#   inspect_client → inspect_extension → check_server → get_client → resolve_command_and_args
-# Defaults to None to preserve existing call-sites that don't need it.
-# [/REVIEW-COMMENT]
 async def inspect_extension(
     name: str,
     config: StdioServer | RemoteServer | SkillServer,
@@ -317,11 +295,6 @@ async def inspect_client(
                     )
                 )
                 continue
-            # [REVIEW-COMMENT]
-            # Pass `client.home_directory` to `inspect_extension` so that the
-            # owner's per-user binary directories are searched when resolving
-            # the server command for stdio servers belonging to another user.
-            # [/REVIEW-COMMENT]
             extension = await inspect_extension(
                 name,
                 server,

--- a/src/agent_scan/mcp_client.py
+++ b/src/agent_scan/mcp_client.py
@@ -4,6 +4,7 @@ import os
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -73,6 +74,13 @@ async def streamablehttp_client_without_session(
 
 
 @asynccontextmanager
+# [REVIEW-COMMENT]
+# Added `home_directory` keyword parameter to `get_client` so the config-file
+# owner's home is forwarded to `resolve_command_and_args`. This enables the
+# resolver to search the owner's per-user binary directories (e.g. ~/.local/bin)
+# when the scanning process runs as a different user. Defaults to None to keep
+# all existing call-sites working without changes.
+# [/REVIEW-COMMENT]
 async def get_client(
     server_config: StdioServer | RemoteServer,
     timeout: int | None = None,
@@ -82,6 +90,7 @@ async def get_client(
     server_name: str | None = None,
     config_path: str | None = None,
     stream_stderr: bool = False,
+    home_directory: Path | None = None,
 ) -> AsyncIterator[tuple]:
     """
     Create an MCP client for the given server config.
@@ -113,7 +122,7 @@ async def get_client(
     elif isinstance(server_config, StdioServer):
         logger.debug("Creating stdio client")
 
-        command, args = resolve_command_and_args(server_config)
+        command, args = resolve_command_and_args(server_config, home_directory=home_directory)
         server_params = StdioServerParameters(
             command=command,
             args=args,
@@ -150,6 +159,11 @@ async def get_client(
             yield streams
 
 
+# [REVIEW-COMMENT]
+# Added `home_directory` keyword parameter to `_check_server_pass` so it can
+# be forwarded to `get_client` (and ultimately to `resolve_command_and_args`).
+# The nested `_check_server` closure captures it via the enclosing scope.
+# [/REVIEW-COMMENT]
 async def _check_server_pass(
     server_config: StdioServer | RemoteServer,
     timeout: int,
@@ -159,6 +173,7 @@ async def _check_server_pass(
     server_name: str | None = None,
     config_path: str | None = None,
     stream_stderr: bool = False,
+    home_directory: Path | None = None,
 ) -> ServerSignature:
     async def _check_server() -> ServerSignature:
         async with get_client(
@@ -169,6 +184,7 @@ async def _check_server_pass(
             server_name=server_name,
             config_path=config_path,
             stream_stderr=stream_stderr,
+            home_directory=home_directory,
         ) as (
             read,
             write,
@@ -227,6 +243,13 @@ async def _check_server_pass(
     return await _check_server()
 
 
+# [REVIEW-COMMENT]
+# Added `home_directory` keyword parameter to `check_server` (the public entry
+# point for server checks) so callers that know the config-file owner's home
+# directory can pass it through. It is forwarded to `_check_server_pass`.
+# For remote servers `home_directory` has no effect (they don't use a local
+# binary), but accepting it here keeps the call-chain uniform.
+# [/REVIEW-COMMENT]
 async def check_server(
     server_config: StdioServer | RemoteServer,
     timeout: int,
@@ -236,6 +259,7 @@ async def check_server(
     server_name: str | None = None,
     config_path: str | None = None,
     stream_stderr: bool = False,
+    home_directory: Path | None = None,
 ) -> tuple[ServerSignature, StdioServer | RemoteServer]:
     logger.debug("Checking server with timeout: %s seconds", timeout)
 
@@ -248,6 +272,7 @@ async def check_server(
                 server_name=server_name,
                 config_path=config_path,
                 stream_stderr=stream_stderr,
+                home_directory=home_directory,
             ),
             timeout,
         )
@@ -300,6 +325,7 @@ async def check_server(
                         server_name=server_name,
                         config_path=config_path,
                         stream_stderr=False,  # stream_stderr is stdio-only
+                        home_directory=home_directory,
                     ),
                     timeout,
                 )

--- a/src/agent_scan/mcp_client.py
+++ b/src/agent_scan/mcp_client.py
@@ -74,13 +74,6 @@ async def streamablehttp_client_without_session(
 
 
 @asynccontextmanager
-# [REVIEW-COMMENT]
-# Added `home_directory` keyword parameter to `get_client` so the config-file
-# owner's home is forwarded to `resolve_command_and_args`. This enables the
-# resolver to search the owner's per-user binary directories (e.g. ~/.local/bin)
-# when the scanning process runs as a different user. Defaults to None to keep
-# all existing call-sites working without changes.
-# [/REVIEW-COMMENT]
 async def get_client(
     server_config: StdioServer | RemoteServer,
     timeout: int | None = None,
@@ -159,11 +152,6 @@ async def get_client(
             yield streams
 
 
-# [REVIEW-COMMENT]
-# Added `home_directory` keyword parameter to `_check_server_pass` so it can
-# be forwarded to `get_client` (and ultimately to `resolve_command_and_args`).
-# The nested `_check_server` closure captures it via the enclosing scope.
-# [/REVIEW-COMMENT]
 async def _check_server_pass(
     server_config: StdioServer | RemoteServer,
     timeout: int,
@@ -243,13 +231,6 @@ async def _check_server_pass(
     return await _check_server()
 
 
-# [REVIEW-COMMENT]
-# Added `home_directory` keyword parameter to `check_server` (the public entry
-# point for server checks) so callers that know the config-file owner's home
-# directory can pass it through. It is forwarded to `_check_server_pass`.
-# For remote servers `home_directory` has no effect (they don't use a local
-# binary), but accepting it here keeps the call-chain uniform.
-# [/REVIEW-COMMENT]
 async def check_server(
     server_config: StdioServer | RemoteServer,
     timeout: int,

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from itertools import chain
+from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
 from lark import Lark
@@ -538,6 +539,14 @@ class ClientToInspect(BaseModel):
     name: str
     client_path: str
     username: str | None = None
+    # [REVIEW-COMMENT]
+    # Added `home_directory` to carry the config-file owner's home directory
+    # through the inspection pipeline. This allows `resolve_command_and_args`
+    # to search the owner's per-user binary directories (e.g. ~/.local/bin)
+    # when the scanning process runs as a *different* user (e.g. root scanning
+    # another user's config). Defaults to None to preserve backward compat.
+    # [/REVIEW-COMMENT]
+    home_directory: Path | None = None
     mcp_configs: dict[
         str,
         list[tuple[str, StdioServer | RemoteServer]]

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -539,13 +539,6 @@ class ClientToInspect(BaseModel):
     name: str
     client_path: str
     username: str | None = None
-    # [REVIEW-COMMENT]
-    # Added `home_directory` to carry the config-file owner's home directory
-    # through the inspection pipeline. This allows `resolve_command_and_args`
-    # to search the owner's per-user binary directories (e.g. ~/.local/bin)
-    # when the scanning process runs as a *different* user (e.g. root scanning
-    # another user's config). Defaults to None to preserve backward compat.
-    # [/REVIEW-COMMENT]
     home_directory: Path | None = None
     mcp_configs: dict[
         str,

--- a/src/agent_scan/signed_binary.py
+++ b/src/agent_scan/signed_binary.py
@@ -33,13 +33,6 @@ def _is_code_launcher(command: str) -> bool:
     return any(p.match(basename) for p in _CODE_LAUNCHER_PATTERNS)
 
 
-# [REVIEW-COMMENT]
-# Added `home_directory` parameter to `check_server_signature` so the signature
-# check can resolve the server binary from the config-file owner's per-user
-# directories when the scanner runs as a different user. The parameter is
-# forwarded directly to `resolve_command_and_args`. Defaults to None (no change
-# in behaviour for existing callers).
-# [/REVIEW-COMMENT]
 def check_server_signature(server: StdioServer, home_directory: Path | None = None) -> StdioServer:
     """Get detailed code signing information."""
     if sys.platform != "darwin":

--- a/src/agent_scan/signed_binary.py
+++ b/src/agent_scan/signed_binary.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 from agent_scan.models import StdioServer
 from agent_scan.utils import resolve_command_and_args
@@ -32,13 +33,20 @@ def _is_code_launcher(command: str) -> bool:
     return any(p.match(basename) for p in _CODE_LAUNCHER_PATTERNS)
 
 
-def check_server_signature(server: StdioServer) -> StdioServer:
+# [REVIEW-COMMENT]
+# Added `home_directory` parameter to `check_server_signature` so the signature
+# check can resolve the server binary from the config-file owner's per-user
+# directories when the scanner runs as a different user. The parameter is
+# forwarded directly to `resolve_command_and_args`. Defaults to None (no change
+# in behaviour for existing callers).
+# [/REVIEW-COMMENT]
+def check_server_signature(server: StdioServer, home_directory: Path | None = None) -> StdioServer:
     """Get detailed code signing information."""
     if sys.platform != "darwin":
         logger.info(f"Binary signature check not supported on {sys.platform}. Only supported on macOS.")
         return server
     try:
-        command, _ = resolve_command_and_args(server)
+        command, _ = resolve_command_and_args(server, home_directory=home_directory)
 
         if _is_code_launcher(command):
             logger.info(

--- a/src/agent_scan/utils.py
+++ b/src/agent_scan/utils.py
@@ -82,11 +82,6 @@ def check_executable_exists(command: str) -> bool:
     return path.exists() or shutil.which(command) is not None
 
 
-# [REVIEW-COMMENT]
-# Extracted system-wide (non-user-specific) binary directories into a module-level
-# constant so they can be reused by `_user_specific_dirs` callers and tested in
-# isolation. These paths are the same regardless of which user owns the MCP config.
-# [/REVIEW-COMMENT]
 _SYSTEM_DIRS: list[str] = [
     # package manager paths
     "/opt/homebrew/bin",
@@ -103,12 +98,6 @@ _SYSTEM_DIRS: list[str] = [
 ]
 
 
-# [REVIEW-COMMENT]
-# Extracted per-user binary directory logic into a helper so it can be called
-# independently for different home directories (e.g. the owner's home vs the
-# current user's home). This makes the home_directory parameter on
-# resolve_command_and_args feasible without code duplication.
-# [/REVIEW-COMMENT]
 def _user_specific_dirs(home: str) -> list[str]:
     """Return per-user binary directories rooted at `home`."""
     nvm_pattern = os.path.join(home, ".nvm", "versions", "node", "*", "bin")
@@ -130,20 +119,6 @@ def _user_specific_dirs(home: str) -> list[str]:
     ]
 
 
-# [REVIEW-COMMENT]
-# Added `home_directory` parameter to `resolve_command_and_args` so callers that
-# know the *owner* of an MCP config file (which may differ from the scanning
-# user) can point us at that user's per-user binary directories.
-#
-# Search order when `home_directory` is provided and differs from the current
-# user's home:
-#   1. owner's per-user dirs  (most likely location for the config owner's tools)
-#   2. current user's per-user dirs  (fallback; scanner may share some tools)
-#   3. system dirs  (last resort, platform-wide paths)
-#
-# When `home_directory` is None *or* equals the current user's home we fall back
-# to the original single-user + system behaviour to preserve backward compat.
-# [/REVIEW-COMMENT]
 def resolve_command_and_args(
     server_config: StdioServer,
     home_directory: Path | None = None,

--- a/src/agent_scan/utils.py
+++ b/src/agent_scan/utils.py
@@ -82,9 +82,83 @@ def check_executable_exists(command: str) -> bool:
     return path.exists() or shutil.which(command) is not None
 
 
-def resolve_command_and_args(server_config: StdioServer) -> tuple[str, list[str] | None]:
+# [REVIEW-COMMENT]
+# Extracted system-wide (non-user-specific) binary directories into a module-level
+# constant so they can be reused by `_user_specific_dirs` callers and tested in
+# isolation. These paths are the same regardless of which user owns the MCP config.
+# [/REVIEW-COMMENT]
+_SYSTEM_DIRS: list[str] = [
+    # package manager paths
+    "/opt/homebrew/bin",
+    "/opt/local/bin",
+    "/snap/bin",
+    # system paths
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+    # docker path
+    "/Applications/Docker.app/Contents/Resources/bin",
+]
+
+
+# [REVIEW-COMMENT]
+# Extracted per-user binary directory logic into a helper so it can be called
+# independently for different home directories (e.g. the owner's home vs the
+# current user's home). This makes the home_directory parameter on
+# resolve_command_and_args feasible without code duplication.
+# [/REVIEW-COMMENT]
+def _user_specific_dirs(home: str) -> list[str]:
+    """Return per-user binary directories rooted at `home`."""
+    nvm_pattern = os.path.join(home, ".nvm", "versions", "node", "*", "bin")
+    nvm_dirs = sorted(glob.glob(nvm_pattern), reverse=True)
+    return [
+        # node / npx
+        *nvm_dirs,
+        os.path.join(home, ".npm-global", "bin"),
+        os.path.join(home, ".yarn", "bin"),
+        os.path.join(home, ".local", "share", "pnpm"),
+        os.path.join(home, ".config", "yarn", "global", "node_modules", ".bin"),
+        # python / uvx
+        os.path.join(home, ".cargo", "bin"),
+        os.path.join(home, ".pyenv", "shims"),
+        # user local paths
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".bin"),
+        os.path.join(home, "bin"),
+    ]
+
+
+# [REVIEW-COMMENT]
+# Added `home_directory` parameter to `resolve_command_and_args` so callers that
+# know the *owner* of an MCP config file (which may differ from the scanning
+# user) can point us at that user's per-user binary directories.
+#
+# Search order when `home_directory` is provided and differs from the current
+# user's home:
+#   1. owner's per-user dirs  (most likely location for the config owner's tools)
+#   2. current user's per-user dirs  (fallback; scanner may share some tools)
+#   3. system dirs  (last resort, platform-wide paths)
+#
+# When `home_directory` is None *or* equals the current user's home we fall back
+# to the original single-user + system behaviour to preserve backward compat.
+# [/REVIEW-COMMENT]
+def resolve_command_and_args(
+    server_config: StdioServer,
+    home_directory: Path | None = None,
+) -> tuple[str, list[str] | None]:
     """
     Resolve the command and arguments for a StdioServer.
+
+    Parameters
+    ----------
+    server_config:
+        The server configuration containing the command to resolve.
+    home_directory:
+        Optional home directory of the user who *owns* the MCP config file.
+        When provided and different from the current user's home, the owner's
+        per-user binary directories are searched before the current user's.
     """
     # check if command points to an executable and whether it exists absolute or on the path
     if check_executable_exists(server_config.command):
@@ -96,36 +170,16 @@ def resolve_command_and_args(server_config: StdioServer) -> tuple[str, list[str]
         raise ValueError(f"Path does not exist: {command}")
 
     # attempt to find the command in well-known directories
-    # npx via nvm - look for node versions directory
-    nvm_pattern = os.path.expanduser("~/.nvm/versions/node/*/bin")
-    nvm_dirs = sorted(glob.glob(nvm_pattern), reverse=True)
-    fallback_dirs = [
-        # node / npx
-        *nvm_dirs,
-        os.path.expanduser("~/.npm-global/bin"),
-        os.path.expanduser("~/.yarn/bin"),
-        os.path.expanduser("~/.local/share/pnpm"),
-        os.path.expanduser("~/.config/yarn/global/node_modules/.bin"),
-        # python / uvx
-        os.path.expanduser("~/.cargo/bin"),
-        os.path.expanduser("~/.pyenv/shims"),
-        # user local paths
-        os.path.expanduser("~/.local/bin"),
-        os.path.expanduser("~/.bin"),
-        os.path.expanduser("~/bin"),
-        # package manager paths
-        "/opt/homebrew/bin",
-        "/opt/local/bin",
-        "/snap/bin",
-        # system paths
-        "/usr/local/bin",
-        "/usr/bin",
-        "/bin",
-        "/usr/sbin",
-        "/sbin",
-        # docker path
-        "/Applications/Docker.app/Contents/Resources/bin",
-    ]
+    current_home = os.path.expanduser("~")
+
+    # Build the ordered list of directories to search.
+    # If home_directory differs from the current user's home, prepend the
+    # owner's per-user dirs so that the config owner's toolchain is preferred.
+    fallback_dirs: list[str] = []
+    if home_directory is not None and str(home_directory) != current_home:
+        fallback_dirs.extend(_user_specific_dirs(str(home_directory)))
+    fallback_dirs.extend(_user_specific_dirs(current_home))
+    fallback_dirs.extend(_SYSTEM_DIRS)
 
     for d in fallback_dirs:
         potential_path = os.path.join(d, command)

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from agent_scan.inspect import get_mcp_config_per_client
-from agent_scan.models import CandidateClient, ClientToInspect
+from agent_scan.inspect import get_mcp_config_per_client, inspect_client
+from agent_scan.models import CandidateClient, ClientToInspect, StdioServer
 from agent_scan.pipelines import InspectArgs, inspect_pipeline
 
 TEST_CANDIDATE_CLIENT = CandidateClient(
@@ -442,3 +442,67 @@ async def test_inspect_pipeline_discovery_mode_without_all_users_falls_back_to_c
         assert scanned_usernames == [getpass.getuser()]
     finally:
         shutil.rmtree(tmp)
+
+
+# --- inspect_client home_directory threading test ---
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_threads_home_directory_to_resolve_command_and_args():
+    """home_directory must reach resolve_command_and_args through the full call chain.
+
+    Guards against an intermediate layer (inspect_extension -> check_server ->
+    _check_server_pass -> get_client) silently dropping the kwarg, which would
+    break --scan-all-users binary lookup for the config owner's per-user dirs.
+    """
+    expected_home = Path("/fake/owner/home")
+    client = ClientToInspect(
+        name="fake-client",
+        client_path="/fake/client",
+        username="owner",
+        home_directory=expected_home,
+        mcp_configs={
+            "/fake/mcp.json": [
+                ("dummy-server", StdioServer(command="dummycmd", args=["--flag"])),
+            ],
+        },
+        skills_dirs={},
+    )
+
+    # Raising from resolve_command_and_args short-circuits the subprocess path
+    # cleanly: the exception is caught by inspect_extension and turned into a
+    # ServerStartupError, but the call (with kwargs) is still recorded.
+    with patch(
+        "agent_scan.mcp_client.resolve_command_and_args",
+        side_effect=RuntimeError("short-circuit after capture"),
+    ) as mock_resolve:
+        await inspect_client(client, timeout=1, tokens=[], scan_skills=False)
+
+    assert mock_resolve.called, "resolve_command_and_args was never invoked"
+    assert mock_resolve.call_args.kwargs.get("home_directory") == expected_home
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_passes_none_home_directory_when_unset():
+    """When ClientToInspect.home_directory is None (single-user scan),
+    resolve_command_and_args must still receive home_directory=None — not a
+    stale value from elsewhere — so the current user's PATH is used."""
+    client = ClientToInspect(
+        name="fake-client",
+        client_path="/fake/client",
+        mcp_configs={
+            "/fake/mcp.json": [
+                ("dummy-server", StdioServer(command="dummycmd", args=[])),
+            ],
+        },
+        skills_dirs={},
+    )
+
+    with patch(
+        "agent_scan.mcp_client.resolve_command_and_args",
+        side_effect=RuntimeError("short-circuit after capture"),
+    ) as mock_resolve:
+        await inspect_client(client, timeout=1, tokens=[], scan_skills=False)
+
+    assert mock_resolve.called
+    assert mock_resolve.call_args.kwargs.get("home_directory") is None

--- a/tests/unit/test_signed_binary.py
+++ b/tests/unit/test_signed_binary.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from agent_scan.models import StdioServer
@@ -36,3 +39,50 @@ def test_check_server_signature(command: str):
 )
 def test_is_code_launcher(command: str, is_code_launcher: bool):
     assert _is_code_launcher(command) == is_code_launcher
+
+
+def test_check_server_signature_forwards_home_directory_to_resolve():
+    """home_directory must reach resolve_command_and_args. check_server_signature
+    is called from get_mcp_config_per_home_directory during --scan-all-users, so the
+    config owner's per-user binary dirs must be searched when resolving the binary
+    to codesign-check.
+
+    Forces sys.platform to "darwin" so the test runs on all CI platforms instead of
+    no-op'ing on Linux/Windows, and patches resolve_command_and_args to short-circuit
+    before any subprocess call.
+    """
+    expected_home = Path("/fake/owner/home")
+    server = StdioServer(command="dummycmd", args=[])
+
+    with (
+        patch("sys.platform", "darwin"),
+        patch(
+            "agent_scan.signed_binary.resolve_command_and_args",
+            side_effect=RuntimeError("short-circuit after capture"),
+        ) as mock_resolve,
+    ):
+        # check_server_signature swallows the exception (broad except) and returns
+        # the original server unchanged — fine: we only assert how resolve was called.
+        result = check_server_signature(server, home_directory=expected_home)
+
+    assert result is server
+    assert mock_resolve.called, "resolve_command_and_args was never invoked"
+    assert mock_resolve.call_args.kwargs.get("home_directory") == expected_home
+
+
+def test_check_server_signature_forwards_none_home_directory_when_unset():
+    """When called without home_directory, resolve_command_and_args must receive
+    home_directory=None (the explicit default), not a stale value."""
+    server = StdioServer(command="dummycmd", args=[])
+
+    with (
+        patch("sys.platform", "darwin"),
+        patch(
+            "agent_scan.signed_binary.resolve_command_and_args",
+            side_effect=RuntimeError("short-circuit after capture"),
+        ) as mock_resolve,
+    ):
+        check_server_signature(server)
+
+    assert mock_resolve.called
+    assert mock_resolve.call_args.kwargs.get("home_directory") is None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,13 +2,15 @@ import io
 import os
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from agent_scan.models import CommandParsingError, rebalance_command_args
+from agent_scan.models import CommandParsingError, StdioServer, rebalance_command_args
 from agent_scan.utils import (
     calculate_distance,
     get_relative_path,
+    resolve_command_and_args,
     suppress_stdout,
 )
 
@@ -155,11 +157,6 @@ class TestResolveCommandAndArgs:
 
     def test_resolve_command_and_args_no_home_directory_searches_current_user_dirs(self, tmp_path):
         """When home_directory=None, a command in ~/.local/bin is found via the current user's dirs."""
-        from unittest.mock import patch
-
-        from agent_scan.models import StdioServer
-        from agent_scan.utils import resolve_command_and_args
-
         # Arrange
         local_bin = tmp_path / ".local" / "bin"
         executable = local_bin / "mycommand"
@@ -177,11 +174,6 @@ class TestResolveCommandAndArgs:
 
     def test_resolve_command_and_args_with_home_directory_searches_owner_home_first(self, tmp_path):
         """When home_directory differs from current home, the owner's dirs are searched first."""
-        from unittest.mock import patch
-
-        from agent_scan.models import StdioServer
-        from agent_scan.utils import resolve_command_and_args
-
         # Arrange
         owner_home = tmp_path / "owner"
         current_home = tmp_path / "current"
@@ -205,11 +197,6 @@ class TestResolveCommandAndArgs:
 
     def test_resolve_command_and_args_with_home_directory_same_as_current_user_no_duplication(self, tmp_path):
         """When home_directory equals the current user's home, dirs are searched once and command is found."""
-        from unittest.mock import patch
-
-        from agent_scan.models import StdioServer
-        from agent_scan.utils import resolve_command_and_args
-
         # Arrange
         local_bin = tmp_path / ".local" / "bin"
         executable = local_bin / "mycommand"
@@ -227,11 +214,6 @@ class TestResolveCommandAndArgs:
 
     def test_resolve_command_and_args_with_home_directory_falls_back_to_current_user_dirs(self, tmp_path):
         """When command is absent from owner's dirs but present in current user's dirs, it is still found."""
-        from unittest.mock import patch
-
-        from agent_scan.models import StdioServer
-        from agent_scan.utils import resolve_command_and_args
-
         # Arrange
         owner_home = tmp_path / "owner"
         current_home = tmp_path / "current"
@@ -256,13 +238,6 @@ class TestResolveCommandAndArgs:
 
     def test_resolve_command_and_args_raises_when_not_found_anywhere(self, tmp_path):
         """When home_directory is provided but the command doesn't exist anywhere, ValueError is raised."""
-        from unittest.mock import patch
-
-        import pytest
-
-        from agent_scan.models import StdioServer
-        from agent_scan.utils import resolve_command_and_args
-
         # Arrange
         owner_home = tmp_path / "owner"
         current_home = tmp_path / "current"
@@ -275,3 +250,25 @@ class TestResolveCommandAndArgs:
         with patch("agent_scan.utils.os.path.expanduser", return_value=str(current_home)):
             with pytest.raises(ValueError, match="not found"):
                 resolve_command_and_args(server_config, home_directory=owner_home)
+
+    def test_resolve_command_and_args_with_home_directory_owner_wins_when_both_have_command(self, tmp_path):
+        """When both owner and current user have the command, the owner's binary is returned."""
+        # Arrange
+        owner_home = tmp_path / "owner"
+        current_home = tmp_path / "current"
+
+        owner_executable = owner_home / ".local" / "bin" / "mycommand"
+        self._make_executable(owner_executable)
+
+        current_executable = current_home / ".local" / "bin" / "mycommand"
+        self._make_executable(current_executable)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act — owner's home is provided; current user's home is mocked to current_home
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(current_home)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=owner_home)
+
+        # Assert — owner's path wins over current user's path
+        assert resolved_command == str(owner_executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 import io
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -141,3 +142,136 @@ class TestSuppressStdout:
 
         # Only the final print should appear
         assert captured_output.getvalue() == "Final line\n"
+
+
+class TestResolveCommandAndArgs:
+    """Tests for the home_directory parameter of resolve_command_and_args."""
+
+    def _make_executable(self, path: Path) -> None:
+        """Create a file and make it executable."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+        path.chmod(0o755)
+
+    def test_resolve_command_and_args_no_home_directory_searches_current_user_dirs(self, tmp_path):
+        """When home_directory=None, a command in ~/.local/bin is found via the current user's dirs."""
+        from unittest.mock import patch
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        local_bin = tmp_path / ".local" / "bin"
+        executable = local_bin / "mycommand"
+        self._make_executable(executable)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(tmp_path)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=None)
+
+        # Assert
+        assert resolved_command == str(executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []
+
+    def test_resolve_command_and_args_with_home_directory_searches_owner_home_first(self, tmp_path):
+        """When home_directory differs from current home, the owner's dirs are searched first."""
+        from unittest.mock import patch
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        owner_home = tmp_path / "owner"
+        current_home = tmp_path / "current"
+
+        owner_local_bin = owner_home / ".local" / "bin"
+        owner_executable = owner_local_bin / "mycommand"
+        self._make_executable(owner_executable)
+
+        # mycommand does NOT exist in current user's dirs
+        (current_home / ".local" / "bin").mkdir(parents=True, exist_ok=True)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(current_home)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=owner_home)
+
+        # Assert
+        assert resolved_command == str(owner_executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []
+
+    def test_resolve_command_and_args_with_home_directory_same_as_current_user_no_duplication(self, tmp_path):
+        """When home_directory equals the current user's home, dirs are searched once and command is found."""
+        from unittest.mock import patch
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        local_bin = tmp_path / ".local" / "bin"
+        executable = local_bin / "mycommand"
+        self._make_executable(executable)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act — home_directory is the same Path as the mocked current home
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(tmp_path)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=tmp_path)
+
+        # Assert — command is found exactly once, no error raised
+        assert resolved_command == str(executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []
+
+    def test_resolve_command_and_args_with_home_directory_falls_back_to_current_user_dirs(self, tmp_path):
+        """When command is absent from owner's dirs but present in current user's dirs, it is still found."""
+        from unittest.mock import patch
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        owner_home = tmp_path / "owner"
+        current_home = tmp_path / "current"
+
+        # mycommand only exists in the current user's .local/bin
+        current_local_bin = current_home / ".local" / "bin"
+        current_executable = current_local_bin / "mycommand"
+        self._make_executable(current_executable)
+
+        # Owner's .local/bin exists but does NOT contain mycommand
+        (owner_home / ".local" / "bin").mkdir(parents=True, exist_ok=True)
+
+        server_config = StdioServer(command="mycommand")
+
+        # Act
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(current_home)):
+            resolved_command, resolved_args = resolve_command_and_args(server_config, home_directory=owner_home)
+
+        # Assert — falls back to current user's path
+        assert resolved_command == str(current_executable)
+        assert not resolved_args  # no args were passed; model normalises None -> []
+
+    def test_resolve_command_and_args_raises_when_not_found_anywhere(self, tmp_path):
+        """When home_directory is provided but the command doesn't exist anywhere, ValueError is raised."""
+        from unittest.mock import patch
+
+        import pytest
+
+        from agent_scan.models import StdioServer
+        from agent_scan.utils import resolve_command_and_args
+
+        # Arrange
+        owner_home = tmp_path / "owner"
+        current_home = tmp_path / "current"
+        owner_home.mkdir(parents=True, exist_ok=True)
+        current_home.mkdir(parents=True, exist_ok=True)
+
+        server_config = StdioServer(command="nonexistentcommand")
+
+        # Act & Assert
+        with patch("agent_scan.utils.os.path.expanduser", return_value=str(current_home)):
+            with pytest.raises(ValueError, match="not found"):
+                resolve_command_and_args(server_config, home_directory=owner_home)


### PR DESCRIPTION
## Summary

- Added `home_directory` field to `ClientToInspect` model to support per-user home directory context when scanning all users
- Extended `resolve_command_and_args` in `utils.py` to accept a `home_directory` parameter, enabling `uv`-based MCP servers to be resolved against a specific user's home directory
- Threaded `home_directory` through the inspection call chain (`inspect.py`, `mcp_client.py`, `signed_binary.py`) so the correct binary path is resolved for each user during `--scan-all-users` scans