### PR TITLE
feat: add Codex hooks support

### DIFF
--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -431,7 +431,7 @@ def main():
     guard_parser = subparsers.add_parser(
         "guard",
         help="Install, uninstall, or check status of Agent Guard hooks",
-        description="Manage Agent Guard hooks for Claude Code and Cursor.",
+        description="Manage Agent Guard hooks for Claude Code, Cursor, and Codex.",
     )
     guard_subparsers = guard_parser.add_subparsers(
         dest="guard_command",
@@ -446,7 +446,7 @@ def main():
     )
     guard_install_parser.add_argument(
         "client",
-        choices=["claude", "cursor"],
+        choices=["claude", "cursor", "codex"],
         help="Client to install hooks for",
     )
     guard_install_parser.add_argument(
@@ -487,7 +487,7 @@ def main():
     )
     guard_uninstall_parser.add_argument(
         "client",
-        choices=["claude", "cursor"],
+        choices=["claude", "cursor", "codex"],
         help="Client to uninstall hooks from",
     )
     guard_uninstall_parser.add_argument(

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -37,18 +37,20 @@ CURSOR_HOOKS_PATH = Path.home() / ".cursor" / "hooks.json"
 CODEX_HOOKS_PATH = Path.home() / ".codex" / "hooks.json"
 
 # Managed (MDM / admin-deployed) config paths — OS-specific
+# Codex managed hooks use a requirements.toml file at a system location
+# (see https://developers.openai.com/codex/hooks#managed-hooks-from-requirementstoml).
 if sys.platform == "darwin":
     CLAUDE_MANAGED_SETTINGS_PATH = Path("/Library/Application Support/ClaudeCode/managed-settings.json")
     CURSOR_MANAGED_HOOKS_PATH = Path("/Library/Application Support/Cursor/hooks.json")
-    CODEX_MANAGED_HOOKS_PATH = Path("/Library/Application Support/Codex/hooks.json")
+    CODEX_MANAGED_HOOKS_PATH = Path("/etc/codex/requirements.toml")
 elif sys.platform == "win32":
     CLAUDE_MANAGED_SETTINGS_PATH = Path("C:/Program Files/ClaudeCode/managed-settings.json")
     CURSOR_MANAGED_HOOKS_PATH = Path("C:/ProgramData/Cursor/hooks.json")
-    CODEX_MANAGED_HOOKS_PATH = Path("C:/ProgramData/Codex/hooks.json")
+    CODEX_MANAGED_HOOKS_PATH = Path("C:/ProgramData/OpenAI/Codex/requirements.toml")
 else:  # Linux and others
     CLAUDE_MANAGED_SETTINGS_PATH = Path("/etc/claude-code/managed-settings.json")
     CURSOR_MANAGED_HOOKS_PATH = Path("/etc/cursor/hooks.json")
-    CODEX_MANAGED_HOOKS_PATH = Path("/etc/codex/hooks.json")
+    CODEX_MANAGED_HOOKS_PATH = Path("/etc/codex/requirements.toml")
 
 CLAUDE_HOOK_EVENTS = [
     "PreToolUse",
@@ -274,7 +276,10 @@ def _install_hooks(
     elif client == "cursor":
         config_changed = _install_cursor(command, config_path)
     elif client == "codex":
-        config_changed = _install_codex(command, config_path)
+        if _is_codex_requirements_toml(config_path):
+            config_changed = _install_codex_managed(command, config_path, dest_path)
+        else:
+            config_changed = _install_codex(command, config_path)
 
     if script_updated or config_changed or minted:
         rich.print(f"[green]\u2713[/green]  {scope.title()} hooks installed for [bold]{label}[/bold]")
@@ -367,6 +372,111 @@ def _install_codex(command: str, path: Path) -> bool:
     return True
 
 
+def _is_codex_requirements_toml(path: Path) -> bool:
+    return path.suffix.lower() == ".toml"
+
+
+def _codex_managed_dirs(config_path: Path) -> tuple[str, str]:
+    """Return (managed_dir, windows_managed_dir) values to embed in requirements.toml.
+
+    The current platform's value is derived from the config_path so the script
+    location stays consistent with where _copy_hook_script writes it. The
+    other-platform value uses the canonical Codex system path.
+    """
+    hooks_dir = (config_path.parent / "hooks").as_posix()
+    if IS_WINDOWS:
+        windows_managed_dir = str(config_path.parent / "hooks")
+        managed_dir = "/etc/codex/hooks"
+        return managed_dir, windows_managed_dir
+    managed_dir = hooks_dir
+    windows_managed_dir = r"C:\ProgramData\OpenAI\Codex\hooks"
+    return managed_dir, windows_managed_dir
+
+
+def _render_codex_requirements_toml(command: str, config_path: Path) -> str:
+    """Generate the requirements.toml content for managed Codex hooks."""
+    managed_dir, windows_managed_dir = _codex_managed_dirs(config_path)
+    lines = [
+        "[features]",
+        "hooks = true",
+        "",
+        "[hooks]",
+        f'managed_dir = "{managed_dir}"',
+        f"windows_managed_dir = '{windows_managed_dir}'",
+        "",
+    ]
+    escaped = command.replace("\\", "\\\\").replace('"', '\\"')
+    for event in CODEX_HOOK_EVENTS:
+        lines.append(f"[[hooks.{event}]]")
+        lines.append(f"[[hooks.{event}.hooks]]")
+        lines.append('type = "command"')
+        lines.append(f'command = "{escaped}"')
+        lines.append("")
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def _install_codex_managed(command: str, path: Path, script_path: Path) -> bool:
+    """Write Codex managed hooks as requirements.toml. Returns True if changed."""
+    new_content = _render_codex_requirements_toml(command, path)
+    if path.exists() and path.read_text() == new_content:
+        return False
+    if path.exists():
+        _backup_file(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new_content)
+    rich.print(f"[green]✓[/green]  Written [dim]{path}[/dim]")
+    return True
+
+
+def _parse_codex_requirements_toml(text: str) -> tuple[list[str], str | None]:
+    """Extract Snyk Agent Guard events and the first matching command from requirements.toml.
+
+    Returns (events, command). Only scans hook command lines containing the
+    agent-guard detection marker.
+    """
+    events: list[str] = []
+    found_cmd: str | None = None
+    current_event: str | None = None
+    header_re = re.compile(r"^\[\[hooks\.([A-Za-z]+)(?:\.hooks)?\]\]\s*$")
+    command_re = re.compile(r'^command\s*=\s*"((?:[^"\\]|\\.)*)"\s*$')
+    for raw in text.splitlines():
+        line = raw.strip()
+        m = header_re.match(line)
+        if m:
+            current_event = m.group(1)
+            continue
+        m = command_re.match(line)
+        if m and current_event:
+            cmd = m.group(1).encode("utf-8").decode("unicode_escape")
+            if _is_agent_scan_command(cmd) and current_event not in events:
+                events.append(current_event)
+                if found_cmd is None:
+                    found_cmd = cmd
+    return events, found_cmd
+
+
+def _detect_codex_managed_install(path: Path) -> dict | None:
+    text = path.read_text()
+    events, found_cmd = _parse_codex_requirements_toml(text)
+    if not events or found_cmd is None:
+        return None
+    return _parse_command_info(found_cmd, events)
+
+
+def _uninstall_codex_managed(path: Path) -> None:
+    if not path.exists():
+        rich.print("[dim]No requirements.toml found. Nothing to uninstall.[/dim]")
+        return
+    text = path.read_text()
+    events, _ = _parse_codex_requirements_toml(text)
+    if not events:
+        rich.print("[dim]No Agent Guard hooks found.[/dim]")
+        return
+    _backup_file(path)
+    path.unlink()
+    rich.print(f"[green]✓[/green]  Removed {len(events)} Agent Guard hook(s) (deleted [dim]{path}[/dim])")
+
+
 # ---------------------------------------------------------------------------
 # Uninstall
 # ---------------------------------------------------------------------------
@@ -397,7 +507,10 @@ def _run_uninstall(args) -> None:
     elif client == "cursor":
         _uninstall_cursor(config_path)
     elif client == "codex":
-        _uninstall_codex(config_path)
+        if _is_codex_requirements_toml(config_path):
+            _uninstall_codex_managed(config_path)
+        else:
+            _uninstall_codex(config_path)
 
     # Remove hook script
     _remove_hook_script(client, config_path)
@@ -602,6 +715,8 @@ def _detect_claude_install(path: Path = CLAUDE_SETTINGS_PATH) -> dict | None:
 def _detect_codex_install(path: Path = CODEX_HOOKS_PATH) -> dict | None:
     if not path.exists():
         return None
+    if _is_codex_requirements_toml(path):
+        return _detect_codex_managed_install(path)
     data = _read_json_or_empty(path)
     hooks = data.get("hooks", {})
 

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1,4 +1,4 @@
-"""Agent Guard hook management for Claude Code and Cursor."""
+"""Agent Guard hook management for Claude Code, Cursor, and Codex."""
 
 from __future__ import annotations
 
@@ -34,17 +34,21 @@ _PERMISSION_DENIED = "__permission_denied__"
 
 CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 CURSOR_HOOKS_PATH = Path.home() / ".cursor" / "hooks.json"
+CODEX_HOOKS_PATH = Path.home() / ".codex" / "hooks.json"
 
 # Managed (MDM / admin-deployed) config paths — OS-specific
 if sys.platform == "darwin":
     CLAUDE_MANAGED_SETTINGS_PATH = Path("/Library/Application Support/ClaudeCode/managed-settings.json")
     CURSOR_MANAGED_HOOKS_PATH = Path("/Library/Application Support/Cursor/hooks.json")
+    CODEX_MANAGED_HOOKS_PATH = Path("/Library/Application Support/Codex/hooks.json")
 elif sys.platform == "win32":
     CLAUDE_MANAGED_SETTINGS_PATH = Path("C:/Program Files/ClaudeCode/managed-settings.json")
     CURSOR_MANAGED_HOOKS_PATH = Path("C:/ProgramData/Cursor/hooks.json")
+    CODEX_MANAGED_HOOKS_PATH = Path("C:/ProgramData/Codex/hooks.json")
 else:  # Linux and others
     CLAUDE_MANAGED_SETTINGS_PATH = Path("/etc/claude-code/managed-settings.json")
     CURSOR_MANAGED_HOOKS_PATH = Path("/etc/cursor/hooks.json")
+    CODEX_MANAGED_HOOKS_PATH = Path("/etc/codex/hooks.json")
 
 CLAUDE_HOOK_EVENTS = [
     "PreToolUse",
@@ -58,6 +62,15 @@ CLAUDE_HOOK_EVENTS = [
     "SubagentStop",
 ]
 CLAUDE_EVENTS_WITH_MATCHER = {"PreToolUse", "PostToolUse", "PostToolUseFailure"}
+
+CODEX_HOOK_EVENTS = [
+    "PreToolUse",
+    "PermissionRequest",
+    "PostToolUse",
+    "UserPromptSubmit",
+    "Stop",
+    "SessionStart",
+]
 
 CURSOR_HOOK_EVENTS = [
     "beforeSubmitPrompt",
@@ -207,7 +220,7 @@ def _run_install(args) -> None:
             sys.exit(1)
         rich.print(f"[green]\u2713[/green]  Push key minted  [yellow]{_mask_key(push_key)}[/yellow]")
 
-    hook_client = "claude-code" if client == "claude" else "cursor"
+    hook_client = _hook_client_name(client)
     minted = not headless  # True if we minted the key in this run
     config_path = _config_path(client, getattr(args, "file", None), managed=managed)
 
@@ -260,6 +273,8 @@ def _install_hooks(
         config_changed = _install_claude(command, config_path)
     elif client == "cursor":
         config_changed = _install_cursor(command, config_path)
+    elif client == "codex":
+        config_changed = _install_codex(command, config_path)
 
     if script_updated or config_changed or minted:
         rich.print(f"[green]\u2713[/green]  {scope.title()} hooks installed for [bold]{label}[/bold]")
@@ -324,6 +339,34 @@ def _install_cursor(command: str, path: Path) -> bool:
     return True
 
 
+def _install_codex(command: str, path: Path) -> bool:
+    """Install Codex hooks. Returns True if the file was changed.
+
+    Codex uses the same hooks.json shape as Claude Code: each event maps to a
+    list of matcher groups, each containing a list of command hooks.
+    """
+    data = _read_json_or_empty(path)
+    hooks = data.get("hooks", {})
+
+    preserved = _count_non_agent_scan_claude(hooks)
+    hooks = _filter_claude_hooks(hooks)
+
+    # Codex matches every event when "matcher" is omitted, so we don't set it.
+    for event in CODEX_HOOK_EVENTS:
+        entry = {"type": "command", "command": command}
+        existing = hooks.get(event, [])
+        existing.append({"hooks": [entry]})
+        hooks[event] = existing
+
+    data["hooks"] = hooks
+
+    if not _write_json_if_changed(path, data):
+        return False
+    note = _preserved_note(preserved)
+    rich.print(f"[green]✓[/green]  Written [dim]{path}[/dim]{note}")
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Uninstall
 # ---------------------------------------------------------------------------
@@ -341,13 +384,20 @@ def _run_uninstall(args) -> None:
     rich.print()
 
     # Detect the installed command to extract push key + tenant for revocation
-    info = _detect_claude_install(config_path) if client == "claude" else _detect_cursor_install(config_path)
+    if client == "claude":
+        info = _detect_claude_install(config_path)
+    elif client == "cursor":
+        info = _detect_cursor_install(config_path)
+    else:  # codex
+        info = _detect_codex_install(config_path)
 
     # Remove hooks from config
     if client == "claude":
         _uninstall_claude(config_path)
     elif client == "cursor":
         _uninstall_cursor(config_path)
+    elif client == "codex":
+        _uninstall_codex(config_path)
 
     # Remove hook script
     _remove_hook_script(client, config_path)
@@ -404,6 +454,33 @@ def _uninstall_claude(path: Path) -> None:
     rich.print(f"[green]\u2713[/green]  Removed {removed} Agent Guard hook(s){_preserved_note(total_after)}")
 
 
+def _uninstall_codex(path: Path) -> None:
+    """Codex uses the Claude-shaped hooks.json, so reuse the Claude filter."""
+    if not path.exists():
+        rich.print("[dim]No hooks.json found. Nothing to uninstall.[/dim]")
+        return
+
+    data = _read_json_or_empty(path)
+    hooks = data.get("hooks", {})
+
+    total_before = sum(len(groups) for groups in hooks.values())
+    filtered = _filter_claude_hooks(hooks)
+    total_after = sum(len(groups) for groups in filtered.values())
+
+    removed = total_before - total_after
+    if removed == 0:
+        rich.print("[dim]No Agent Guard hooks found.[/dim]")
+        return
+
+    _backup_file(path)
+    if filtered:
+        data["hooks"] = filtered
+    else:
+        data.pop("hooks", None)
+    _write_json(path, data)
+    rich.print(f"[green]✓[/green]  Removed {removed} Agent Guard hook(s){_preserved_note(total_after)}")
+
+
 def _uninstall_cursor(path: Path) -> None:
     if not path.exists():
         rich.print("[dim]No hooks.json found. Nothing to uninstall.[/dim]")
@@ -438,6 +515,8 @@ def _run_status() -> None:
     rich.print()
     _print_client_status("Cursor", CURSOR_HOOKS_PATH, _detect_cursor_install())
     rich.print()
+    _print_client_status("Codex", CODEX_HOOKS_PATH, _detect_codex_install())
+    rich.print()
 
     rich.print("[bold]Managed hooks:[/bold]")
     claude_managed_info: dict | str | None
@@ -453,6 +532,13 @@ def _run_status() -> None:
     except PermissionError:
         cursor_managed_info = _PERMISSION_DENIED
     _print_client_status("Cursor", CURSOR_MANAGED_HOOKS_PATH, cursor_managed_info)
+    rich.print()
+    codex_managed_info: dict | str | None
+    try:
+        codex_managed_info = _detect_codex_install(CODEX_MANAGED_HOOKS_PATH)
+    except PermissionError:
+        codex_managed_info = _PERMISSION_DENIED
+    _print_client_status("Codex", CODEX_MANAGED_HOOKS_PATH, codex_managed_info)
     rich.print()
 
     rich.print("[dim]# interactive flow (user-level)[/dim]")
@@ -513,6 +599,31 @@ def _detect_claude_install(path: Path = CLAUDE_SETTINGS_PATH) -> dict | None:
     return _parse_command_info(found_cmd, events)
 
 
+def _detect_codex_install(path: Path = CODEX_HOOKS_PATH) -> dict | None:
+    if not path.exists():
+        return None
+    data = _read_json_or_empty(path)
+    hooks = data.get("hooks", {})
+
+    events = []
+    found_cmd = None
+    for event in CODEX_HOOK_EVENTS:
+        for group in hooks.get(event, []):
+            for h in group.get("hooks", []):
+                if _is_agent_scan_command(h.get("command", "")):
+                    events.append(event)
+                    if found_cmd is None:
+                        found_cmd = h["command"]
+                    break
+            else:
+                continue
+            break
+
+    if not events or found_cmd is None:
+        return None
+    return _parse_command_info(found_cmd, events)
+
+
 def _detect_cursor_install(path: Path = CURSOR_HOOKS_PATH) -> dict | None:
     if not path.exists():
         return None
@@ -543,7 +654,7 @@ def _send_test_event(push_key: str, url: str, hook_client: str, script_path: Pat
     """Send a test hooksConfigured event by invoking the hook script. Returns True on success."""
     import subprocess
 
-    if hook_client == "claude-code":
+    if hook_client == "claude-code" or hook_client == "codex":
         payload = '{"hook_event_name":"hooksConfigured","session_id":"hooks-setup"}'
     else:
         payload = '{"hook_event_name":"hooksConfigured","conversation_id":"hooks-setup"}'
@@ -689,8 +800,17 @@ def _extract_env_from_cmd(cmd: str, key: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+_CLIENT_LABELS = {"claude": "Claude Code", "cursor": "Cursor", "codex": "Codex"}
+_HOOK_CLIENT_NAMES = {"claude": "claude-code", "cursor": "cursor", "codex": "codex"}
+
+
 def _client_label(client: str) -> str:
-    return "Claude Code" if client == "claude" else "Cursor"
+    return _CLIENT_LABELS.get(client, client)
+
+
+def _hook_client_name(client: str) -> str:
+    """Endpoint slug used on the agent-monitor side (and --client in the hook script)."""
+    return _HOOK_CLIENT_NAMES.get(client, client)
 
 
 def _config_path(client: str, override: str | None = None, managed: bool = False) -> Path:
@@ -698,8 +818,16 @@ def _config_path(client: str, override: str | None = None, managed: bool = False
     if override:
         return Path(override)
     if managed:
-        return CLAUDE_MANAGED_SETTINGS_PATH if client == "claude" else CURSOR_MANAGED_HOOKS_PATH
-    return CLAUDE_SETTINGS_PATH if client == "claude" else CURSOR_HOOKS_PATH
+        if client == "claude":
+            return CLAUDE_MANAGED_SETTINGS_PATH
+        if client == "cursor":
+            return CURSOR_MANAGED_HOOKS_PATH
+        return CODEX_MANAGED_HOOKS_PATH
+    if client == "claude":
+        return CLAUDE_SETTINGS_PATH
+    if client == "cursor":
+        return CURSOR_HOOKS_PATH
+    return CODEX_HOOKS_PATH
 
 
 def _preflight_writable(config_path: Path) -> None:

--- a/src/agent_scan/hooks/snyk-agent-guard.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard.ps1
@@ -1,6 +1,6 @@
 #
 # Thin-client hook handler for forwarding agent hook events to Evo Agent Guard.
-# Supports both Claude Code and Cursor via the -Client argument.
+# Supports Claude Code, Cursor, and Codex via the -Client argument.
 #
 # Usage:
 #   powershell -File snyk-agent-guard.ps1 -Client claude-code -PushKey '...' -RemoteUrl 'https://...'
@@ -11,7 +11,7 @@
 #
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("claude-code","cursor")]
+    [ValidateSet("claude-code","cursor","codex")]
     [string]$Client,
 
     [Parameter(Mandatory=$false)]
@@ -52,6 +52,9 @@ switch ($Client) {
     }
     "cursor" {
         $endpoint = "/hidden/agent-monitor/hooks/cursor"
+    }
+    "codex" {
+        $endpoint = "/hidden/agent-monitor/hooks/codex"
     }
 }
 

--- a/src/agent_scan/hooks/snyk-agent-guard.sh
+++ b/src/agent_scan/hooks/snyk-agent-guard.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #
 # Thin-client hook handler for forwarding agent hook events to Evo Agent Guard.
-# Supports both Claude Code and Cursor via the --client argument.
+# Supports Claude Code, Cursor, and Codex via the --client argument.
 #
 # Usage:
 #   PUSH_KEY='...' REMOTE_HOOKS_BASE_URL='...' bash snyk-agent-guard.sh --client claude-code
 #   PUSH_KEY='...' REMOTE_HOOKS_BASE_URL='...' bash snyk-agent-guard.sh --client cursor
+#   PUSH_KEY='...' REMOTE_HOOKS_BASE_URL='...' bash snyk-agent-guard.sh --client codex
 #
 # Reads a JSON payload from stdin and POSTs it (base64-encoded) to the Agent Guard endpoint.
 #
@@ -99,7 +100,11 @@ hook_main() {
       endpoint="/hidden/agent-monitor/hooks/cursor"
       user_agent="snyk/snyk-agent-guard.sh Agent Scan v${AGENT_SCAN_VERSION}"
       ;;
-    *) die "Unknown client: ${client}. Expected claude-code or cursor." ;;
+    codex)
+      endpoint="/hidden/agent-monitor/hooks/codex"
+      user_agent="snyk/snyk-agent-guard.sh Agent Scan v${AGENT_SCAN_VERSION}"
+      ;;
+    *) die "Unknown client: ${client}. Expected claude-code, cursor, or codex." ;;
   esac
 
   local url="${REMOTE_HOOKS_BASE_URL}${endpoint}?version=${VERSION}"

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -21,6 +21,9 @@ from agent_scan.guard import (
     CLAUDE_HOOK_EVENTS,
     CLAUDE_MANAGED_SETTINGS_PATH,
     CLAUDE_SETTINGS_PATH,
+    CODEX_HOOK_EVENTS,
+    CODEX_HOOKS_PATH,
+    CODEX_MANAGED_HOOKS_PATH,
     CURSOR_HOOK_EVENTS,
     CURSOR_HOOKS_PATH,
     CURSOR_MANAGED_HOOKS_PATH,
@@ -29,12 +32,14 @@ from agent_scan.guard import (
     _compact_events,
     _config_path,
     _detect_claude_install,
+    _detect_codex_install,
     _detect_cursor_install,
     _ensure_guard_enabled_for_tenant,
     _extract_env_from_cmd,
     _filter_claude_hooks,
     _filter_cursor_hooks,
     _install_claude,
+    _install_codex,
     _install_cursor,
     _is_agent_scan_command,
     _mask_key,
@@ -44,6 +49,7 @@ from agent_scan.guard import (
     _run_install,
     _shell_quote,
     _uninstall_claude,
+    _uninstall_codex,
     _uninstall_cursor,
 )
 from agent_scan.pushkeys import GuardEnabledAccessDeniedError
@@ -1057,11 +1063,17 @@ class TestConfigPath:
     def test_cursor_user_default(self):
         assert _config_path("cursor") == CURSOR_HOOKS_PATH
 
+    def test_codex_user_default(self):
+        assert _config_path("codex") == CODEX_HOOKS_PATH
+
     def test_claude_managed(self):
         assert _config_path("claude", managed=True) == CLAUDE_MANAGED_SETTINGS_PATH
 
     def test_cursor_managed(self):
         assert _config_path("cursor", managed=True) == CURSOR_MANAGED_HOOKS_PATH
+
+    def test_codex_managed(self):
+        assert _config_path("codex", managed=True) == CODEX_MANAGED_HOOKS_PATH
 
     def test_file_override_takes_precedence_over_managed(self):
         override = "/custom/path/settings.json"
@@ -1079,11 +1091,17 @@ class TestManagedPathConstants:
     def test_cursor_managed_path_is_absolute(self):
         assert CURSOR_MANAGED_HOOKS_PATH.is_absolute()
 
+    def test_codex_managed_path_is_absolute(self):
+        assert CODEX_MANAGED_HOOKS_PATH.is_absolute()
+
     def test_claude_managed_filename(self):
         assert CLAUDE_MANAGED_SETTINGS_PATH.name == "managed-settings.json"
 
     def test_cursor_managed_filename(self):
         assert CURSOR_MANAGED_HOOKS_PATH.name == "hooks.json"
+
+    def test_codex_managed_filename(self):
+        assert CODEX_MANAGED_HOOKS_PATH.name == "hooks.json"
 
     @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific paths")
     def test_macos_claude_managed_path(self):
@@ -1297,6 +1315,140 @@ def _get_script_path(name: str) -> Path:
 IS_WINDOWS = sys.platform == "win32"
 
 
+# ===================================================================
+# Codex: install / uninstall / detect
+# ===================================================================
+
+
+CODEX_AGENT_SCAN_CMD = (
+    "PUSH_KEY='pk-codex' REMOTE_HOOKS_BASE_URL='https://api.snyk.io' "
+    "TENANT_ID='tid-1' bash '/home/u/.codex/hooks/snyk-agent-guard.sh' --client codex"
+)
+
+
+class TestInstallCodex:
+    def test_creates_file_when_missing(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _install_codex(CODEX_AGENT_SCAN_CMD, path)
+
+        data = json.loads(path.read_text())
+        hooks = data["hooks"]
+        assert set(hooks.keys()) == set(CODEX_HOOK_EVENTS)
+        for event in CODEX_HOOK_EVENTS:
+            groups = hooks[event]
+            assert len(groups) == 1
+            assert groups[0]["hooks"][0]["command"] == CODEX_AGENT_SCAN_CMD
+            # No matcher field — omitting matches every occurrence per Codex docs.
+            assert "matcher" not in groups[0]
+
+    def test_preserves_other_hooks(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _write(
+            path,
+            {
+                "hooks": {
+                    "PreToolUse": [_claude_group(OTHER_CMD)],
+                    "Stop": [_claude_group(OTHER_CMD)],
+                }
+            },
+        )
+        _install_codex(CODEX_AGENT_SCAN_CMD, path)
+
+        data = json.loads(path.read_text())
+        groups = data["hooks"]["PreToolUse"]
+        assert len(groups) == 2
+        assert groups[0]["hooks"][0]["command"] == OTHER_CMD
+        assert groups[1]["hooks"][0]["command"] == CODEX_AGENT_SCAN_CMD
+
+    def test_replaces_old_agent_scan_hooks(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        old_cmd = CODEX_AGENT_SCAN_CMD.replace("pk-codex", "pk-old")
+        _write(path, {"hooks": {"PreToolUse": [_claude_group(old_cmd)], "Stop": [_claude_group(old_cmd)]}})
+        new_cmd = CODEX_AGENT_SCAN_CMD.replace("pk-codex", "pk-new")
+        _install_codex(new_cmd, path)
+
+        data = json.loads(path.read_text())
+        for event in CODEX_HOOK_EVENTS:
+            groups = data["hooks"][event]
+            assert len(groups) == 1
+            assert groups[0]["hooks"][0]["command"] == new_cmd
+
+    def test_idempotent_no_rewrite(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _install_codex(CODEX_AGENT_SCAN_CMD, path)
+        mtime1 = path.stat().st_mtime_ns
+        _install_codex(CODEX_AGENT_SCAN_CMD, path)
+        assert path.stat().st_mtime_ns == mtime1
+
+
+class TestUninstallCodex:
+    def test_missing_file(self, tmp_path):
+        _uninstall_codex(tmp_path / "hooks.json")  # should not raise
+
+    def test_removes_only_agent_scan(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _write(
+            path,
+            {
+                "hooks": {
+                    "PreToolUse": [_claude_group(OTHER_CMD), _claude_group(CODEX_AGENT_SCAN_CMD)],
+                    "Stop": [_claude_group(CODEX_AGENT_SCAN_CMD)],
+                }
+            },
+        )
+        _uninstall_codex(path)
+
+        data = json.loads(path.read_text())
+        assert len(data["hooks"]["PreToolUse"]) == 1
+        assert data["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == OTHER_CMD
+        assert "Stop" not in data["hooks"]
+
+    def test_removes_hooks_key_when_empty(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _write(path, {"hooks": {"PreToolUse": [_claude_group(CODEX_AGENT_SCAN_CMD)]}})
+        _uninstall_codex(path)
+
+        data = json.loads(path.read_text())
+        assert "hooks" not in data
+
+    def test_full_install_then_uninstall(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _write(path, {"unrelated": True})
+        _install_codex(CODEX_AGENT_SCAN_CMD, path)
+        _uninstall_codex(path)
+
+        data = json.loads(path.read_text())
+        assert "hooks" not in data
+        assert data["unrelated"] is True
+
+
+class TestDetectCodex:
+    def test_missing_file(self, tmp_path):
+        assert _detect_codex_install(tmp_path / "nope.json") is None
+
+    def test_no_hooks_key(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _write(path, {"other": 1})
+        assert _detect_codex_install(path) is None
+
+    def test_no_agent_scan_hooks(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _write(path, {"hooks": {"PreToolUse": [_claude_group(OTHER_CMD)]}})
+        assert _detect_codex_install(path) is None
+
+    def test_detects_after_install(self, tmp_path):
+        path = tmp_path / "hooks.json"
+        _install_codex(CODEX_AGENT_SCAN_CMD, path)
+
+        info = _detect_codex_install(path)
+        assert info is not None
+        assert info["auth_type"] == "pushkey"
+        assert info["auth_value"] == "pk-codex"
+        assert info["tenant_id"] == "tid-1"
+        assert info["host"] == "api.snyk.io"
+        assert set(info["events"]) == set(CODEX_HOOK_EVENTS)
+
+
 @pytest.mark.skipif(IS_WINDOWS, reason="bash script; skipped on Windows")
 class TestBashHookScript:
     """Integration: invoke the real .sh script against a local HTTP server."""
@@ -1348,6 +1500,24 @@ class TestBashHookScript:
         )
         assert result.returncode == 0, result.stderr
         assert "/hidden/agent-monitor/hooks/cursor" in _HookHandler.last_request["path"]
+
+    def test_codex_endpoint(self, hook_server):
+        script = _get_script_path("snyk-agent-guard.sh")
+        payload = '{"hook_event_name":"hooksConfigured","session_id":"s1"}'
+        result = subprocess.run(
+            ["bash", str(script), "--client", "codex"],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "PUSH_KEY": "test-pk-codex",
+                "REMOTE_HOOKS_BASE_URL": hook_server,
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert "/hidden/agent-monitor/hooks/codex" in _HookHandler.last_request["path"]
 
     def test_missing_push_key_fails(self, hook_server):
         script = _get_script_path("snyk-agent-guard.sh")

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -1101,7 +1101,7 @@ class TestManagedPathConstants:
         assert CURSOR_MANAGED_HOOKS_PATH.name == "hooks.json"
 
     def test_codex_managed_filename(self):
-        assert CODEX_MANAGED_HOOKS_PATH.name == "hooks.json"
+        assert CODEX_MANAGED_HOOKS_PATH.name == "requirements.toml"
 
     @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific paths")
     def test_macos_claude_managed_path(self):
@@ -1128,6 +1128,15 @@ class TestManagedPathConstants:
     def test_windows_cursor_managed_path(self):
         assert "Cursor" in str(CURSOR_MANAGED_HOOKS_PATH)
         assert "hooks.json" in str(CURSOR_MANAGED_HOOKS_PATH)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix-specific path")
+    def test_unix_codex_managed_path(self):
+        assert str(CODEX_MANAGED_HOOKS_PATH) == "/etc/codex/requirements.toml"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific paths")
+    def test_windows_codex_managed_path(self):
+        assert "Codex" in str(CODEX_MANAGED_HOOKS_PATH)
+        assert "requirements.toml" in str(CODEX_MANAGED_HOOKS_PATH)
 
 
 class TestManagedInstallClaude:
@@ -1447,6 +1456,93 @@ class TestDetectCodex:
         assert info["tenant_id"] == "tid-1"
         assert info["host"] == "api.snyk.io"
         assert set(info["events"]) == set(CODEX_HOOK_EVENTS)
+
+
+# ===================================================================
+# Codex managed: requirements.toml install / uninstall / detect
+# ===================================================================
+
+
+class TestCodexManagedRequirementsToml:
+    def _import_managed_helpers(self):
+        from agent_scan.guard import (
+            _detect_codex_managed_install,
+            _install_codex_managed,
+            _render_codex_requirements_toml,
+            _uninstall_codex_managed,
+        )
+
+        return (
+            _install_codex_managed,
+            _uninstall_codex_managed,
+            _detect_codex_managed_install,
+            _render_codex_requirements_toml,
+        )
+
+    def test_render_contains_features_and_all_events(self, tmp_path):
+        _, _, _, render = self._import_managed_helpers()
+        path = tmp_path / "requirements.toml"
+        content = render(CODEX_AGENT_SCAN_CMD, path)
+        assert "[features]" in content
+        assert "hooks = true" in content
+        assert "[hooks]" in content
+        assert "managed_dir" in content
+        assert "windows_managed_dir" in content
+        for event in CODEX_HOOK_EVENTS:
+            assert f"[[hooks.{event}]]" in content
+            assert f"[[hooks.{event}.hooks]]" in content
+
+    def test_install_writes_toml(self, tmp_path):
+        install, _, _, _ = self._import_managed_helpers()
+        path = tmp_path / "requirements.toml"
+        script = tmp_path / "hooks" / "snyk-agent-guard.sh"
+        changed = install(CODEX_AGENT_SCAN_CMD, path, script)
+        assert changed
+        text = path.read_text()
+        assert "PUSH_KEY" in text
+        assert CODEX_AGENT_SCAN_CMD in text
+
+    def test_install_idempotent(self, tmp_path):
+        install, _, _, _ = self._import_managed_helpers()
+        path = tmp_path / "requirements.toml"
+        script = tmp_path / "hooks" / "snyk-agent-guard.sh"
+        install(CODEX_AGENT_SCAN_CMD, path, script)
+        assert install(CODEX_AGENT_SCAN_CMD, path, script) is False
+
+    def test_detect_after_install(self, tmp_path):
+        install, _, detect, _ = self._import_managed_helpers()
+        path = tmp_path / "requirements.toml"
+        script = tmp_path / "hooks" / "snyk-agent-guard.sh"
+        install(CODEX_AGENT_SCAN_CMD, path, script)
+
+        info = detect(path)
+        assert info is not None
+        assert info["auth_value"] == "pk-codex"
+        assert info["tenant_id"] == "tid-1"
+        assert set(info["events"]) == set(CODEX_HOOK_EVENTS)
+
+    def test_detect_dispatches_via_extension(self, tmp_path):
+        install, _, _, _ = self._import_managed_helpers()
+        path = tmp_path / "requirements.toml"
+        script = tmp_path / "hooks" / "snyk-agent-guard.sh"
+        install(CODEX_AGENT_SCAN_CMD, path, script)
+
+        info = _detect_codex_install(path)
+        assert info is not None
+        assert info["auth_value"] == "pk-codex"
+
+    def test_uninstall_removes_file(self, tmp_path):
+        install, uninstall, _, _ = self._import_managed_helpers()
+        path = tmp_path / "requirements.toml"
+        script = tmp_path / "hooks" / "snyk-agent-guard.sh"
+        install(CODEX_AGENT_SCAN_CMD, path, script)
+        assert path.exists()
+        uninstall(path)
+        assert not path.exists()
+
+    def test_uninstall_missing_file_is_noop(self, tmp_path):
+        _, uninstall, _, _ = self._import_managed_helpers()
+        uninstall(tmp_path / "requirements.toml")  # should not raise
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="bash script; skipped on Windows")


### PR DESCRIPTION
## Summary
- Adds \`codex\` as a third \`guard install/uninstall\` client alongside \`claude\` and \`cursor\`.
- Writes \`~/.codex/hooks.json\` (Codex uses the same Claude-shaped \`hooks.json\` schema: event → matcher groups → command hooks) with one entry per supported event: \`PreToolUse\`, \`PermissionRequest\`, \`PostToolUse\`, \`UserPromptSubmit\`, \`Stop\`, \`SessionStart\`.
- Bundles managed-config paths (\`/Library/Application Support/Codex/hooks.json\`, etc.) for the \`--managed\` flow.
- Extends \`snyk-agent-guard.sh\` / \`.ps1\` to route \`--client codex\` to \`/hidden/agent-monitor/hooks/codex\`.
- Status output (\`snyk-agent-scan guard\`) now lists Codex alongside Claude Code and Cursor.