### PR TITLE
Add GitHub code scanning SARIF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,19 @@ These options are available for all commands:
 --verbose              Enable detailed logging output
 --print-errors         Show error details and tracebacks
 --json                 Output results in JSON format instead of rich text
+--sarif                Output results in SARIF 2.1.0 format for GitHub code scanning
+--sarif-output FILE    Write SARIF 2.1.0 results to a file for GitHub code scanning upload
 ```
+
+### GitHub Advanced Security
+
+Agent Scan can emit SARIF for GitHub Advanced Security code scanning:
+
+```bash
+uvx snyk-agent-scan@latest scan --sarif-output agent-scan.sarif
+```
+
+Upload the generated SARIF with `github/codeql-action/upload-sarif`. See [GitHub Advanced Security code scanning](docs/github-advanced-security.md) for a complete workflow.
 
 ### Commands
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,4 @@ This is the documentation for [Agent Scan](https://github.com/snyk/agent-scan). 
 
 - **[Scanning](scanning.md)** — How scanning works, CLI parameters, and usage examples.
 - **[Issue Codes](issue-codes.md)** — Reference for all security issues, warnings, toxic flows, and system codes detected by Agent Scan.
+- **[GitHub Advanced Security](github-advanced-security.md)** — Emit SARIF and upload Agent Scan findings to GitHub code scanning.

--- a/docs/github-advanced-security.md
+++ b/docs/github-advanced-security.md
@@ -1,0 +1,67 @@
+# GitHub Advanced Security code scanning
+
+Agent Scan can emit SARIF 2.1.0 so findings appear in GitHub Advanced Security code scanning alerts.
+
+## Command line
+
+Write SARIF to a file:
+
+```bash
+uvx snyk-agent-scan@latest scan --sarif-output agent-scan.sarif
+```
+
+Write SARIF to stdout:
+
+```bash
+uvx snyk-agent-scan@latest scan --sarif
+```
+
+For CI, combine SARIF with `--ci` so the job fails when Agent Scan finds unignored issues or runtime failures. Because CI cannot answer MCP consent prompts, CI scans that start stdio MCP servers must also opt in with `--dangerously-run-mcp-servers`.
+
+```bash
+uvx snyk-agent-scan@latest scan \
+  --ci \
+  --dangerously-run-mcp-servers \
+  --sarif-output agent-scan.sarif
+```
+
+## GitHub Actions workflow
+
+```yaml
+name: Agent Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  agent-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Run Agent Scan
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          uvx snyk-agent-scan@latest scan \
+            --ci \
+            --dangerously-run-mcp-servers \
+            --sarif-output agent-scan.sarif
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: agent-scan.sarif
+```
+
+Use `--ignore-issues-codes W003,W004` with `--ci` if your organization intentionally suppresses specific Agent Scan issue codes. Ignored issues are removed before the SARIF file is written.

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import logging
 import sys
+from pathlib import Path
 
 import psutil
 import rich
@@ -34,6 +35,7 @@ from agent_scan.pipelines import (
     inspect_pipeline,
 )
 from agent_scan.printer import print_scan_result
+from agent_scan.sarif import scan_results_to_sarif
 from agent_scan.upload import get_hostname
 from agent_scan.utils import ensure_unicode_console, get_push_key, parse_headers, suppress_stdout
 from agent_scan.version import version_info
@@ -197,6 +199,19 @@ def add_common_arguments(parser):
         action="store_true",
         default=False,
         help="Output results in JSON format instead of rich text",
+    )
+    parser.add_argument(
+        "--sarif",
+        action="store_true",
+        default=False,
+        help="Output results in SARIF 2.1.0 format for GitHub code scanning",
+    )
+    parser.add_argument(
+        "--sarif-output",
+        type=str,
+        default=None,
+        metavar="FILE",
+        help="Write SARIF 2.1.0 results to a file for GitHub code scanning upload",
     )
     parser.add_argument(
         "--skip-ssl-verify",
@@ -370,6 +385,7 @@ def main():
             f"  {program_name} --verbose           # Enable detailed logging output\n"
             f"  {program_name} --print-errors      # Show error details and tracebacks\n"
             f"  {program_name} --json              # Output results in JSON format\n"
+            f"  {program_name} --sarif-output agent-scan.sarif # Write SARIF for GitHub code scanning\n"
             f"  {program_name} --ci                # With --ci, exit with a non-zero code when there are analysis findings or runtime failures\n\n"
             f"  # Multiple control servers with individual options:\n"
             f'  {program_name} --control-server https://server1.com --control-server-H "Auth: token1" \\\n'
@@ -735,6 +751,12 @@ def _apply_ignore_codes(result: list[ScanPathResult], ignore_codes: set[str]) ->
         scan_result.issues = [i for i in scan_result.issues if i.code not in ignore_codes]
 
 
+def _validate_output_args(json_output: bool, sarif_stdout: bool) -> None:
+    if json_output and sarif_stdout:
+        rich.print("[bold red]Error: --json and --sarif cannot both write to stdout.[/bold red]", file=sys.stderr)
+        sys.exit(2)
+
+
 def _handle_ci_exit(result: list[ScanPathResult], json_output: bool, ignore_codes: set[str]) -> None:
     """In CI mode, exit with code 1 if any issues or unignored failures remain."""
     has_issues = any(scan_result.issues for scan_result in result)
@@ -755,13 +777,16 @@ def _handle_ci_exit(result: list[ScanPathResult], json_output: bool, ignore_code
 
 async def print_scan_inspect(mode="scan", args=None):
     json_output: bool = hasattr(args, "json") and args.json
+    sarif_stdout: bool = hasattr(args, "sarif") and args.sarif
+    sarif_output_path: str | None = getattr(args, "sarif_output", None)
     print_errors: bool = hasattr(args, "print_errors") and args.print_errors
     full_description: bool = hasattr(args, "print_full_descriptions") and args.print_full_descriptions
     verbose: bool = hasattr(args, "verbose") and args.verbose
     ci_mode: bool = hasattr(args, "ci") and args.ci
+    _validate_output_args(json_output, sarif_stdout)
     ignore_codes = _parse_ignore_codes(args, ci_mode)
 
-    if json_output:
+    if json_output or sarif_stdout:
         with suppress_stdout():
             result = await run_scan(args, mode=mode)
     else:
@@ -773,6 +798,8 @@ async def print_scan_inspect(mode="scan", args=None):
     if json_output:
         result_dict = {r.path: r.model_dump(mode="json") for r in result}
         print(json.dumps(result_dict, indent=2))
+    elif sarif_stdout:
+        print(json.dumps(scan_results_to_sarif(result), indent=2))
     else:
         print_scan_result(
             result,
@@ -782,6 +809,10 @@ async def print_scan_inspect(mode="scan", args=None):
             full_description=full_description,
             args=args,
         )
+
+    if sarif_output_path:
+        sarif_text = json.dumps(scan_results_to_sarif(result), indent=2)
+        Path(sarif_output_path).write_text(sarif_text + "\n", encoding="utf-8")
 
     if ci_mode:
         _handle_ci_exit(result, json_output, ignore_codes)

--- a/src/agent_scan/sarif.py
+++ b/src/agent_scan/sarif.py
@@ -1,0 +1,200 @@
+import hashlib
+import os
+from pathlib import Path
+from typing import Any
+
+from agent_scan.models import FAILURE_CATEGORY_TO_CODE, Issue, ScanError, ScanPathResult, ServerScanResult
+from agent_scan.version import version_info
+
+
+def scan_results_to_sarif(results: list[ScanPathResult], base_dir: str | Path | None = None) -> dict[str, Any]:
+    """Convert Agent Scan results to SARIF 2.1.0 for GitHub code scanning."""
+    rules: dict[str, dict[str, Any]] = {}
+    sarif_results: list[dict[str, Any]] = []
+    root = Path(base_dir or os.getcwd()).resolve()
+
+    for scan_result in results:
+        for issue in scan_result.issues:
+            rule = _rule_for_issue(issue)
+            rules[rule["id"]] = rule
+            sarif_results.append(_result_for_issue(scan_result, issue, root))
+
+        if scan_result.error:
+            rule = _rule_for_error(scan_result.error)
+            rules[rule["id"]] = rule
+            sarif_results.append(_result_for_path_error(scan_result, scan_result.error, root))
+
+        for server_index, server in enumerate(scan_result.servers or []):
+            if server.error:
+                rule = _rule_for_error(server.error)
+                rules[rule["id"]] = rule
+                sarif_results.append(_result_for_server_error(scan_result, server, server_index, server.error, root))
+
+    return {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "Snyk Agent Scan",
+                        "semanticVersion": version_info,
+                        "informationUri": "https://github.com/snyk/agent-scan",
+                        "rules": sorted(rules.values(), key=lambda rule: rule["id"]),
+                    }
+                },
+                "results": sarif_results,
+            }
+        ],
+    }
+
+
+def _rule_for_issue(issue: Issue) -> dict[str, Any]:
+    return {
+        "id": issue.code,
+        "name": issue.code,
+        "shortDescription": {"text": _rule_title(issue.code)},
+        "fullDescription": {"text": issue.message},
+        "helpUri": f"https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md#{issue.code.lower()}",
+        "properties": {
+            "tags": ["security", "agent-scan", "ai-agent"],
+            "precision": "medium",
+            "security-severity": _security_severity(issue.code),
+        },
+    }
+
+
+def _rule_for_error(error: ScanError) -> dict[str, Any]:
+    code = FAILURE_CATEGORY_TO_CODE.get(error.category, FAILURE_CATEGORY_TO_CODE[None])
+    return {
+        "id": code,
+        "name": code,
+        "shortDescription": {"text": _rule_title(code)},
+        "fullDescription": {"text": error.text or "Agent Scan runtime error"},
+        "helpUri": "https://github.com/snyk/agent-scan/blob/main/docs/json-output.md#1-checking-for-execution-failures",
+        "properties": {
+            "tags": ["security", "agent-scan", "runtime"],
+            "precision": "medium",
+            "security-severity": "6.0" if error.is_failure else "3.0",
+        },
+    }
+
+
+def _result_for_issue(scan_result: ScanPathResult, issue: Issue, root: Path) -> dict[str, Any]:
+    server_name, entity_name = _referenced_names(scan_result, issue.reference)
+    message_parts = [f"[{issue.code}] {issue.message}"]
+    if server_name:
+        message_parts.append(f"Server: {server_name}")
+    if entity_name:
+        message_parts.append(f"Component: {entity_name}")
+
+    return {
+        "ruleId": issue.code,
+        "level": _level_for_code(issue.code),
+        "message": {"text": " ".join(message_parts)},
+        "locations": [_location(scan_result.path, root)],
+        "partialFingerprints": {
+            "agentScanIssue": _fingerprint(scan_result.path, issue.code, issue.message, issue.reference, server_name, entity_name)
+        },
+        "properties": {
+            "reference": list(issue.reference) if issue.reference is not None else None,
+            "extraData": issue.extra_data,
+        },
+    }
+
+
+def _result_for_path_error(scan_result: ScanPathResult, error: ScanError, root: Path) -> dict[str, Any]:
+    code = FAILURE_CATEGORY_TO_CODE.get(error.category, FAILURE_CATEGORY_TO_CODE[None])
+    return {
+        "ruleId": code,
+        "level": "error" if error.is_failure else "note",
+        "message": {"text": f"[{code}] Failed to scan {scan_result.path}: {error.text}"},
+        "locations": [_location(scan_result.path, root)],
+        "partialFingerprints": {"agentScanIssue": _fingerprint(scan_result.path, code, error.text)},
+    }
+
+
+def _result_for_server_error(
+    scan_result: ScanPathResult,
+    server: ServerScanResult,
+    server_index: int,
+    error: ScanError,
+    root: Path,
+) -> dict[str, Any]:
+    code = FAILURE_CATEGORY_TO_CODE.get(error.category, FAILURE_CATEGORY_TO_CODE[None])
+    server_name = server.name or f"server[{server_index}]"
+    return {
+        "ruleId": code,
+        "level": "error" if error.is_failure else "note",
+        "message": {"text": f"[{code}] Failed to scan {server_name} in {scan_result.path}: {error.text}"},
+        "locations": [_location(scan_result.path, root)],
+        "partialFingerprints": {"agentScanIssue": _fingerprint(scan_result.path, code, error.text, server_index, server_name)},
+        "properties": {"reference": [server_index, None]},
+    }
+
+
+def _location(path: str, root: Path) -> dict[str, Any]:
+    return {
+        "physicalLocation": {
+            "artifactLocation": {
+                "uri": _artifact_uri(path, root),
+            },
+            "region": {"startLine": 1},
+        }
+    }
+
+
+def _artifact_uri(path: str, root: Path) -> str:
+    artifact_path = Path(path).expanduser()
+    try:
+        resolved = artifact_path.resolve()
+        relative = resolved.relative_to(root)
+        return relative.as_posix()
+    except (OSError, ValueError):
+        return artifact_path.as_posix()
+
+
+def _referenced_names(scan_result: ScanPathResult, reference: tuple[int, int | None] | None) -> tuple[str | None, str | None]:
+    if reference is None or scan_result.servers is None:
+        return None, None
+
+    server_index, entity_index = reference
+    if server_index < 0 or server_index >= len(scan_result.servers):
+        return None, None
+
+    server = scan_result.servers[server_index]
+    server_name = server.name
+    if entity_index is None:
+        return server_name, None
+    if entity_index < 0 or entity_index >= len(server.entities):
+        return server_name, None
+    return server_name, getattr(server.entities[entity_index], "name", None)
+
+
+def _level_for_code(code: str) -> str:
+    if code.startswith("E"):
+        return "error"
+    if code.startswith("W"):
+        return "warning"
+    return "note"
+
+
+def _security_severity(code: str) -> str:
+    if code.startswith("E"):
+        return "8.0"
+    if code.startswith("W"):
+        return "5.0"
+    return "3.0"
+
+
+def _rule_title(code: str) -> str:
+    if code.startswith("E"):
+        return "Agent security error"
+    if code.startswith("W"):
+        return "Agent security warning"
+    return "Agent Scan runtime or analysis notice"
+
+
+def _fingerprint(*parts: object) -> str:
+    text = "\x1f".join("" if part is None else str(part) for part in parts)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -621,6 +621,99 @@ class TestJSONOutput:
             assert isinstance(parsed, dict)
 
 
+class TestSarifOutput:
+    """Test suite for SARIF output functionality."""
+
+    @pytest.mark.asyncio
+    async def test_sarif_output_only_contains_sarif(self):
+        """Test that SARIF stdout mode suppresses scan-time stdout."""
+        import io
+        import json
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path.json",
+            issues=[Issue(code="W001", message="warning", reference=None)],
+        )
+
+        async def mock_run_scan_with_print(*args, **kwargs):
+            print("scan progress")
+            return [mock_result]
+
+        with patch("agent_scan.cli.run_scan", side_effect=mock_run_scan_with_print):
+            args = Namespace(
+                json=False,
+                sarif=True,
+                sarif_output=None,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=False,
+            )
+
+            captured_output = io.StringIO()
+            original_stdout = sys.stdout
+
+            try:
+                sys.stdout = captured_output
+                await print_scan_inspect(mode="scan", args=args)
+            finally:
+                sys.stdout = original_stdout
+
+            output = captured_output.getvalue()
+            assert "scan progress" not in output
+            parsed = json.loads(output)
+            assert parsed["version"] == "2.1.0"
+            assert parsed["runs"][0]["results"][0]["ruleId"] == "W001"
+
+    @pytest.mark.asyncio
+    async def test_sarif_output_file_is_written(self, tmp_path):
+        """Test that --sarif-output writes a SARIF file without replacing rich output."""
+        import json
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        sarif_path = tmp_path / "agent-scan.sarif"
+        mock_result = ScanPathResult(
+            path="/test/path.json",
+            issues=[Issue(code="E001", message="error", reference=None)],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=False,
+                sarif=False,
+                sarif_output=str(sarif_path),
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=False,
+            )
+
+            await print_scan_inspect(mode="scan", args=args)
+
+        parsed = json.loads(sarif_path.read_text(encoding="utf-8"))
+        assert parsed["version"] == "2.1.0"
+        assert parsed["runs"][0]["results"][0]["ruleId"] == "E001"
+
+    @pytest.mark.asyncio
+    async def test_json_and_sarif_stdout_conflict_exits_2(self):
+        """--json and --sarif both write machine-readable stdout, so they are mutually exclusive."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        args = Namespace(json=True, sarif=True, sarif_output=None, verbose=False, ci=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            await print_scan_inspect(mode="scan", args=args)
+
+        assert exc_info.value.code == 2
+
+
 class TestIgnoreIssuesCodes:
     """Tests for --ignore-issues-codes filtering."""
 

--- a/tests/unit/test_sarif.py
+++ b/tests/unit/test_sarif.py
@@ -1,0 +1,48 @@
+from agent_scan.models import Issue, RemoteServer, ScanError, ScanPathResult, ServerScanResult
+from agent_scan.sarif import scan_results_to_sarif
+
+
+def test_sarif_includes_issues_and_runtime_failures(tmp_path):
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text("{}", encoding="utf-8")
+    scan_result = ScanPathResult(
+        path=str(config_path),
+        issues=[Issue(code="E001", message="Prompt injection risk", reference=None)],
+        error=ScanError(message="parse failed", is_failure=True, category="parse_error"),
+    )
+
+    sarif = scan_results_to_sarif([scan_result], base_dir=tmp_path)
+
+    assert sarif["version"] == "2.1.0"
+    run = sarif["runs"][0]
+    rule_ids = {rule["id"] for rule in run["tool"]["driver"]["rules"]}
+    assert rule_ids == {"E001", "X005"}
+
+    results = run["results"]
+    assert [result["ruleId"] for result in results] == ["E001", "X005"]
+    assert results[0]["level"] == "error"
+    assert results[0]["locations"][0]["physicalLocation"]["artifactLocation"]["uri"] == "mcp.json"
+    assert results[1]["message"]["text"] == f"[X005] Failed to scan {config_path}: parse failed"
+
+
+def test_sarif_includes_server_failure_reference(tmp_path):
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text("{}", encoding="utf-8")
+    scan_result = ScanPathResult(
+        path=str(config_path),
+        servers=[
+            ServerScanResult(
+                name="github",
+                server=RemoteServer(url="https://example.com/mcp"),
+                error=ScanError(message="startup failed", is_failure=True, category="server_startup"),
+            )
+        ],
+    )
+
+    sarif = scan_results_to_sarif([scan_result], base_dir=tmp_path)
+
+    result = sarif["runs"][0]["results"][0]
+    assert result["ruleId"] == "X001"
+    assert result["level"] == "error"
+    assert result["properties"]["reference"] == [0, None]
+    assert "github" in result["message"]["text"]


### PR DESCRIPTION
## Summary
- add SARIF 2.1.0 conversion for Agent Scan issues and runtime failures
- add --sarif and --sarif-output CLI options for GitHub code scanning upload
- document a GitHub Advanced Security workflow using github/codeql-action/upload-sarif

## Validation
- AGENT_SCAN_ENVIRONMENT=test uv run --extra test -m pytest --runner=uv -x tests/unit/test_sarif.py tests/unit/test_cli_parsing.py::TestSarifOutput
- uv run --extra dev ruff check src/agent_scan/sarif.py src/agent_scan/cli.py tests/unit/test_sarif.py tests/unit/test_cli_parsing.py
- git diff --check

Note: repo-wide ruff currently reports pre-existing issues under tests/skills/docx/ooxml/scripts, outside this change.