### PR TITLE
Probe shim shell deps in bootstrap runtimes

### DIFF
--- a/src/agent_scan/utils.py
+++ b/src/agent_scan/utils.py
@@ -59,17 +59,11 @@ _DEFAULT_PROBED_TOOLS: tuple[str, ...] = (
     "docker",
     # Shell-side dependencies of snyk_mcp_stdio_local_proxy.sh. The shim
     # is bash-only (uses process substitution `>(...)`) and shells out to
-    # shasum/cut/mktemp/tee/grep. Probing them here lets the server gate
-    # the stdio-local-proxy runtime flag on hosts that actually have the
-    # toolchain — and surface missing pieces in telemetry. Note: on BSD
-    # (macOS) `cut`, `mktemp`, and `tee` reject `--version`, so probes
-    # for those will be None there; that's the existing
-    # "probe-didn't-work" signal, not "tool is missing".
+    # shasum/grep. Probing them here lets the server gate the
+    # stdio-local-proxy runtime flag on hosts that actually have the
+    # toolchain — and surface missing pieces in telemetry.
     "bash",
     "shasum",
-    "cut",
-    "mktemp",
-    "tee",
     "grep",
 )
 

--- a/src/agent_scan/utils.py
+++ b/src/agent_scan/utils.py
@@ -51,7 +51,27 @@ _TOOL_VERSION_PROBE_TIMEOUT = 2.0
 # may resolve to a different interpreter than the one running agent-scan
 # if multiple Pythons are on PATH; that's accepted in exchange for treating
 # every runtime uniformly.
-_DEFAULT_PROBED_TOOLS: tuple[str, ...] = ("python", "node", "npx", "uvx", "docker")
+_DEFAULT_PROBED_TOOLS: tuple[str, ...] = (
+    "python",
+    "node",
+    "npx",
+    "uvx",
+    "docker",
+    # Shell-side dependencies of snyk_mcp_stdio_local_proxy.sh. The shim
+    # is bash-only (uses process substitution `>(...)`) and shells out to
+    # shasum/cut/mktemp/tee/grep. Probing them here lets the server gate
+    # the stdio-local-proxy runtime flag on hosts that actually have the
+    # toolchain — and surface missing pieces in telemetry. Note: on BSD
+    # (macOS) `cut`, `mktemp`, and `tee` reject `--version`, so probes
+    # for those will be None there; that's the existing
+    # "probe-didn't-work" signal, not "tool is missing".
+    "bash",
+    "shasum",
+    "cut",
+    "mktemp",
+    "tee",
+    "grep",
+)
 
 # Wall-clock cap for the `Get-CimInstance Win32_UserProfile` query that
 # enumerates Windows user profiles under --scan-all-users. WMI/CIM is known

--- a/tests/unit/test_bootstrap_payload.py
+++ b/tests/unit/test_bootstrap_payload.py
@@ -62,6 +62,17 @@ async def test_payload_runtimes_passes_through_probed_tools_verbatim(monkeypatch
             "npx": "10.2.3",
             "uvx": "0.4.18",
             "docker": None,
+            # Shell-side deps of the stdio-local-proxy shim. bash/shasum/grep
+            # support `--version` on both GNU and BSD; cut/mktemp/tee accept
+            # it on GNU but not on BSD — the BSD-None case is exercised here
+            # via `mktemp` so the payload contract for the shim deps stays
+            # pinned alongside the original runtimes set.
+            "bash": "GNU bash, version 5.2.15",
+            "shasum": "shasum (perl) version 6.04",
+            "cut": "cut (GNU coreutils) 9.4",
+            "mktemp": None,
+            "tee": "tee (GNU coreutils) 9.4",
+            "grep": "grep (GNU grep) 3.11",
         }
 
     monkeypatch.setattr(bootstrap_module, "get_tool_versions", fake_probes)
@@ -76,6 +87,14 @@ async def test_payload_runtimes_passes_through_probed_tools_verbatim(monkeypatch
     # `None` means "we probed and the tool isn't installed" — it must be
     # preserved as an explicit null in the payload, not dropped.
     assert runtimes["docker"] is None
+    # Shim deps: each is reported verbatim, including the BSD-None case
+    # for mktemp (where `--version` is unsupported on BSD/macOS).
+    assert runtimes["bash"] == "GNU bash, version 5.2.15"
+    assert runtimes["shasum"] == "shasum (perl) version 6.04"
+    assert runtimes["cut"] == "cut (GNU coreutils) 9.4"
+    assert runtimes["mktemp"] is None
+    assert runtimes["tee"] == "tee (GNU coreutils) 9.4"
+    assert runtimes["grep"] == "grep (GNU grep) 3.11"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Extends `_DEFAULT_PROBED_TOOLS` in `src/agent_scan/utils.py` with the six shell-side dependencies of `snyk_mcp_stdio_local_proxy.sh`: `bash`, `shasum`, `cut`, `mktemp`, `tee`, `grep`.
- These now ride through the existing `get_tool_versions()` pipeline and land in `HostInfo.runtimes` on every client-bootstrap payload — no new plumbing, no schema change.
- The control server can use the resulting telemetry to gate `enable-stdio-local-proxy` on hosts that actually have the toolchain, and missing pieces become visible in dashboards instead of failing silently at scan time.

## Why these tools
The shim (`src/agent_scan/snyk_mcp_stdio_local_proxy.sh`) is bash-only — it uses process substitution `>(...)` on line 7, which `dash`/`ash`/BusyBox don't support — and shells out to:

| Tool | Use in shim |
|------|-------------|
| `bash` | shebang + `set -eu` + `>(...)` |
| `shasum` | `shasum -a 256` for the per-server log hash (line 4) |
| `cut` | `cut -c1-12` to truncate the hash (line 4) |
| `mktemp` | log file allocation under `/tmp` (line 5) |
| `tee` | duplicates stdout to the log (line 7) |
| `grep` | `grep --line-buffered -E …` filters MCP frames (line 7) |

`printf` / `set` are bash builtins and `env` is the shebang resolver — those don't need probing.

## BSD `--version` caveat
On macOS (BSD coreutils variants), `cut --version`, `mktemp --version`, and `tee --version` exit non-zero, so the probe returns `None` for those. That matches the existing `_probe_tool_version` contract — `None` means "probe didn't work", not "tool is missing" — so no schema change is needed. `bash`, `shasum`, and `grep` all support `--version` on both GNU and BSD and will return a real version line everywhere.

## Test plan
- [x] `uv run pytest tests/unit/test_bootstrap_payload.py tests/unit/test_utils.py` — 49 passed
- [x] `pre-commit run --files src/agent_scan/utils.py tests/unit/test_bootstrap_payload.py` — green (mypy, ruff, ruff-format, …)
- `test_payload_runtimes_passes_through_probed_tools_verbatim` now asserts all six new keys, including a `None` for `mktemp` to pin the BSD case.