### PR TITLE
fix: persist tenant_id in PowerShell guard hook command

### DIFF
--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -663,6 +663,7 @@ def _parse_command_info(cmd: str, events: list[str]) -> dict:
 _PS_PARAM_MAP = {
     "PUSH_KEY": "PushKey",
     "REMOTE_HOOKS_BASE_URL": "RemoteUrl",
+    "TENANT_ID": "TenantId",
 }
 
 
@@ -740,7 +741,10 @@ def _build_hook_command(push_key: str, url: str, script_path: Path, hook_client:
 def _build_hook_command_powershell(
     push_key: str, url: str, script_path: Path, hook_client: str, *, tenant_id: str = ""
 ) -> str:
-    return f"powershell -File '{script_path}' -Client {hook_client} -PushKey '{push_key}' -RemoteUrl '{url}'"
+    cmd = f"powershell -File '{script_path}' -Client {hook_client} -PushKey '{push_key}' -RemoteUrl '{url}'"
+    if tenant_id:
+        cmd += f" -TenantId '{tenant_id}'"
+    return cmd
 
 
 def _shell_quote(s: str) -> str:

--- a/src/agent_scan/hooks/snyk-agent-guard.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard.ps1
@@ -18,7 +18,10 @@ param(
     [string]$PushKey,
 
     [Parameter(Mandatory=$false)]
-    [string]$RemoteUrl
+    [string]$RemoteUrl,
+
+    [Parameter(Mandatory=$false)]
+    [string]$TenantId
 )
 
 $ErrorActionPreference = "Stop"

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -189,6 +189,14 @@ class TestBuildHookCommand:
     def test_without_tenant_powershell_no_tenant_id(self):
         cmd = _build_hook_command("pk", "https://api.snyk.io", Path("/x/hook.ps1"), "claude-code")
         assert "TENANT_ID" not in cmd
+        assert "-TenantId" not in cmd
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="powershell command format")
+    def test_with_tenant_powershell(self):
+        cmd = _build_hook_command(
+            "pk", "https://api.snyk.io", Path("/x/hook.ps1"), "claude-code", tenant_id="tid"
+        )
+        assert "-TenantId 'tid'" in cmd
 
     def test_roundtrip_extract(self):
         cmd = _build_hook_command(
@@ -196,9 +204,7 @@ class TestBuildHookCommand:
         )
         assert _extract_env_from_cmd(cmd, "PUSH_KEY") == "my-key"
         assert _extract_env_from_cmd(cmd, "REMOTE_HOOKS_BASE_URL") == "https://example.com"
-        # tenant_id is only in bash commands, not powershell
-        if sys.platform != "win32":
-            assert _extract_env_from_cmd(cmd, "TENANT_ID") == "t-1"
+        assert _extract_env_from_cmd(cmd, "TENANT_ID") == "t-1"
 
 
 class TestParseCommandInfo:


### PR DESCRIPTION
## Summary

The bash hook command embeds `TENANT_ID='...'` as an env-var prefix so `_extract_env_from_cmd` can recover the tenant later (used by `guard status`, `guard uninstall`, and `_parse_command_info`). The PowerShell builder accepted `tenant_id` as a kwarg but never emitted it, so on Windows the tenant was lost once the hook was written into `settings.json` and could not be round-tripped.

This PR brings the PowerShell command to parity:

- Adds an optional `-TenantId` param to `snyk-agent-guard.ps1`. It is declared but not used at runtime, mirroring the bash script which also does not read `TENANT_ID` — both are persisted purely for round-trip recovery.
- Emits `-TenantId '<value>'` from `_build_hook_command_powershell` when a tenant id is provided.
- Adds `TENANT_ID -> TenantId` to `_PS_PARAM_MAP` so `_extract_env_from_cmd` recovers it on Windows.
- Drops the platform-gated branch in `test_roundtrip_extract` and adds an explicit `test_with_tenant_powershell` case.

Note: this only fixes the persistence/round-trip side. Neither the bash nor the PowerShell hook script forwards `tenant_id` in the request payload today, so wire-level behavior is unchanged.