### PR TITLE
feat: introduce per-agent discovery ABC, wire in Claude Code

### DIFF
--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -32,10 +32,7 @@ logger = logging.getLogger(__name__)
 
 McpConfigsResult = dict[
     str,
-    list[tuple[str, StdioServer | RemoteServer]]
-    | FileNotFoundConfig
-    | UnknownConfigFormat
-    | CouldNotParseMCPConfig,
+    list[tuple[str, StdioServer | RemoteServer]] | FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig,
 ]
 SkillsDirsResult = dict[str, list[tuple[str, SkillServer]] | FileNotFoundConfig]
 
@@ -45,10 +42,23 @@ class AgentDiscoverer(ABC):
 
     Concrete subclasses encapsulate one agent's filesystem layout: where the
     install lives, which JSON file(s) hold its MCP servers, and which directory
-    holds its skills.
+    holds its skills. Subclasses MUST set the ``name`` class attribute to the
+    canonical agent name used in ``well_known_clients``; this is enforced in
+    ``__init_subclass__``.
+
+    Note: this abstraction intentionally does NOT consult the corresponding
+    ``CandidateClient`` row's ``mcp_config_globs`` / ``skills_dir_globs``
+    fields. Subclasses encode their layout directly. If a future agent
+    genuinely needs glob-based discovery, override ``discover_mcp_servers`` /
+    ``discover_skills`` to handle it explicitly.
     """
 
-    name: str
+    name: str = ""
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if not cls.name:
+            raise TypeError(f"{cls.__name__} must set a non-empty 'name' class attribute")
 
     @abstractmethod
     def client_exists(self, home_directory: Path | None) -> str | None:

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -8,8 +8,10 @@ remains the fallback for agents that don't have a subclass yet.
 """
 
 import logging
+import os
 import traceback
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from pathlib import Path
 
 import pyjson5
@@ -37,7 +39,7 @@ McpConfigsResult = dict[
 ]
 SkillsDirsResult = dict[str, list[tuple[str, SkillServer]] | FileNotFoundConfig]
 
-# Cap recursion into ``~/.claude/plugins/{cache,repos}`` to mirror the legacy
+# Cap traversal into ``~/.claude/plugins/{cache,repos}`` to mirror the legacy
 # glob-based discovery, which uses ``CandidateClient.max_glob_depth=6``. We pick
 # a slightly larger budget here because plugin install layouts vary.
 _MAX_PLUGIN_RGLOB_DEPTH = 10
@@ -45,6 +47,27 @@ _MAX_PLUGIN_RGLOB_DEPTH = 10
 # Top-level keys that only ever appear on a single server config (StdioServer.command,
 # RemoteServer.url/serverUrl). Used to disambiguate wrapped vs flat .mcp.json payloads.
 _SERVER_CONFIG_DISCRIMINATOR_KEYS = frozenset({"command", "url", "serverUrl"})
+
+
+def _walk_under_depth(base: Path, name: str, max_path_depth: int, *, want_file: bool) -> Iterator[Path]:
+    """Yield paths named ``name`` under ``base``, pruning traversal so each yielded
+    path's relative parts count is at most ``max_path_depth``.
+
+    Unlike ``Path.rglob`` + post-hoc filtering, traversal stops at the cap rather
+    than walking the full subtree first — so a pathologically deep plugin layout
+    cannot blow up the walk. When ``want_file`` is True, only file entries are
+    yielded; otherwise directory entries.
+    """
+    for root_str, dirs, files in os.walk(base):
+        root = Path(root_str)
+        dir_depth = len(root.relative_to(base).parts)
+        candidates = files if want_file else dirs
+        if name in candidates:
+            yield root / name
+        # The dir we're in is at depth `dir_depth`; an entry inside it sits at
+        # depth+1. Prune once depth+1 reaches the cap so we don't descend further.
+        if dir_depth + 1 >= max_path_depth:
+            dirs.clear()
 
 
 def _select_servers_payload(file_data: dict) -> dict:
@@ -107,12 +130,7 @@ class AgentDiscoverer(ABC):
 
     @abstractmethod
     def discover_mcp_servers(self) -> McpConfigsResult:
-        """Parse the agent's MCP config file(s) and return them keyed by absolute path.
-
-        Subclasses that need real async I/O (subprocess calls, HTTP probes) should
-        override as ``async def`` and have callers wrap with ``asyncio.run`` /
-        ``asyncio.to_thread`` at the dispatch site.
-        """
+        """Parse the agent's MCP config file(s) and return them keyed by absolute path."""
 
     @abstractmethod
     def discover_skills(self) -> SkillsDirsResult:
@@ -235,8 +253,6 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         if not isinstance(top, dict) or not top:
             return {}
         entries = self._validate_servers(top, source=f"global mcpServers in {config_path.as_posix()}")
-        if isinstance(entries, CouldNotParseMCPConfig):
-            return {config_path.as_posix(): entries}
         return {config_path.as_posix(): entries}
 
     def _discover_project_mcp_servers(self) -> McpConfigsResult:
@@ -322,9 +338,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         for base in self._plugin_base_dirs():
             if not base.exists():
                 continue
-            for mcp_file in base.rglob(".mcp.json"):
-                if len(mcp_file.relative_to(base).parts) > _MAX_PLUGIN_RGLOB_DEPTH:
-                    continue
+            for mcp_file in _walk_under_depth(base, ".mcp.json", _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
                 if not mcp_file.is_file():
                     continue
                 file_data = self._load_json_file(mcp_file)
@@ -349,9 +363,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         for base in self._plugin_base_dirs():
             if not base.exists():
                 continue
-            for skills_dir in base.rglob("skills"):
-                if len(skills_dir.relative_to(base).parts) > _MAX_PLUGIN_RGLOB_DEPTH:
-                    continue
+            for skills_dir in _walk_under_depth(base, "skills", _MAX_PLUGIN_RGLOB_DEPTH, want_file=False):
                 if skills_dir.is_dir():
                     result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
         return result

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -115,7 +115,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     _mcp_config_path = "~/.claude.json"
     _skills_subdir = "skills"
     _project_dotclaude_subdir = ".claude"
-    _plugin_cache_subdir = "plugins/cache"
+    _plugin_subdirs: tuple[str, ...] = ("plugins/cache", "plugins/repos")
 
     # --- public (override AgentDiscoverer abstracts) ---
 
@@ -266,46 +266,51 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
 
     # --- private: plugin discovery ---
 
-    def _plugin_cache_dir(self) -> Path:
-        return expand_path(Path(self._install_path), self.home_directory) / self._plugin_cache_subdir
+    def _plugin_base_dirs(self) -> list[Path]:
+        """Roots where Claude Code stages installed plugins: ``cache/`` (hydrated)
+        and ``repos/`` (git-cloned source). Both can host MCP servers and skills."""
+        install = expand_path(Path(self._install_path), self.home_directory)
+        return [install / sub for sub in self._plugin_subdirs]
 
     async def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
-        """Scan ``~/.claude/plugins/cache/**/.mcp.json``.
+        """Scan plugin ``.mcp.json`` files under every plugin base dir.
 
         Plugin ``.mcp.json`` files use the flat ``{name: serverConfig}`` format
         (no ``mcpServers`` wrapper). A top-level ``mcpServers`` key is also
         tolerated for plugins that ship the wrapped format.
         """
-        cache_dir = self._plugin_cache_dir()
-        if not cache_dir.exists():
-            return {}
         result: McpConfigsResult = {}
-        for mcp_file in cache_dir.rglob(".mcp.json"):
-            if not mcp_file.is_file():
+        for base in self._plugin_base_dirs():
+            if not base.exists():
                 continue
-            file_data = self._load_json_file(mcp_file)
-            if file_data is None:
-                continue
-            if isinstance(file_data, CouldNotParseMCPConfig):
-                result[mcp_file.as_posix()] = file_data
-                continue
-            if not isinstance(file_data, dict) or not file_data:
-                continue
-            raw_servers = file_data.get("mcpServers") if "mcpServers" in file_data else file_data
-            if not isinstance(raw_servers, dict) or not raw_servers:
-                continue
-            result[mcp_file.as_posix()] = self._validate_servers(raw_servers, source=f"plugin {mcp_file.as_posix()}")
+            for mcp_file in base.rglob(".mcp.json"):
+                if not mcp_file.is_file():
+                    continue
+                file_data = self._load_json_file(mcp_file)
+                if file_data is None:
+                    continue
+                if isinstance(file_data, CouldNotParseMCPConfig):
+                    result[mcp_file.as_posix()] = file_data
+                    continue
+                if not isinstance(file_data, dict) or not file_data:
+                    continue
+                raw_servers = file_data.get("mcpServers") if "mcpServers" in file_data else file_data
+                if not isinstance(raw_servers, dict) or not raw_servers:
+                    continue
+                result[mcp_file.as_posix()] = self._validate_servers(
+                    raw_servers, source=f"plugin {mcp_file.as_posix()}"
+                )
         return result
 
     def _discover_plugin_skills(self) -> SkillsDirsResult:
-        """Scan ``~/.claude/plugins/cache/**/skills/`` for plugin-bundled skills."""
-        cache_dir = self._plugin_cache_dir()
-        if not cache_dir.exists():
-            return {}
+        """Scan ``skills/`` subdirs under every plugin base dir."""
         result: SkillsDirsResult = {}
-        for skills_dir in cache_dir.rglob("skills"):
-            if skills_dir.is_dir():
-                result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
+        for base in self._plugin_base_dirs():
+            if not base.exists():
+                continue
+            for skills_dir in base.rglob("skills"):
+                if skills_dir.is_dir():
+                    result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
         return result
 
     # --- internal helpers ---

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -306,11 +306,13 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     # --- private: skills discovery ---
 
     def _discover_global_skill(self) -> SkillsDirsResult:
-        """Scan ``~/.claude/skills`` for user-global skills."""
-        skills_dir = expand_path(Path(self._install_path), self.home_directory) / self._skills_subdir
-        if not skills_dir.exists():
-            return {}
-        return {skills_dir.as_posix(): inspect_skills_dir(str(skills_dir))}
+        """Scan ``<install>/skills`` under each user-global folder for skills."""
+        result: SkillsDirsResult = {}
+        for folder in self._discover_global_folders():
+            skills_dir = folder / self._skills_subdir
+            if skills_dir.exists():
+                result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
+        return result
 
     def _discover_project_skills(self) -> SkillsDirsResult:
         """For each project (and every ancestor up to root), scan ``<path>/.claude/skills`` if present."""
@@ -326,8 +328,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     def _plugin_base_dirs(self) -> list[Path]:
         """Roots where Claude Code stages installed plugins: ``cache/`` (hydrated)
         and ``repos/`` (git-cloned source). Both can host MCP servers and skills."""
-        install = expand_path(Path(self._install_path), self.home_directory)
-        return [install / sub for sub in self._plugin_subdirs]
+        return [folder / sub for folder in self._discover_global_folders() for sub in self._plugin_subdirs]
 
     def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
         """Scan plugin ``.mcp.json`` files under every plugin base dir.

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -138,47 +138,19 @@ class AgentDiscoverer(ABC):
     def discover_skills(self) -> SkillsDirsResult:
         """List the agent's skills, keyed by absolute skills-dir path."""
 
-    def discover(self) -> list[ClientToInspect]:
-        """Assemble one ClientToInspect per parent folder of discovered paths.
-
-        Discovered ``mcp_configs`` and ``skills_dirs`` entries are bucketed by
-        ``Path(key).parent`` — each unique parent folder becomes one CTI whose
-        ``client_path`` is that parent. CTIs carry only the dict subset whose
-        keys share that parent, preserving the dict shape downstream code expects.
-
-        If the agent isn't installed, returns ``[]``. If the agent is installed
-        but discovery turned up nothing, returns a single CTI pinned at the
-        install path with empty dicts so downstream still records the agent.
-        """
+    def discover(self) -> ClientToInspect | None:
+        """Assemble a ClientToInspect, or None when the agent isn't installed."""
         client_path = self.client_exists()
         if client_path is None:
-            return []
+            return None
         mcp_configs = self.discover_mcp_servers()
         skills_dirs = self.discover_skills()
-
-        mcp_buckets: dict[str, McpConfigsResult] = {}
-        skills_buckets: dict[str, SkillsDirsResult] = {}
-        for key, value in mcp_configs.items():
-            parent = Path(key).parent.as_posix()
-            mcp_buckets.setdefault(parent, {})[key] = value
-        for key, value in skills_dirs.items():
-            parent = Path(key).parent.as_posix()
-            skills_buckets.setdefault(parent, {})[key] = value
-
-        parents = sorted(set(mcp_buckets) | set(skills_buckets))
-        if not parents:
-            return [
-                ClientToInspect(name=self.name, client_path=client_path, mcp_configs={}, skills_dirs={}),
-            ]
-        return [
-            ClientToInspect(
-                name=self.name,
-                client_path=parent,
-                mcp_configs=mcp_buckets.get(parent, {}),
-                skills_dirs=skills_buckets.get(parent, {}),
-            )
-            for parent in parents
-        ]
+        return ClientToInspect(
+            name=self.name,
+            client_path=client_path,
+            mcp_configs=mcp_configs,
+            skills_dirs=skills_dirs,
+        )
 
 
 class ClaudeCodeDiscoverer(AgentDiscoverer):

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -78,18 +78,20 @@ def _select_servers_payload(file_data: dict) -> dict:
     * Wrapped: ``{"mcpServers": {<name>: <server-config>, ...}}``
     * Flat:    ``{<name>: <server-config>, ...}``
 
-    If ``file_data["mcpServers"]`` exists and looks like a *server map* (its value
-    is a dict, none of whose own top-level keys are server-config discriminators),
-    return it (wrapped). Otherwise return ``file_data`` itself (flat) — this
-    correctly handles the adversarial case of a flat-format file whose single
-    server happens to be literally named "mcpServers".
+    Disambiguation by *value type*, not just key presence: ``file_data["mcpServers"]``
+    is treated as a flat-format server config only if one of the discriminator keys
+    (``command``/``url``/``serverUrl``) is present with a string value — those are
+    always strings on a real server config. A wrapped server *named* "command" maps
+    to a dict (the server's own config), so it correctly stays wrapped.
 
     Note: only applied to plugin and per-project ``.mcp.json`` files. The global
     ``~/.claude.json`` is machine-managed by Claude Code and never flat; its
     parser short-circuits on a missing top-level ``mcpServers`` key.
     """
     candidate = file_data.get("mcpServers")
-    if isinstance(candidate, dict) and not (candidate.keys() & _SERVER_CONFIG_DISCRIMINATOR_KEYS):
+    if isinstance(candidate, dict) and not any(
+        isinstance(candidate.get(key), str) for key in _SERVER_CONFIG_DISCRIMINATOR_KEYS
+    ):
         return candidate
     return file_data
 

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -7,11 +7,12 @@ skills directories. The legacy `inspect.get_mcp_config_per_client()` path
 remains the fallback for agents that don't have a subclass yet.
 """
 
-import json
 import logging
 import traceback
 from abc import ABC, abstractmethod
 from pathlib import Path
+
+import pyjson5
 
 from agent_scan.models import (
     ClaudeConfigFile,
@@ -35,6 +36,11 @@ McpConfigsResult = dict[
     list[tuple[str, StdioServer | RemoteServer]] | FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig,
 ]
 SkillsDirsResult = dict[str, list[tuple[str, SkillServer]] | FileNotFoundConfig]
+
+# Cap recursion into ``~/.claude/plugins/{cache,repos}`` to mirror the legacy
+# glob-based discovery, which uses ``CandidateClient.max_glob_depth=6``. We pick
+# a slightly larger budget here because plugin install layouts vary.
+_MAX_PLUGIN_RGLOB_DEPTH = 10
 
 
 class AgentDiscoverer(ABC):
@@ -284,6 +290,8 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             if not base.exists():
                 continue
             for mcp_file in base.rglob(".mcp.json"):
+                if len(mcp_file.relative_to(base).parts) > _MAX_PLUGIN_RGLOB_DEPTH:
+                    continue
                 if not mcp_file.is_file():
                     continue
                 file_data = self._load_json_file(mcp_file)
@@ -309,6 +317,8 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             if not base.exists():
                 continue
             for skills_dir in base.rglob("skills"):
+                if len(skills_dir.relative_to(base).parts) > _MAX_PLUGIN_RGLOB_DEPTH:
+                    continue
                 if skills_dir.is_dir():
                     result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
         return result
@@ -324,11 +334,18 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     def _load_json_file(self, path: Path) -> dict | CouldNotParseMCPConfig | None:
         """JSON-decode an arbitrary file. ``None`` if missing, parsed dict on success,
         ``CouldNotParseMCPConfig`` on malformed JSON.
+
+        Uses ``pyjson5`` to match the legacy ``mcp_client.scan_mcp_config_file``
+        path, which tolerates ``//`` comments and trailing commas. An empty or
+        whitespace-only file is treated as an empty config (also matching legacy).
         """
         if not path.exists():
             return None
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
+            content = path.read_text(encoding="utf-8")
+            if content.strip() == "":
+                return {}
+            return pyjson5.loads(content)
         except Exception as e:
             logger.exception("Error reading %s: %s", path.as_posix(), e)
             return CouldNotParseMCPConfig(
@@ -351,10 +368,10 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
                 is_failure=True,
             )
         servers = validated.get_servers()
-        for server_config in servers.values():
+        for name, server_config in servers.items():
             if isinstance(server_config, StdioServer):
-                server_config = check_server_signature(server_config)
-        return [(name, server) for name, server in servers.items()]
+                servers[name] = check_server_signature(server_config)
+        return list(servers.items())
 
 
 DISCOVERERS: dict[str, type[AgentDiscoverer]] = {
@@ -366,10 +383,19 @@ def find_discoverers(home_directory: Path | None) -> list[AgentDiscoverer]:
     """Construct one instance per registered discoverer with the given home, and
     return only those whose ``client_exists()`` confirms the agent is installed.
     Each returned instance is home-bound; the caller just runs
-    ``await d.discover()`` on each."""
+    ``await d.discover()`` on each.
+
+    A discoverer whose ``client_exists()`` raises is skipped (and logged) so a
+    single buggy subclass cannot abort discovery for the whole machine.
+    """
     found: list[AgentDiscoverer] = []
     for cls in DISCOVERERS.values():
         discoverer = cls(home_directory)
-        if discoverer.client_exists() is not None:
+        try:
+            exists = discoverer.client_exists() is not None
+        except Exception:
+            logger.exception("Discoverer %s.client_exists() raised; skipping", cls.__name__)
+            continue
+        if exists:
             found.append(discoverer)
     return found

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -26,7 +26,7 @@ from agent_scan.models import (
 )
 from agent_scan.signed_binary import check_server_signature
 from agent_scan.skill_client import inspect_skills_dir
-from agent_scan.well_known_clients import expand_path
+from agent_scan.well_known_clients import CLAUDE_CODE_NAME, expand_path
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,34 @@ SkillsDirsResult = dict[str, list[tuple[str, SkillServer]] | FileNotFoundConfig]
 # glob-based discovery, which uses ``CandidateClient.max_glob_depth=6``. We pick
 # a slightly larger budget here because plugin install layouts vary.
 _MAX_PLUGIN_RGLOB_DEPTH = 10
+
+# Top-level keys that only ever appear on a single server config (StdioServer.command,
+# RemoteServer.url/serverUrl). Used to disambiguate wrapped vs flat .mcp.json payloads.
+_SERVER_CONFIG_DISCRIMINATOR_KEYS = frozenset({"command", "url", "serverUrl"})
+
+
+def _select_servers_payload(file_data: dict) -> dict:
+    """Pick the server-map payload from a ``.mcp.json`` file (plugin or project scope).
+
+    Files come in two shapes:
+
+    * Wrapped: ``{"mcpServers": {<name>: <server-config>, ...}}``
+    * Flat:    ``{<name>: <server-config>, ...}``
+
+    If ``file_data["mcpServers"]`` exists and looks like a *server map* (its value
+    is a dict, none of whose own top-level keys are server-config discriminators),
+    return it (wrapped). Otherwise return ``file_data`` itself (flat) — this
+    correctly handles the adversarial case of a flat-format file whose single
+    server happens to be literally named "mcpServers".
+
+    Note: only applied to plugin and per-project ``.mcp.json`` files. The global
+    ``~/.claude.json`` is machine-managed by Claude Code and never flat; its
+    parser short-circuits on a missing top-level ``mcpServers`` key.
+    """
+    candidate = file_data.get("mcpServers")
+    if isinstance(candidate, dict) and not (candidate.keys() & _SERVER_CONFIG_DISCRIMINATOR_KEYS):
+        return candidate
+    return file_data
 
 
 class AgentDiscoverer(ABC):
@@ -78,19 +106,24 @@ class AgentDiscoverer(ABC):
         """Return the resolved install path if the agent is present, else None."""
 
     @abstractmethod
-    async def discover_mcp_servers(self) -> McpConfigsResult:
-        """Parse the agent's MCP config file(s) and return them keyed by absolute path."""
+    def discover_mcp_servers(self) -> McpConfigsResult:
+        """Parse the agent's MCP config file(s) and return them keyed by absolute path.
+
+        Subclasses that need real async I/O (subprocess calls, HTTP probes) should
+        override as ``async def`` and have callers wrap with ``asyncio.run`` /
+        ``asyncio.to_thread`` at the dispatch site.
+        """
 
     @abstractmethod
     def discover_skills(self) -> SkillsDirsResult:
         """List the agent's skills, keyed by absolute skills-dir path."""
 
-    async def discover(self) -> ClientToInspect | None:
+    def discover(self) -> ClientToInspect | None:
         """Assemble a ClientToInspect, or None when the agent isn't installed."""
         client_path = self.client_exists()
         if client_path is None:
             return None
-        mcp_configs = await self.discover_mcp_servers()
+        mcp_configs = self.discover_mcp_servers()
         skills_dirs = self.discover_skills()
         return ClientToInspect(
             name=self.name,
@@ -115,7 +148,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
       project listed in ``~/.claude.json``.
     """
 
-    name = "claude code"
+    name = CLAUDE_CODE_NAME
 
     _install_path = "~/.claude"
     _mcp_config_path = "~/.claude.json"
@@ -134,11 +167,11 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             logger.warning("Permission error for path %s", path.as_posix())
         return None
 
-    async def discover_mcp_servers(self) -> McpConfigsResult:
+    def discover_mcp_servers(self) -> McpConfigsResult:
         result: McpConfigsResult = {}
-        result.update(await self._discover_global_mcp_servers())
-        result.update(await self._discover_project_mcp_servers())
-        result.update(await self._discover_plugin_mcp_servers())
+        result.update(self._discover_global_mcp_servers())
+        result.update(self._discover_project_mcp_servers())
+        result.update(self._discover_plugin_mcp_servers())
         return result
 
     def discover_skills(self) -> SkillsDirsResult:
@@ -188,7 +221,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
 
     # --- private: MCP discovery ---
 
-    async def _discover_global_mcp_servers(self) -> McpConfigsResult:
+    def _discover_global_mcp_servers(self) -> McpConfigsResult:
         """Parse top-level ``mcpServers`` from ``~/.claude.json`` — the user-global scope."""
         config_path = expand_path(Path(self._mcp_config_path), self.home_directory)
         if not config_path.exists():
@@ -206,7 +239,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             return {config_path.as_posix(): entries}
         return {config_path.as_posix(): entries}
 
-    async def _discover_project_mcp_servers(self) -> McpConfigsResult:
+    def _discover_project_mcp_servers(self) -> McpConfigsResult:
         """Per-project MCP discovery for each path in ``_project_paths_with_ancestors``.
 
         Two sources are checked at every path:
@@ -242,9 +275,9 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             if isinstance(file_data, CouldNotParseMCPConfig):
                 result[mcp_file.as_posix()] = file_data
                 continue
-            if not isinstance(file_data, dict):
+            if not isinstance(file_data, dict) or not file_data:
                 continue
-            file_mcp = file_data.get("mcpServers")
+            file_mcp = _select_servers_payload(file_data)
             if not isinstance(file_mcp, dict) or not file_mcp:
                 continue
             result[mcp_file.as_posix()] = self._validate_servers(
@@ -278,7 +311,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         install = expand_path(Path(self._install_path), self.home_directory)
         return [install / sub for sub in self._plugin_subdirs]
 
-    async def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
+    def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
         """Scan plugin ``.mcp.json`` files under every plugin base dir.
 
         Plugin ``.mcp.json`` files use the flat ``{name: serverConfig}`` format
@@ -302,7 +335,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
                     continue
                 if not isinstance(file_data, dict) or not file_data:
                     continue
-                raw_servers = file_data.get("mcpServers") if "mcpServers" in file_data else file_data
+                raw_servers = _select_servers_payload(file_data)
                 if not isinstance(raw_servers, dict) or not raw_servers:
                     continue
                 result[mcp_file.as_posix()] = self._validate_servers(
@@ -383,7 +416,7 @@ def find_discoverers(home_directory: Path | None) -> list[AgentDiscoverer]:
     """Construct one instance per registered discoverer with the given home, and
     return only those whose ``client_exists()`` confirms the agent is installed.
     Each returned instance is home-bound; the caller just runs
-    ``await d.discover()`` on each.
+    ``d.discover()`` on each.
 
     A discoverer whose ``client_exists()`` raises is skipped (and logged) so a
     single buggy subclass cannot abort discovery for the whole machine.

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -46,6 +46,10 @@ class AgentDiscoverer(ABC):
     canonical agent name used in ``well_known_clients``; this is enforced in
     ``__init_subclass__``.
 
+    A discoverer is bound to a single user's ``home_directory`` at construction;
+    the multi-user (`--scan-all-users`) loop in ``pipelines`` constructs one
+    discoverer per home directory.
+
     Note: this abstraction intentionally does NOT consult the corresponding
     ``CandidateClient`` row's ``mcp_config_globs`` / ``skills_dir_globs``
     fields. Subclasses encode their layout directly. If a future agent
@@ -55,30 +59,33 @@ class AgentDiscoverer(ABC):
 
     name: str = ""
 
+    def __init__(self, home_directory: Path | None) -> None:
+        self.home_directory = home_directory
+
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)
         if not cls.name:
             raise TypeError(f"{cls.__name__} must set a non-empty 'name' class attribute")
 
     @abstractmethod
-    def client_exists(self, home_directory: Path | None) -> str | None:
+    def client_exists(self) -> str | None:
         """Return the resolved install path if the agent is present, else None."""
 
     @abstractmethod
-    async def discover_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
+    async def discover_mcp_servers(self) -> McpConfigsResult:
         """Parse the agent's MCP config file(s) and return them keyed by absolute path."""
 
     @abstractmethod
-    def discover_skills(self, home_directory: Path | None) -> SkillsDirsResult:
+    def discover_skills(self) -> SkillsDirsResult:
         """List the agent's skills, keyed by absolute skills-dir path."""
 
-    async def discover(self, home_directory: Path | None) -> ClientToInspect | None:
+    async def discover(self) -> ClientToInspect | None:
         """Assemble a ClientToInspect, or None when the agent isn't installed."""
-        client_path = self.client_exists(home_directory)
+        client_path = self.client_exists()
         if client_path is None:
             return None
-        mcp_configs = await self.discover_mcp_servers(home_directory)
-        skills_dirs = self.discover_skills(home_directory)
+        mcp_configs = await self.discover_mcp_servers()
+        skills_dirs = self.discover_skills()
         return ClientToInspect(
             name=self.name,
             client_path=client_path,
@@ -111,8 +118,8 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
 
     # --- public (override AgentDiscoverer abstracts) ---
 
-    def client_exists(self, home_directory: Path | None) -> str | None:
-        path = expand_path(Path(self._install_path), home_directory)
+    def client_exists(self) -> str | None:
+        path = expand_path(Path(self._install_path), self.home_directory)
         try:
             if path.exists():
                 return path.as_posix()
@@ -120,27 +127,27 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             logger.warning("Permission error for path %s", path.as_posix())
         return None
 
-    async def discover_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
+    async def discover_mcp_servers(self) -> McpConfigsResult:
         result: McpConfigsResult = {}
-        result.update(await self._discover_global_mcp_servers(home_directory))
-        result.update(await self._discover_project_mcp_servers(home_directory))
+        result.update(await self._discover_global_mcp_servers())
+        result.update(await self._discover_project_mcp_servers())
         return result
 
-    def discover_skills(self, home_directory: Path | None) -> SkillsDirsResult:
+    def discover_skills(self) -> SkillsDirsResult:
         result: SkillsDirsResult = {}
-        result.update(self._discover_global_skill(home_directory))
-        result.update(self._discover_project_skills(home_directory))
+        result.update(self._discover_global_skill())
+        result.update(self._discover_project_skills())
         return result
 
     # --- private: folder enumeration ---
 
-    def _discover_global_folders(self, home_directory: Path | None) -> list[Path]:
+    def _discover_global_folders(self) -> list[Path]:
         """Folders that hold user-global Claude Code state (currently just ``~/.claude``)."""
-        return [expand_path(Path(self._install_path), home_directory)]
+        return [expand_path(Path(self._install_path), self.home_directory)]
 
-    def _discover_project_folders(self, home_directory: Path | None) -> list[Path]:
+    def _discover_project_folders(self) -> list[Path]:
         """Project root paths recorded under ``projects`` in ``~/.claude.json``."""
-        data = self._load_config_raw(home_directory)
+        data = self._load_config_raw()
         if not isinstance(data, dict):
             return []
         projects = data.get("projects")
@@ -150,12 +157,12 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
 
     # --- private: MCP discovery ---
 
-    async def _discover_global_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
+    async def _discover_global_mcp_servers(self) -> McpConfigsResult:
         """Parse top-level ``mcpServers`` from ``~/.claude.json`` — the user-global scope."""
-        config_path = expand_path(Path(self._mcp_config_path), home_directory)
+        config_path = expand_path(Path(self._mcp_config_path), self.home_directory)
         if not config_path.exists():
             return {}
-        data = self._load_config_raw(home_directory)
+        data = self._load_config_raw()
         if isinstance(data, CouldNotParseMCPConfig):
             return {config_path.as_posix(): data}
         if not isinstance(data, dict):
@@ -168,15 +175,15 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             return {config_path.as_posix(): entries}
         return {config_path.as_posix(): entries}
 
-    async def _discover_project_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
+    async def _discover_project_mcp_servers(self) -> McpConfigsResult:
         """Parse ``projects.<path>.mcpServers`` from ``~/.claude.json`` — per-project scope.
 
         Each project contributes one entry keyed by its absolute project path.
         """
-        config_path = expand_path(Path(self._mcp_config_path), home_directory)
+        config_path = expand_path(Path(self._mcp_config_path), self.home_directory)
         if not config_path.exists():
             return {}
-        data = self._load_config_raw(home_directory)
+        data = self._load_config_raw()
         if isinstance(data, CouldNotParseMCPConfig):
             return {config_path.as_posix(): data}
         if not isinstance(data, dict):
@@ -200,17 +207,17 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
 
     # --- private: skills discovery ---
 
-    def _discover_global_skill(self, home_directory: Path | None) -> SkillsDirsResult:
+    def _discover_global_skill(self) -> SkillsDirsResult:
         """Scan ``~/.claude/skills`` for user-global skills."""
-        skills_dir = expand_path(Path(self._install_path), home_directory) / self._skills_subdir
+        skills_dir = expand_path(Path(self._install_path), self.home_directory) / self._skills_subdir
         if not skills_dir.exists():
             return {}
         return {skills_dir.as_posix(): inspect_skills_dir(str(skills_dir))}
 
-    def _discover_project_skills(self, home_directory: Path | None) -> SkillsDirsResult:
+    def _discover_project_skills(self) -> SkillsDirsResult:
         """For each project, scan ``<project>/.claude/skills`` if present."""
         result: SkillsDirsResult = {}
-        for project_path in self._discover_project_folders(home_directory):
+        for project_path in self._discover_project_folders():
             skills_dir = project_path / self._project_dotclaude_subdir / self._skills_subdir
             if skills_dir.exists():
                 result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
@@ -218,11 +225,11 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
 
     # --- internal helpers ---
 
-    def _load_config_raw(self, home_directory: Path | None) -> dict | CouldNotParseMCPConfig | None:
+    def _load_config_raw(self) -> dict | CouldNotParseMCPConfig | None:
         """Read and JSON-decode ``~/.claude.json``. Returns ``None`` if missing,
         a dict on success, or a ``CouldNotParseMCPConfig`` on malformed JSON.
         """
-        config_path = expand_path(Path(self._mcp_config_path), home_directory)
+        config_path = expand_path(Path(self._mcp_config_path), self.home_directory)
         if not config_path.exists():
             return None
         try:
@@ -260,9 +267,15 @@ _DISCOVERERS: dict[str, type[AgentDiscoverer]] = {
 }
 
 
-def get_discoverer(name: str) -> AgentDiscoverer:
-    """Return a discoverer for the agent name, or raise NotImplementedError."""
+def get_discoverer_class(name: str) -> type[AgentDiscoverer]:
+    """Return the discoverer class for an agent name, or raise NotImplementedError.
+
+    Callers instantiate the class with the target ``home_directory``. Looking
+    up the class (rather than a constructed instance) lets one well-known
+    client be scanned across multiple home directories without re-checking
+    NotImplementedError per user.
+    """
     cls = _DISCOVERERS.get(name)
     if cls is None:
         raise NotImplementedError(f"No AgentDiscoverer implemented for agent {name!r}")
-    return cls()
+    return cls

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -115,6 +115,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     _mcp_config_path = "~/.claude.json"
     _skills_subdir = "skills"
     _project_dotclaude_subdir = ".claude"
+    _plugin_cache_subdir = "plugins/cache"
 
     # --- public (override AgentDiscoverer abstracts) ---
 
@@ -131,12 +132,14 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         result: McpConfigsResult = {}
         result.update(await self._discover_global_mcp_servers())
         result.update(await self._discover_project_mcp_servers())
+        result.update(await self._discover_plugin_mcp_servers())
         return result
 
     def discover_skills(self) -> SkillsDirsResult:
         result: SkillsDirsResult = {}
         result.update(self._discover_global_skill())
         result.update(self._discover_project_skills())
+        result.update(self._discover_plugin_skills())
         return result
 
     # --- private: folder enumeration ---
@@ -258,6 +261,50 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         for path in self._project_paths_with_ancestors():
             skills_dir = path / self._project_dotclaude_subdir / self._skills_subdir
             if skills_dir.exists():
+                result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
+        return result
+
+    # --- private: plugin discovery ---
+
+    def _plugin_cache_dir(self) -> Path:
+        return expand_path(Path(self._install_path), self.home_directory) / self._plugin_cache_subdir
+
+    async def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
+        """Scan ``~/.claude/plugins/cache/**/.mcp.json``.
+
+        Plugin ``.mcp.json`` files use the flat ``{name: serverConfig}`` format
+        (no ``mcpServers`` wrapper). A top-level ``mcpServers`` key is also
+        tolerated for plugins that ship the wrapped format.
+        """
+        cache_dir = self._plugin_cache_dir()
+        if not cache_dir.exists():
+            return {}
+        result: McpConfigsResult = {}
+        for mcp_file in cache_dir.rglob(".mcp.json"):
+            if not mcp_file.is_file():
+                continue
+            file_data = self._load_json_file(mcp_file)
+            if file_data is None:
+                continue
+            if isinstance(file_data, CouldNotParseMCPConfig):
+                result[mcp_file.as_posix()] = file_data
+                continue
+            if not isinstance(file_data, dict) or not file_data:
+                continue
+            raw_servers = file_data.get("mcpServers") if "mcpServers" in file_data else file_data
+            if not isinstance(raw_servers, dict) or not raw_servers:
+                continue
+            result[mcp_file.as_posix()] = self._validate_servers(raw_servers, source=f"plugin {mcp_file.as_posix()}")
+        return result
+
+    def _discover_plugin_skills(self) -> SkillsDirsResult:
+        """Scan ``~/.claude/plugins/cache/**/skills/`` for plugin-bundled skills."""
+        cache_dir = self._plugin_cache_dir()
+        if not cache_dir.exists():
+            return {}
+        result: SkillsDirsResult = {}
+        for skills_dir in cache_dir.rglob("skills"):
+            if skills_dir.is_dir():
                 result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
         return result
 

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -380,12 +380,18 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         return self._load_json_file(expand_path(Path(self._mcp_config_path), self.home_directory))
 
     def _load_json_file(self, path: Path) -> dict | CouldNotParseMCPConfig | None:
-        """JSON-decode an arbitrary file. ``None`` if missing, parsed dict on success,
-        ``CouldNotParseMCPConfig`` on malformed JSON.
+        """JSON-decode an arbitrary file. ``None`` if missing or unreadable due to
+        permissions, parsed dict on success, ``CouldNotParseMCPConfig`` on
+        malformed JSON.
 
         Uses ``pyjson5`` to match the legacy ``mcp_client.scan_mcp_config_file``
         path, which tolerates ``//`` comments and trailing commas. An empty or
         whitespace-only file is treated as an empty config (also matching legacy).
+
+        ``PermissionError`` is treated like a missing file — under
+        ``--scan-all-users`` an unprivileged process routinely hits homes it
+        can't read, and surfacing those as ``CouldNotParseMCPConfig`` would
+        misclassify access-control denials as malformed-config errors.
         """
         if not path.exists():
             return None
@@ -394,6 +400,9 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             if content.strip() == "":
                 return {}
             return pyjson5.loads(content)
+        except PermissionError:
+            logger.warning("Permission denied reading %s", path.as_posix())
+            return None
         except Exception as e:
             logger.exception("Error reading %s: %s", path.as_posix(), e)
             return CouldNotParseMCPConfig(

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -7,13 +7,14 @@ skills directories. The legacy `inspect.get_mcp_config_per_client()` path
 remains the fallback for agents that don't have a subclass yet.
 """
 
+import json
 import logging
 import traceback
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from agent_scan.mcp_client import scan_mcp_config_file
 from agent_scan.models import (
+    ClaudeConfigFile,
     ClientToInspect,
     CouldNotParseMCPConfig,
     FileNotFoundConfig,
@@ -21,7 +22,6 @@ from agent_scan.models import (
     SkillServer,
     StdioServer,
     UnknownConfigFormat,
-    UnknownMCPConfig,
 )
 from agent_scan.signed_binary import check_server_signature
 from agent_scan.skill_client import inspect_skills_dir
@@ -88,11 +88,28 @@ class AgentDiscoverer(ABC):
 
 
 class ClaudeCodeDiscoverer(AgentDiscoverer):
+    """Claude Code discovery: ``~/.claude.json`` + ``~/.claude/skills/`` + per-project scopes.
+
+    The public ``discover_mcp_servers`` / ``discover_skills`` methods orchestrate six
+    private helpers split by scope:
+
+    * ``_discover_global_folders`` / ``_discover_project_folders`` enumerate where to look.
+    * ``_discover_global_mcp_servers`` reads the top-level ``mcpServers`` key in
+      ``~/.claude.json``; ``_discover_project_mcp_servers`` reads each
+      ``projects.<path>.mcpServers`` block.
+    * ``_discover_global_skill`` reads ``~/.claude/skills``;
+      ``_discover_project_skills`` reads ``<project>/.claude/skills`` for every
+      project listed in ``~/.claude.json``.
+    """
+
     name = "claude code"
 
     _install_path = "~/.claude"
     _mcp_config_path = "~/.claude.json"
-    _skills_dir_path = "~/.claude/skills"
+    _skills_subdir = "skills"
+    _project_dotclaude_subdir = ".claude"
+
+    # --- public (override AgentDiscoverer abstracts) ---
 
     def client_exists(self, home_directory: Path | None) -> str | None:
         path = expand_path(Path(self._install_path), home_directory)
@@ -104,41 +121,138 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         return None
 
     async def discover_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
-        mcp_configs: McpConfigsResult = {}
-        mcp_config_path = expand_path(Path(self._mcp_config_path), home_directory)
-        if not mcp_config_path.exists():
-            return mcp_configs
-        try:
-            mcp_config = await scan_mcp_config_file(str(mcp_config_path))
-            if isinstance(mcp_config, UnknownMCPConfig):
-                mcp_configs[mcp_config_path.as_posix()] = UnknownConfigFormat(
-                    message=f"Unknown MCP config: {mcp_config_path.as_posix()}",
-                    is_failure=False,
-                )
-                return mcp_configs
+        result: McpConfigsResult = {}
+        result.update(await self._discover_global_mcp_servers(home_directory))
+        result.update(await self._discover_project_mcp_servers(home_directory))
+        return result
 
-            server_configs_by_name = mcp_config.get_servers()
-            for server_config in server_configs_by_name.values():
-                if isinstance(server_config, StdioServer):
-                    server_config = check_server_signature(server_config)
-            mcp_configs[mcp_config_path.as_posix()] = [
-                (server_name, server) for server_name, server in server_configs_by_name.items()
-            ]
+    def discover_skills(self, home_directory: Path | None) -> SkillsDirsResult:
+        result: SkillsDirsResult = {}
+        result.update(self._discover_global_skill(home_directory))
+        result.update(self._discover_project_skills(home_directory))
+        return result
+
+    # --- private: folder enumeration ---
+
+    def _discover_global_folders(self, home_directory: Path | None) -> list[Path]:
+        """Folders that hold user-global Claude Code state (currently just ``~/.claude``)."""
+        return [expand_path(Path(self._install_path), home_directory)]
+
+    def _discover_project_folders(self, home_directory: Path | None) -> list[Path]:
+        """Project root paths recorded under ``projects`` in ``~/.claude.json``."""
+        data = self._load_config_raw(home_directory)
+        if not isinstance(data, dict):
+            return []
+        projects = data.get("projects")
+        if not isinstance(projects, dict):
+            return []
+        return [Path(p) for p in projects if isinstance(p, str)]
+
+    # --- private: MCP discovery ---
+
+    async def _discover_global_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
+        """Parse top-level ``mcpServers`` from ``~/.claude.json`` — the user-global scope."""
+        config_path = expand_path(Path(self._mcp_config_path), home_directory)
+        if not config_path.exists():
+            return {}
+        data = self._load_config_raw(home_directory)
+        if isinstance(data, CouldNotParseMCPConfig):
+            return {config_path.as_posix(): data}
+        if not isinstance(data, dict):
+            return {}
+        top = data.get("mcpServers")
+        if not isinstance(top, dict) or not top:
+            return {}
+        entries = self._validate_servers(top, source=f"global mcpServers in {config_path.as_posix()}")
+        if isinstance(entries, CouldNotParseMCPConfig):
+            return {config_path.as_posix(): entries}
+        return {config_path.as_posix(): entries}
+
+    async def _discover_project_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
+        """Parse ``projects.<path>.mcpServers`` from ``~/.claude.json`` — per-project scope.
+
+        Each project contributes one entry keyed by its absolute project path.
+        """
+        config_path = expand_path(Path(self._mcp_config_path), home_directory)
+        if not config_path.exists():
+            return {}
+        data = self._load_config_raw(home_directory)
+        if isinstance(data, CouldNotParseMCPConfig):
+            return {config_path.as_posix(): data}
+        if not isinstance(data, dict):
+            return {}
+        projects = data.get("projects")
+        if not isinstance(projects, dict):
+            return {}
+
+        result: McpConfigsResult = {}
+        for project_path, project_config in projects.items():
+            if not isinstance(project_path, str) or not isinstance(project_config, dict):
+                continue
+            project_mcp = project_config.get("mcpServers")
+            if not isinstance(project_mcp, dict) or not project_mcp:
+                continue
+            entries = self._validate_servers(
+                project_mcp, source=f"projects.{project_path}.mcpServers in {config_path.as_posix()}"
+            )
+            result[project_path] = entries
+        return result
+
+    # --- private: skills discovery ---
+
+    def _discover_global_skill(self, home_directory: Path | None) -> SkillsDirsResult:
+        """Scan ``~/.claude/skills`` for user-global skills."""
+        skills_dir = expand_path(Path(self._install_path), home_directory) / self._skills_subdir
+        if not skills_dir.exists():
+            return {}
+        return {skills_dir.as_posix(): inspect_skills_dir(str(skills_dir))}
+
+    def _discover_project_skills(self, home_directory: Path | None) -> SkillsDirsResult:
+        """For each project, scan ``<project>/.claude/skills`` if present."""
+        result: SkillsDirsResult = {}
+        for project_path in self._discover_project_folders(home_directory):
+            skills_dir = project_path / self._project_dotclaude_subdir / self._skills_subdir
+            if skills_dir.exists():
+                result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
+        return result
+
+    # --- internal helpers ---
+
+    def _load_config_raw(self, home_directory: Path | None) -> dict | CouldNotParseMCPConfig | None:
+        """Read and JSON-decode ``~/.claude.json``. Returns ``None`` if missing,
+        a dict on success, or a ``CouldNotParseMCPConfig`` on malformed JSON.
+        """
+        config_path = expand_path(Path(self._mcp_config_path), home_directory)
+        if not config_path.exists():
+            return None
+        try:
+            return json.loads(config_path.read_text(encoding="utf-8"))
         except Exception as e:
-            logger.exception("Error parsing MCP config file %s: %s", mcp_config_path.as_posix(), e)
-            mcp_configs[mcp_config_path.as_posix()] = CouldNotParseMCPConfig(
-                message=f"could not parse file {mcp_config_path.as_posix()}",
+            logger.exception("Error reading %s: %s", config_path.as_posix(), e)
+            return CouldNotParseMCPConfig(
+                message=f"could not parse file {config_path.as_posix()}",
                 traceback=traceback.format_exc(),
                 is_failure=True,
             )
-        return mcp_configs
 
-    def discover_skills(self, home_directory: Path | None) -> SkillsDirsResult:
-        skills_dirs: SkillsDirsResult = {}
-        skills_dir_path = expand_path(Path(self._skills_dir_path), home_directory)
-        if skills_dir_path.exists():
-            skills_dirs[skills_dir_path.as_posix()] = inspect_skills_dir(str(skills_dir_path))
-        return skills_dirs
+    def _validate_servers(
+        self, raw: dict, source: str
+    ) -> list[tuple[str, StdioServer | RemoteServer]] | CouldNotParseMCPConfig:
+        """Validate a raw ``mcpServers`` mapping into typed Stdio/Remote server entries."""
+        try:
+            validated = ClaudeConfigFile(mcpServers=raw)
+        except Exception as e:
+            logger.exception("Invalid %s: %s", source, e)
+            return CouldNotParseMCPConfig(
+                message=f"could not parse {source}",
+                traceback=traceback.format_exc(),
+                is_failure=True,
+            )
+        servers = validated.get_servers()
+        for server_config in servers.values():
+            if isinstance(server_config, StdioServer):
+                server_config = check_server_signature(server_config)
+        return [(name, server) for name, server in servers.items()]
 
 
 _DISCOVERERS: dict[str, type[AgentDiscoverer]] = {

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -138,19 +138,47 @@ class AgentDiscoverer(ABC):
     def discover_skills(self) -> SkillsDirsResult:
         """List the agent's skills, keyed by absolute skills-dir path."""
 
-    def discover(self) -> ClientToInspect | None:
-        """Assemble a ClientToInspect, or None when the agent isn't installed."""
+    def discover(self) -> list[ClientToInspect]:
+        """Assemble one ClientToInspect per parent folder of discovered paths.
+
+        Discovered ``mcp_configs`` and ``skills_dirs`` entries are bucketed by
+        ``Path(key).parent`` — each unique parent folder becomes one CTI whose
+        ``client_path`` is that parent. CTIs carry only the dict subset whose
+        keys share that parent, preserving the dict shape downstream code expects.
+
+        If the agent isn't installed, returns ``[]``. If the agent is installed
+        but discovery turned up nothing, returns a single CTI pinned at the
+        install path with empty dicts so downstream still records the agent.
+        """
         client_path = self.client_exists()
         if client_path is None:
-            return None
+            return []
         mcp_configs = self.discover_mcp_servers()
         skills_dirs = self.discover_skills()
-        return ClientToInspect(
-            name=self.name,
-            client_path=client_path,
-            mcp_configs=mcp_configs,
-            skills_dirs=skills_dirs,
-        )
+
+        mcp_buckets: dict[str, McpConfigsResult] = {}
+        skills_buckets: dict[str, SkillsDirsResult] = {}
+        for key, value in mcp_configs.items():
+            parent = Path(key).parent.as_posix()
+            mcp_buckets.setdefault(parent, {})[key] = value
+        for key, value in skills_dirs.items():
+            parent = Path(key).parent.as_posix()
+            skills_buckets.setdefault(parent, {})[key] = value
+
+        parents = sorted(set(mcp_buckets) | set(skills_buckets))
+        if not parents:
+            return [
+                ClientToInspect(name=self.name, client_path=client_path, mcp_configs={}, skills_dirs={}),
+            ]
+        return [
+            ClientToInspect(
+                name=self.name,
+                client_path=parent,
+                mcp_configs=mcp_buckets.get(parent, {}),
+                skills_dirs=skills_buckets.get(parent, {}),
+            )
+            for parent in parents
+        ]
 
 
 class ClaudeCodeDiscoverer(AgentDiscoverer):

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -393,9 +393,9 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         can't read, and surfacing those as ``CouldNotParseMCPConfig`` would
         misclassify access-control denials as malformed-config errors.
         """
-        if not path.exists():
-            return None
         try:
+            if not path.exists():
+                return None
             content = path.read_text(encoding="utf-8")
             if content.strip() == "":
                 return {}

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -262,20 +262,19 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         return [(name, server) for name, server in servers.items()]
 
 
-_DISCOVERERS: dict[str, type[AgentDiscoverer]] = {
+DISCOVERERS: dict[str, type[AgentDiscoverer]] = {
     ClaudeCodeDiscoverer.name: ClaudeCodeDiscoverer,
 }
 
 
-def get_discoverer_class(name: str) -> type[AgentDiscoverer]:
-    """Return the discoverer class for an agent name, or raise NotImplementedError.
-
-    Callers instantiate the class with the target ``home_directory``. Looking
-    up the class (rather than a constructed instance) lets one well-known
-    client be scanned across multiple home directories without re-checking
-    NotImplementedError per user.
-    """
-    cls = _DISCOVERERS.get(name)
-    if cls is None:
-        raise NotImplementedError(f"No AgentDiscoverer implemented for agent {name!r}")
-    return cls
+def find_discoverers(home_directory: Path | None) -> list[AgentDiscoverer]:
+    """Construct one instance per registered discoverer with the given home, and
+    return only those whose ``client_exists()`` confirms the agent is installed.
+    Each returned instance is home-bound; the caller just runs
+    ``await d.discover()`` on each."""
+    found: list[AgentDiscoverer] = []
+    for cls in DISCOVERERS.values():
+        discoverer = cls(home_directory)
+        if discoverer.client_exists() is not None:
+            found.append(discoverer)
+    return found

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -155,6 +155,28 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
             return []
         return [Path(p) for p in projects if isinstance(p, str)]
 
+    def _project_paths_with_ancestors(self) -> list[Path]:
+        """Project roots plus every ancestor up to filesystem root, deduplicated.
+
+        Walking up lets project-scope MCP and skills discovery pick up
+        ``.mcp.json`` or ``.claude/skills`` directories living in any
+        parent folder of a registered project (e.g. a monorepo root that
+        contains many project subdirectories).
+        """
+        seen: set[Path] = set()
+        result: list[Path] = []
+        for project_path in self._discover_project_folders():
+            cur = project_path
+            while True:
+                if cur not in seen:
+                    seen.add(cur)
+                    result.append(cur)
+                parent = cur.parent
+                if parent == cur:
+                    break
+                cur = parent
+        return result
+
     # --- private: MCP discovery ---
 
     async def _discover_global_mcp_servers(self) -> McpConfigsResult:
@@ -176,33 +198,49 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         return {config_path.as_posix(): entries}
 
     async def _discover_project_mcp_servers(self) -> McpConfigsResult:
-        """Parse ``projects.<path>.mcpServers`` from ``~/.claude.json`` — per-project scope.
+        """Per-project MCP discovery for each path in ``_project_paths_with_ancestors``.
 
-        Each project contributes one entry keyed by its absolute project path.
+        Two sources are checked at every path:
+
+        1. ``projects.<path>.mcpServers`` in ``~/.claude.json`` — keyed by the project path.
+        2. ``<path>/.mcp.json`` on disk — keyed by the absolute file path.
+
+        A malformed ``.mcp.json`` becomes a ``CouldNotParseMCPConfig`` entry.
         """
         config_path = expand_path(Path(self._mcp_config_path), self.home_directory)
-        if not config_path.exists():
-            return {}
         data = self._load_config_raw()
         if isinstance(data, CouldNotParseMCPConfig):
             return {config_path.as_posix(): data}
-        if not isinstance(data, dict):
-            return {}
-        projects = data.get("projects")
+        projects = data.get("projects") if isinstance(data, dict) else None
         if not isinstance(projects, dict):
-            return {}
+            projects = {}
 
         result: McpConfigsResult = {}
-        for project_path, project_config in projects.items():
-            if not isinstance(project_path, str) or not isinstance(project_config, dict):
+        for path in self._project_paths_with_ancestors():
+            key = path.as_posix()
+            project_config = projects.get(key)
+            if isinstance(project_config, dict):
+                project_mcp = project_config.get("mcpServers")
+                if isinstance(project_mcp, dict) and project_mcp:
+                    result[key] = self._validate_servers(
+                        project_mcp, source=f"projects.{key}.mcpServers in {config_path.as_posix()}"
+                    )
+
+            mcp_file = path / ".mcp.json"
+            file_data = self._load_json_file(mcp_file)
+            if file_data is None:
                 continue
-            project_mcp = project_config.get("mcpServers")
-            if not isinstance(project_mcp, dict) or not project_mcp:
+            if isinstance(file_data, CouldNotParseMCPConfig):
+                result[mcp_file.as_posix()] = file_data
                 continue
-            entries = self._validate_servers(
-                project_mcp, source=f"projects.{project_path}.mcpServers in {config_path.as_posix()}"
+            if not isinstance(file_data, dict):
+                continue
+            file_mcp = file_data.get("mcpServers")
+            if not isinstance(file_mcp, dict) or not file_mcp:
+                continue
+            result[mcp_file.as_posix()] = self._validate_servers(
+                file_mcp, source=f"mcpServers in {mcp_file.as_posix()}"
             )
-            result[project_path] = entries
         return result
 
     # --- private: skills discovery ---
@@ -215,10 +253,10 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         return {skills_dir.as_posix(): inspect_skills_dir(str(skills_dir))}
 
     def _discover_project_skills(self) -> SkillsDirsResult:
-        """For each project, scan ``<project>/.claude/skills`` if present."""
+        """For each project (and every ancestor up to root), scan ``<path>/.claude/skills`` if present."""
         result: SkillsDirsResult = {}
-        for project_path in self._discover_project_folders():
-            skills_dir = project_path / self._project_dotclaude_subdir / self._skills_subdir
+        for path in self._project_paths_with_ancestors():
+            skills_dir = path / self._project_dotclaude_subdir / self._skills_subdir
             if skills_dir.exists():
                 result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
         return result
@@ -229,15 +267,20 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         """Read and JSON-decode ``~/.claude.json``. Returns ``None`` if missing,
         a dict on success, or a ``CouldNotParseMCPConfig`` on malformed JSON.
         """
-        config_path = expand_path(Path(self._mcp_config_path), self.home_directory)
-        if not config_path.exists():
+        return self._load_json_file(expand_path(Path(self._mcp_config_path), self.home_directory))
+
+    def _load_json_file(self, path: Path) -> dict | CouldNotParseMCPConfig | None:
+        """JSON-decode an arbitrary file. ``None`` if missing, parsed dict on success,
+        ``CouldNotParseMCPConfig`` on malformed JSON.
+        """
+        if not path.exists():
             return None
         try:
-            return json.loads(config_path.read_text(encoding="utf-8"))
+            return json.loads(path.read_text(encoding="utf-8"))
         except Exception as e:
-            logger.exception("Error reading %s: %s", config_path.as_posix(), e)
+            logger.exception("Error reading %s: %s", path.as_posix(), e)
             return CouldNotParseMCPConfig(
-                message=f"could not parse file {config_path.as_posix()}",
+                message=f"could not parse file {path.as_posix()}",
                 traceback=traceback.format_exc(),
                 is_failure=True,
             )

--- a/src/agent_scan/agent_discovery.py
+++ b/src/agent_scan/agent_discovery.py
@@ -1,0 +1,144 @@
+"""Per-agent abstraction for discovering MCP servers and skills.
+
+This module sits alongside the existing data-driven discovery pipeline
+(`well_known_clients.py` + `inspect.py`). Each subclass of `AgentDiscoverer`
+owns the agent-specific knowledge of where to look for config files and
+skills directories. The legacy `inspect.get_mcp_config_per_client()` path
+remains the fallback for agents that don't have a subclass yet.
+"""
+
+import logging
+import traceback
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from agent_scan.mcp_client import scan_mcp_config_file
+from agent_scan.models import (
+    ClientToInspect,
+    CouldNotParseMCPConfig,
+    FileNotFoundConfig,
+    RemoteServer,
+    SkillServer,
+    StdioServer,
+    UnknownConfigFormat,
+    UnknownMCPConfig,
+)
+from agent_scan.signed_binary import check_server_signature
+from agent_scan.skill_client import inspect_skills_dir
+from agent_scan.well_known_clients import expand_path
+
+logger = logging.getLogger(__name__)
+
+
+McpConfigsResult = dict[
+    str,
+    list[tuple[str, StdioServer | RemoteServer]]
+    | FileNotFoundConfig
+    | UnknownConfigFormat
+    | CouldNotParseMCPConfig,
+]
+SkillsDirsResult = dict[str, list[tuple[str, SkillServer]] | FileNotFoundConfig]
+
+
+class AgentDiscoverer(ABC):
+    """Abstract per-agent discoverer.
+
+    Concrete subclasses encapsulate one agent's filesystem layout: where the
+    install lives, which JSON file(s) hold its MCP servers, and which directory
+    holds its skills.
+    """
+
+    name: str
+
+    @abstractmethod
+    def client_exists(self, home_directory: Path | None) -> str | None:
+        """Return the resolved install path if the agent is present, else None."""
+
+    @abstractmethod
+    async def discover_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
+        """Parse the agent's MCP config file(s) and return them keyed by absolute path."""
+
+    @abstractmethod
+    def discover_skills(self, home_directory: Path | None) -> SkillsDirsResult:
+        """List the agent's skills, keyed by absolute skills-dir path."""
+
+    async def discover(self, home_directory: Path | None) -> ClientToInspect | None:
+        """Assemble a ClientToInspect, or None when the agent isn't installed."""
+        client_path = self.client_exists(home_directory)
+        if client_path is None:
+            return None
+        mcp_configs = await self.discover_mcp_servers(home_directory)
+        skills_dirs = self.discover_skills(home_directory)
+        return ClientToInspect(
+            name=self.name,
+            client_path=client_path,
+            mcp_configs=mcp_configs,
+            skills_dirs=skills_dirs,
+        )
+
+
+class ClaudeCodeDiscoverer(AgentDiscoverer):
+    name = "claude code"
+
+    _install_path = "~/.claude"
+    _mcp_config_path = "~/.claude.json"
+    _skills_dir_path = "~/.claude/skills"
+
+    def client_exists(self, home_directory: Path | None) -> str | None:
+        path = expand_path(Path(self._install_path), home_directory)
+        try:
+            if path.exists():
+                return path.as_posix()
+        except PermissionError:
+            logger.warning("Permission error for path %s", path.as_posix())
+        return None
+
+    async def discover_mcp_servers(self, home_directory: Path | None) -> McpConfigsResult:
+        mcp_configs: McpConfigsResult = {}
+        mcp_config_path = expand_path(Path(self._mcp_config_path), home_directory)
+        if not mcp_config_path.exists():
+            return mcp_configs
+        try:
+            mcp_config = await scan_mcp_config_file(str(mcp_config_path))
+            if isinstance(mcp_config, UnknownMCPConfig):
+                mcp_configs[mcp_config_path.as_posix()] = UnknownConfigFormat(
+                    message=f"Unknown MCP config: {mcp_config_path.as_posix()}",
+                    is_failure=False,
+                )
+                return mcp_configs
+
+            server_configs_by_name = mcp_config.get_servers()
+            for server_config in server_configs_by_name.values():
+                if isinstance(server_config, StdioServer):
+                    server_config = check_server_signature(server_config)
+            mcp_configs[mcp_config_path.as_posix()] = [
+                (server_name, server) for server_name, server in server_configs_by_name.items()
+            ]
+        except Exception as e:
+            logger.exception("Error parsing MCP config file %s: %s", mcp_config_path.as_posix(), e)
+            mcp_configs[mcp_config_path.as_posix()] = CouldNotParseMCPConfig(
+                message=f"could not parse file {mcp_config_path.as_posix()}",
+                traceback=traceback.format_exc(),
+                is_failure=True,
+            )
+        return mcp_configs
+
+    def discover_skills(self, home_directory: Path | None) -> SkillsDirsResult:
+        skills_dirs: SkillsDirsResult = {}
+        skills_dir_path = expand_path(Path(self._skills_dir_path), home_directory)
+        if skills_dir_path.exists():
+            skills_dirs[skills_dir_path.as_posix()] = inspect_skills_dir(str(skills_dir_path))
+        return skills_dirs
+
+
+_DISCOVERERS: dict[str, type[AgentDiscoverer]] = {
+    ClaudeCodeDiscoverer.name: ClaudeCodeDiscoverer,
+}
+
+
+def get_discoverer(name: str) -> AgentDiscoverer:
+    """Return a discoverer for the agent name, or raise NotImplementedError."""
+    cls = _DISCOVERERS.get(name)
+    if cls is None:
+        raise NotImplementedError(f"No AgentDiscoverer implemented for agent {name!r}")
+    return cls()

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-from agent_scan.agent_discovery import get_discoverer
+from agent_scan.agent_discovery import get_discoverer_class
 from agent_scan.direct_scanner import direct_scan_to_server_config, is_direct_scan
 from agent_scan.inspect import (
     get_mcp_config_per_client,
@@ -85,14 +85,15 @@ async def discover_clients_to_inspect(
     else:
         for client in get_well_known_clients():
             try:
-                discoverer = get_discoverer(client.name)
+                discoverer_cls = get_discoverer_class(client.name)
             except NotImplementedError:
                 # Legacy path — unchanged for every agent without a discoverer subclass.
                 ctis = await get_mcp_config_per_client(client, home_dirs_with_users)
             else:
                 ctis = []
                 for home_directory, username in home_dirs_with_users:
-                    cti = await discoverer.discover(home_directory)
+                    discoverer = discoverer_cls(home_directory)
+                    cti = await discoverer.discover()
                     if cti is not None:
                         cti.username = username
                         ctis.append(cti)

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -109,11 +109,11 @@ async def discover_clients_to_inspect(
             else:
                 logger.info(f"Client {client.name} does not exist on this machine. {client.client_exists_paths}")
 
-        # Phase B — ABC path. Runs in parallel and merges into Phase A's output.
+        # Phase B — ABC path. Runs sequentially after Phase A and merges into its output.
         abc_touched: list[ClientToInspect] = []
         for home_directory, username in home_dirs_with_users:
             for discoverer in find_discoverers(home_directory):
-                cti = await discoverer.discover()
+                cti = discoverer.discover()
                 if cti is None:
                     continue
                 cti.username = username

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -95,28 +95,29 @@ async def discover_clients_to_inspect(
         for home_directory, username in home_dirs_with_users:
             for discoverer in find_discoverers(home_directory):
                 try:
-                    cti = discoverer.discover()
+                    ctis = discoverer.discover()
                 except Exception:
                     logger.exception("Discoverer %s.discover() raised; skipping", type(discoverer).__name__)
                     continue
-                if cti is None:
-                    continue
-                cti.username = username
-                existing = next(
-                    (c for c in clients_to_inspect if c.name == cti.name and c.username == cti.username),
-                    None,
-                )
-                if existing is None:
-                    clients_to_inspect.append(cti)
-                else:
-                    # Dict union: legacy keys first (insertion order), ABC keys appended.
-                    # ABC values win on key collision (e.g., both phases emit a server
-                    # under ``~/.claude.json``). Distinct keys from each phase coexist
-                    # — same-name servers under different keys are kept as separate
-                    # registrations (e.g., the same ``github`` server configured in
-                    # two projects must both reach the inspector).
-                    existing.mcp_configs = {**existing.mcp_configs, **cti.mcp_configs}
-                    existing.skills_dirs = {**existing.skills_dirs, **cti.skills_dirs}
+                for cti in ctis:
+                    cti.username = username
+                    existing = next(
+                        (
+                            c
+                            for c in clients_to_inspect
+                            if c.name == cti.name and c.username == cti.username and c.client_path == cti.client_path
+                        ),
+                        None,
+                    )
+                    if existing is None:
+                        clients_to_inspect.append(cti)
+                    else:
+                        # Same (name, username, client_path) — merge dict-union. ABC
+                        # values win on key collision; distinct keys from each phase
+                        # coexist (same-name servers under different keys both reach
+                        # the inspector).
+                        existing.mcp_configs = {**existing.mcp_configs, **cti.mcp_configs}
+                        existing.skills_dirs = {**existing.skills_dirs, **cti.skills_dirs}
 
     # Only report usernames where an agent was detected in their home directory.
     # When no usernames were associated with detected agents:

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-from agent_scan.agent_discovery import get_discoverer_class
+from agent_scan.agent_discovery import find_discoverers
 from agent_scan.direct_scanner import direct_scan_to_server_config, is_direct_scan
 from agent_scan.inspect import (
     get_mcp_config_per_client,
@@ -52,6 +52,24 @@ class PushArgs(BaseModel):
     version: str | None = None
 
 
+def _dedup_mcp_servers(cti: ClientToInspect) -> None:
+    """In ``mcp_configs``, keep each server name only under its latest-inserted key.
+
+    Preserves error-type entries (FileNotFoundConfig / UnknownConfigFormat /
+    CouldNotParseMCPConfig) untouched.
+    """
+    last_key: dict[str, str] = {}
+    for key, entries in cti.mcp_configs.items():
+        if isinstance(entries, list):
+            for name, _ in entries:
+                last_key[name] = key
+
+    for key in list(cti.mcp_configs.keys()):
+        entries = cti.mcp_configs[key]
+        if isinstance(entries, list):
+            cti.mcp_configs[key] = [(n, s) for n, s in entries if last_key.get(n) == key]
+
+
 async def discover_clients_to_inspect(
     inspect_args: InspectArgs,
 ) -> tuple[list[ClientToInspect], list[ScanPathResult], list[str]]:
@@ -83,24 +101,40 @@ async def discover_clients_to_inspect(
                     )
                 )
     else:
+        # Phase A — legacy path. Runs for EVERY well-known client including Claude Code.
         for client in get_well_known_clients():
-            try:
-                discoverer_cls = get_discoverer_class(client.name)
-            except NotImplementedError:
-                # Legacy path — unchanged for every agent without a discoverer subclass.
-                ctis = await get_mcp_config_per_client(client, home_dirs_with_users)
-            else:
-                ctis = []
-                for home_directory, username in home_dirs_with_users:
-                    discoverer = discoverer_cls(home_directory)
-                    cti = await discoverer.discover()
-                    if cti is not None:
-                        cti.username = username
-                        ctis.append(cti)
+            ctis = await get_mcp_config_per_client(client, home_dirs_with_users)
             if ctis:
                 clients_to_inspect.extend(ctis)
             else:
                 logger.info(f"Client {client.name} does not exist on this machine. {client.client_exists_paths}")
+
+        # Phase B — ABC path. Runs in parallel and merges into Phase A's output.
+        abc_touched: list[ClientToInspect] = []
+        for home_directory, username in home_dirs_with_users:
+            for discoverer in find_discoverers(home_directory):
+                cti = await discoverer.discover()
+                if cti is None:
+                    continue
+                cti.username = username
+                existing = next(
+                    (c for c in clients_to_inspect if c.name == cti.name and c.username == cti.username),
+                    None,
+                )
+                if existing is None:
+                    clients_to_inspect.append(cti)
+                    abc_touched.append(cti)
+                else:
+                    # Dict union: legacy keys first (insertion order), ABC keys appended.
+                    # ABC values WIN on key collision (silent override of any legacy entry
+                    # under the same key). Phase C dedup below favors latest-inserted key.
+                    existing.mcp_configs = {**existing.mcp_configs, **cti.mcp_configs}
+                    existing.skills_dirs = {**existing.skills_dirs, **cti.skills_dirs}
+                    abc_touched.append(existing)
+
+        # Phase C — server-name dedup on ABC-touched CTIs.
+        for cti in abc_touched:
+            _dedup_mcp_servers(cti)
 
     # Only report usernames where an agent was detected in their home directory.
     # When no usernames were associated with detected agents:

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
+from agent_scan.agent_discovery import get_discoverer
 from agent_scan.direct_scanner import direct_scan_to_server_config, is_direct_scan
 from agent_scan.inspect import (
     get_mcp_config_per_client,
@@ -83,7 +84,18 @@ async def discover_clients_to_inspect(
                 )
     else:
         for client in get_well_known_clients():
-            ctis = await get_mcp_config_per_client(client, home_dirs_with_users)
+            try:
+                discoverer = get_discoverer(client.name)
+            except NotImplementedError:
+                # Legacy path — unchanged for every agent without a discoverer subclass.
+                ctis = await get_mcp_config_per_client(client, home_dirs_with_users)
+            else:
+                ctis = []
+                for home_directory, username in home_dirs_with_users:
+                    cti = await discoverer.discover(home_directory)
+                    if cti is not None:
+                        cti.username = username
+                        ctis.append(cti)
             if ctis:
                 clients_to_inspect.extend(ctis)
             else:

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -52,31 +52,6 @@ class PushArgs(BaseModel):
     version: str | None = None
 
 
-def _dedup_mcp_servers(cti: ClientToInspect) -> None:
-    """In ``mcp_configs``, keep each server name only under its latest-inserted key.
-
-    Preserves error-type entries (FileNotFoundConfig / UnknownConfigFormat /
-    CouldNotParseMCPConfig) untouched. Drops keys whose list was non-empty before
-    dedup but became empty after — those are stale legacy entries fully shadowed
-    by an ABC key. Keys that were already empty pre-dedup are left in place.
-    """
-    last_key: dict[str, str] = {}
-    for key, entries in cti.mcp_configs.items():
-        if isinstance(entries, list):
-            for name, _ in entries:
-                last_key[name] = key
-
-    for key in list(cti.mcp_configs.keys()):
-        entries = cti.mcp_configs[key]
-        if not isinstance(entries, list):
-            continue
-        deduped = [(n, s) for n, s in entries if last_key.get(n) == key]
-        if not deduped and entries:
-            del cti.mcp_configs[key]
-        else:
-            cti.mcp_configs[key] = deduped
-
-
 async def discover_clients_to_inspect(
     inspect_args: InspectArgs,
 ) -> tuple[list[ClientToInspect], list[ScanPathResult], list[str]]:
@@ -117,7 +92,6 @@ async def discover_clients_to_inspect(
                 logger.info(f"Client {client.name} does not exist on this machine. {client.client_exists_paths}")
 
         # Phase B — ABC path. Runs sequentially after Phase A and merges into its output.
-        abc_touched: list[ClientToInspect] = []
         for home_directory, username in home_dirs_with_users:
             for discoverer in find_discoverers(home_directory):
                 try:
@@ -134,18 +108,15 @@ async def discover_clients_to_inspect(
                 )
                 if existing is None:
                     clients_to_inspect.append(cti)
-                    abc_touched.append(cti)
                 else:
                     # Dict union: legacy keys first (insertion order), ABC keys appended.
-                    # ABC values WIN on key collision (silent override of any legacy entry
-                    # under the same key). Phase C dedup below favors latest-inserted key.
+                    # ABC values win on key collision (e.g., both phases emit a server
+                    # under ``~/.claude.json``). Distinct keys from each phase coexist
+                    # — same-name servers under different keys are kept as separate
+                    # registrations (e.g., the same ``github`` server configured in
+                    # two projects must both reach the inspector).
                     existing.mcp_configs = {**existing.mcp_configs, **cti.mcp_configs}
                     existing.skills_dirs = {**existing.skills_dirs, **cti.skills_dirs}
-                    abc_touched.append(existing)
-
-        # Phase C — server-name dedup on ABC-touched CTIs.
-        for cti in abc_touched:
-            _dedup_mcp_servers(cti)
 
     # Only report usernames where an agent was detected in their home directory.
     # When no usernames were associated with detected agents:

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -95,29 +95,28 @@ async def discover_clients_to_inspect(
         for home_directory, username in home_dirs_with_users:
             for discoverer in find_discoverers(home_directory):
                 try:
-                    ctis = discoverer.discover()
+                    cti = discoverer.discover()
                 except Exception:
                     logger.exception("Discoverer %s.discover() raised; skipping", type(discoverer).__name__)
                     continue
-                for cti in ctis:
-                    cti.username = username
-                    existing = next(
-                        (
-                            c
-                            for c in clients_to_inspect
-                            if c.name == cti.name and c.username == cti.username and c.client_path == cti.client_path
-                        ),
-                        None,
-                    )
-                    if existing is None:
-                        clients_to_inspect.append(cti)
-                    else:
-                        # Same (name, username, client_path) — merge dict-union. ABC
-                        # values win on key collision; distinct keys from each phase
-                        # coexist (same-name servers under different keys both reach
-                        # the inspector).
-                        existing.mcp_configs = {**existing.mcp_configs, **cti.mcp_configs}
-                        existing.skills_dirs = {**existing.skills_dirs, **cti.skills_dirs}
+                if cti is None:
+                    continue
+                cti.username = username
+                existing = next(
+                    (c for c in clients_to_inspect if c.name == cti.name and c.username == cti.username),
+                    None,
+                )
+                if existing is None:
+                    clients_to_inspect.append(cti)
+                else:
+                    # Dict union: legacy keys first (insertion order), ABC keys appended.
+                    # ABC values win on key collision (e.g., both phases emit a server
+                    # under ``~/.claude.json``). Distinct keys from each phase coexist
+                    # — same-name servers under different keys are kept as separate
+                    # registrations (e.g., the same ``github`` server configured in
+                    # two projects must both reach the inspector).
+                    existing.mcp_configs = {**existing.mcp_configs, **cti.mcp_configs}
+                    existing.skills_dirs = {**existing.skills_dirs, **cti.skills_dirs}
 
     # Only report usernames where an agent was detected in their home directory.
     # When no usernames were associated with detected agents:

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -56,7 +56,9 @@ def _dedup_mcp_servers(cti: ClientToInspect) -> None:
     """In ``mcp_configs``, keep each server name only under its latest-inserted key.
 
     Preserves error-type entries (FileNotFoundConfig / UnknownConfigFormat /
-    CouldNotParseMCPConfig) untouched.
+    CouldNotParseMCPConfig) untouched. Drops keys whose list was non-empty before
+    dedup but became empty after — those are stale legacy entries fully shadowed
+    by an ABC key. Keys that were already empty pre-dedup are left in place.
     """
     last_key: dict[str, str] = {}
     for key, entries in cti.mcp_configs.items():
@@ -66,8 +68,13 @@ def _dedup_mcp_servers(cti: ClientToInspect) -> None:
 
     for key in list(cti.mcp_configs.keys()):
         entries = cti.mcp_configs[key]
-        if isinstance(entries, list):
-            cti.mcp_configs[key] = [(n, s) for n, s in entries if last_key.get(n) == key]
+        if not isinstance(entries, list):
+            continue
+        deduped = [(n, s) for n, s in entries if last_key.get(n) == key]
+        if not deduped and entries:
+            del cti.mcp_configs[key]
+        else:
+            cti.mcp_configs[key] = deduped
 
 
 async def discover_clients_to_inspect(
@@ -113,7 +120,11 @@ async def discover_clients_to_inspect(
         abc_touched: list[ClientToInspect] = []
         for home_directory, username in home_dirs_with_users:
             for discoverer in find_discoverers(home_directory):
-                cti = discoverer.discover()
+                try:
+                    cti = discoverer.discover()
+                except Exception:
+                    logger.exception("Discoverer %s.discover() raised; skipping", type(discoverer).__name__)
+                    continue
                 if cti is None:
                     continue
                 cti.username = username

--- a/src/agent_scan/well_known_clients.py
+++ b/src/agent_scan/well_known_clients.py
@@ -9,6 +9,11 @@ from agent_scan.models import CandidateClient
 # Set up logger for this module
 logger = logging.getLogger(__name__)
 
+# Canonical agent name for Claude Code. Used as ``CandidateClient.name`` in the
+# per-OS lists below and as ``ClaudeCodeDiscoverer.name``; the Phase B merge in
+# ``pipelines.discover_clients_to_inspect`` relies on these matching exactly.
+CLAUDE_CODE_NAME = "claude code"
+
 
 MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
     CandidateClient(
@@ -40,7 +45,7 @@ MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_paths=[],
     ),
     CandidateClient(
-        name="claude code",
+        name=CLAUDE_CODE_NAME,
         client_exists_paths=["~/.claude"],
         mcp_config_paths=["~/.claude.json"],
         skills_dir_paths=["~/.claude/skills"],
@@ -130,7 +135,7 @@ LINUX_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_paths=["~/.copilot/skills"],
     ),
     CandidateClient(
-        name="claude code",
+        name=CLAUDE_CODE_NAME,
         client_exists_paths=["~/.claude"],
         mcp_config_paths=["~/.claude.json"],
         skills_dir_paths=["~/.claude/skills"],
@@ -227,7 +232,7 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_paths=[],
     ),
     CandidateClient(
-        name="claude code",
+        name=CLAUDE_CODE_NAME,
         client_exists_paths=["~/.claude"],
         mcp_config_paths=["~/.claude.json"],
         skills_dir_paths=["~/.claude/skills"],

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -1443,3 +1443,174 @@ async def test_discover_clients_to_inspect_skips_discoverer_whose_discover_raise
     names = {c.name for c in ctis}
     assert "claude code" in names
     assert "exploding-mid" not in names
+
+
+# --- _load_json_file permission handling ---
+
+
+def test_load_json_file_returns_none_on_permission_error(tmp_path, monkeypatch):
+    """A ``PermissionError`` during read must return ``None`` (missing-file
+    semantics), not a ``CouldNotParseMCPConfig`` entry.
+
+    Under ``--scan-all-users`` an unprivileged process routinely hits homes it
+    can't read; surfacing those as parse errors would misclassify access-control
+    denials as malformed configs.
+    """
+    from pathlib import Path
+
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"mcpServers": {"srv": {"command": "echo"}}}')
+
+    real_read_text = Path.read_text
+
+    def fake_read_text(self, *args, **kwargs):
+        if self.name == ".claude.json":
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    # The unreadable file is silently skipped — no parse-error sentinel surfaces.
+    assert mcp_configs == {}
+
+
+def test_load_json_file_still_returns_could_not_parse_for_malformed_json(tmp_path):
+    """Regression guard: real parse failures still produce ``CouldNotParseMCPConfig``.
+    Splitting out the ``PermissionError`` branch must not weaken malformed-JSON handling.
+    """
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text("{not valid json")
+
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entry = next(iter(mcp_configs.values()))
+    assert isinstance(entry, CouldNotParseMCPConfig)
+
+
+# --- Multi-user pipeline (--scan-all-users) end-to-end ---
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_keeps_per_user_isolation_under_scan_all_users(tmp_path):
+    """End-to-end multi-home test for the ``(name, username)`` merge predicate.
+
+    Phase B looks up the existing CTI via
+    ``c.name == cti.name and c.username == cti.username`` (pipelines.py:131).
+    If the ``username`` half of that predicate ever regresses (e.g. someone
+    simplifies to ``c.name == cti.name``), bob's ABC discoverer would merge
+    into the *first* "claude code" CTI in insertion order — which is alice's —
+    contaminating alice's CTI with bob's servers and leaving bob's CTI without
+    its ABC-discovered project key.
+
+    The test gives each user a *distinct* server name and a *distinct* project
+    path so cross-contamination is trivially detectable.
+    """
+    from agent_scan.models import CandidateClient
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    alice_home = tmp_path / "alice"
+    bob_home = tmp_path / "bob"
+    (alice_home / ".claude").mkdir(parents=True)
+    (bob_home / ".claude").mkdir(parents=True)
+    (alice_home / ".claude.json").write_text(
+        '{"projects": {"/alice/repo": {"mcpServers": {"alice-srv": {"command": "echo"}}}}}'
+    )
+    (bob_home / ".claude.json").write_text(
+        '{"projects": {"/bob/repo": {"mcpServers": {"bob-srv": {"command": "echo"}}}}}'
+    )
+
+    candidate = CandidateClient(
+        name="claude code",
+        client_exists_paths=["~/.claude"],
+        mcp_config_paths=["~/.claude.json"],
+        skills_dir_paths=["~/.claude/skills"],
+    )
+
+    with (
+        patch(
+            "agent_scan.pipelines.get_readable_home_directories",
+            return_value=[(alice_home, "alice"), (bob_home, "bob")],
+        ),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+    ):
+        args = InspectArgs(timeout=10, tokens=[], paths=[], all_users=True)
+        ctis, _, _ = await discover_clients_to_inspect(args)
+
+    claude_ctis = [c for c in ctis if c.name == "claude code"]
+    by_user = {c.username: c for c in claude_ctis}
+    assert set(by_user) == {"alice", "bob"}, f"Expected one CTI per user, got {sorted(by_user)}"
+
+    def server_names(cti):
+        names = set()
+        for entries in cti.mcp_configs.values():
+            if isinstance(entries, list):
+                for name, _ in entries:
+                    names.add(name)
+        return names
+
+    alice_servers = server_names(by_user["alice"])
+    bob_servers = server_names(by_user["bob"])
+
+    # No cross-contamination: each user's CTI contains ONLY its own distinct server.
+    assert alice_servers == {"alice-srv"}, (
+        f"alice's CTI must contain only alice-srv (cross-contamination from bob "
+        f"indicates the username predicate regressed); got {alice_servers}"
+    )
+    assert bob_servers == {"bob-srv"}, (
+        f"bob's CTI must contain only bob-srv (cross-contamination from alice "
+        f"indicates the username predicate regressed); got {bob_servers}"
+    )
+
+    # Each user's CTI carries its own ABC-discovered project key. If the
+    # username predicate were dropped, bob's ABC would never reach bob's CTI
+    # and /bob/repo would be missing from bob_keys.
+    assert "/alice/repo" in by_user["alice"].mcp_configs
+    assert "/bob/repo" in by_user["bob"].mcp_configs
+    assert "/bob/repo" not in by_user["alice"].mcp_configs
+    assert "/alice/repo" not in by_user["bob"].mcp_configs
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_propagates_all_users_flag_to_home_enumeration(tmp_path):
+    """The ``InspectArgs.all_users`` flag must reach
+    ``get_readable_home_directories`` unmodified.
+
+    Regression guard: if the pipeline ever drops the kwarg or hardcodes a
+    value, ``--scan-all-users`` would silently degrade to scanning only the
+    current user — every per-user assertion in the rest of the suite would
+    still pass (they all mock the home list directly), but real CLI runs
+    would skip every other user on the box.
+    """
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    captured: dict = {}
+
+    def fake_home_enum(*, all_users):
+        captured.setdefault("calls", []).append(all_users)
+        return [(tmp_path, "alice")]
+
+    # all_users=True must reach the enumeration as True.
+    with (
+        patch("agent_scan.pipelines.get_readable_home_directories", side_effect=fake_home_enum),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[]),
+    ):
+        await discover_clients_to_inspect(InspectArgs(timeout=10, tokens=[], paths=[], all_users=True))
+
+    # all_users=False (single-user default) must reach as False.
+    with (
+        patch("agent_scan.pipelines.get_readable_home_directories", side_effect=fake_home_enum),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[]),
+    ):
+        await discover_clients_to_inspect(InspectArgs(timeout=10, tokens=[], paths=[], all_users=False))
+
+    assert captured["calls"] == [True, False], (
+        f"Pipeline must pass all_users through unchanged to get_readable_home_directories; "
+        f"got call sequence {captured['calls']}"
+    )

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -492,6 +492,116 @@ def test_claude_code_discoverer_discover_skills_combines_global_and_project(tmp_
     assert len(skills_dirs) == 2  # one global, one project
 
 
+# --- ClaudeCodeDiscoverer: plugin MCP + skills ---
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_plugin_mcp_servers_parses_flat_format(tmp_path):
+    """Plugin .mcp.json files use the flat {name: serverConfig} format."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    plugin_dir = tmp_path / ".claude" / "plugins" / "cache" / "vendor" / "my-plugin" / "1.0.0"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".mcp.json").write_text('{"plugin-srv": {"command": "echo", "args": ["p"]}}')
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    key = next(iter(mcp_configs))
+    assert key.endswith("/1.0.0/.mcp.json")
+    entries = mcp_configs[key]
+    assert isinstance(entries, list) and len(entries) == 1
+    name, server = entries[0]
+    assert name == "plugin-srv"
+    assert isinstance(server, StdioServer)
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_plugin_mcp_servers_empty_when_cache_missing(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    assert mcp_configs == {}
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_plugin_mcp_records_could_not_parse(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    plugin_dir = tmp_path / ".claude" / "plugins" / "cache" / "bad" / "plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".mcp.json").write_text("{not valid json")
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entry = next(iter(mcp_configs.values()))
+    assert isinstance(entry, CouldNotParseMCPConfig)
+    assert entry.is_failure is True
+
+
+def test_claude_code_discoverer_plugin_skills_scans_cache(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    plugin_skill_dir = tmp_path / ".claude" / "plugins" / "cache" / "vendor" / "my-plugin" / "skills" / "plug-skill"
+    plugin_skill_dir.mkdir(parents=True)
+    (plugin_skill_dir / "SKILL.md").write_text("---\nname: plug-skill\ndescription: p\n---\n\nB.\n")
+
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_skills()
+
+    assert len(skills_dirs) == 1
+    key = next(iter(skills_dirs))
+    assert key.endswith("/my-plugin/skills")
+    entries = skills_dirs[key]
+    assert isinstance(entries, list) and len(entries) == 1
+    skill_name, skill = entries[0]
+    assert skill_name == "plug-skill"
+    assert isinstance(skill, SkillServer)
+
+
+def test_claude_code_discoverer_plugin_skills_empty_when_cache_missing(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_skills()
+
+    assert skills_dirs == {}
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_discover_mcp_includes_plugin_servers(tmp_path):
+    """Plugin MCP entries flow through public discover_mcp_servers."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    plugin_dir = tmp_path / ".claude" / "plugins" / "cache" / "v" / "p"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".mcp.json").write_text('{"plug": {"command": "x"}}')
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    plugin_keys = [k for k in mcp_configs if k.endswith("/p/.mcp.json")]
+    assert len(plugin_keys) == 1
+
+
+def test_claude_code_discoverer_discover_skills_includes_plugin_skills(tmp_path):
+    """Plugin skill dirs flow through public discover_skills."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    plugin_skill_dir = tmp_path / ".claude" / "plugins" / "cache" / "v" / "p" / "skills" / "ps"
+    plugin_skill_dir.mkdir(parents=True)
+    (plugin_skill_dir / "SKILL.md").write_text("---\nname: ps\ndescription: x\n---\n\nB.\n")
+
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path).discover_skills()
+
+    plugin_keys = [k for k in skills_dirs if "/plugins/cache/" in k]
+    assert len(plugin_keys) == 1
+
+
 # --- ClaudeCodeDiscoverer: end-to-end discover() ---
 
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -857,7 +857,7 @@ def test_agent_discoverer_subclass_without_name_raises():
             def client_exists(self):
                 return None
 
-            async def discover_mcp_servers(self):
+            def discover_mcp_servers(self):
                 return {}
 
             def discover_skills(self):
@@ -1344,7 +1344,7 @@ def test_find_discoverers_skips_discoverer_that_raises_unexpected_exception(tmp_
         def client_exists(self):
             raise RuntimeError("boom")
 
-        async def discover_mcp_servers(self):
+        def discover_mcp_servers(self):
             return {}
 
         def discover_skills(self):

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -1,16 +1,16 @@
 """Tests for the per-agent discovery ABC (agent_discovery module)."""
 
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from agent_scan.models import (
     ClientToInspect,
+    CouldNotParseMCPConfig,
     SkillServer,
     StdioServer,
+    UnknownConfigFormat,
 )
-
 
 # --- ClaudeCodeDiscoverer: client_exists ---
 
@@ -44,9 +44,7 @@ async def test_claude_code_discoverer_parses_mcp_servers(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
-    (tmp_path / ".claude.json").write_text(
-        '{"mcpServers": {"my-server": {"command": "echo", "args": ["hi"]}}}'
-    )
+    (tmp_path / ".claude.json").write_text('{"mcpServers": {"my-server": {"command": "echo", "args": ["hi"]}}}')
 
     discoverer = ClaudeCodeDiscoverer()
     mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
@@ -61,6 +59,44 @@ async def test_claude_code_discoverer_parses_mcp_servers(tmp_path):
     assert name == "my-server"
     assert isinstance(server, StdioServer)
     assert server.command == "echo"
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_marks_unknown_config_format(tmp_path):
+    """Valid JSON that doesn't match any known MCP schema becomes UnknownConfigFormat."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    # Has an `mcp` field but in a shape no specific model accepts —
+    # scan_mcp_config_file returns UnknownMCPConfig, which the discoverer
+    # converts to UnknownConfigFormat.
+    (tmp_path / ".claude.json").write_text('{"mcp": {"foo": "bar"}}')
+
+    discoverer = ClaudeCodeDiscoverer()
+    mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
+
+    assert len(mcp_configs) == 1
+    entry = next(iter(mcp_configs.values()))
+    assert isinstance(entry, UnknownConfigFormat)
+    assert entry.is_failure is False
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_records_could_not_parse_on_invalid_json(tmp_path):
+    """Malformed JSON in ~/.claude.json becomes CouldNotParseMCPConfig with traceback."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text("{not valid json")
+
+    discoverer = ClaudeCodeDiscoverer()
+    mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
+
+    assert len(mcp_configs) == 1
+    entry = next(iter(mcp_configs.values()))
+    assert isinstance(entry, CouldNotParseMCPConfig)
+    assert entry.is_failure is True
+    assert entry.traceback
 
 
 @pytest.mark.asyncio
@@ -88,9 +124,7 @@ def test_claude_code_discoverer_parses_skills(tmp_path):
     skills_dir.mkdir(parents=True)
     my_skill = skills_dir / "my-skill"
     my_skill.mkdir()
-    (my_skill / "SKILL.md").write_text(
-        "---\nname: my-skill\ndescription: A test skill\n---\n\nBody.\n"
-    )
+    (my_skill / "SKILL.md").write_text("---\nname: my-skill\ndescription: A test skill\n---\n\nBody.\n")
 
     discoverer = ClaudeCodeDiscoverer()
     skills_dirs = discoverer.discover_skills(tmp_path)
@@ -126,14 +160,10 @@ async def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_p
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
-    (tmp_path / ".claude.json").write_text(
-        '{"mcpServers": {"toy": {"command": "echo", "args": []}}}'
-    )
+    (tmp_path / ".claude.json").write_text('{"mcpServers": {"toy": {"command": "echo", "args": []}}}')
     my_skill = tmp_path / ".claude" / "skills" / "demo"
     my_skill.mkdir(parents=True)
-    (my_skill / "SKILL.md").write_text(
-        "---\nname: demo\ndescription: Demo skill\n---\n\nBody.\n"
-    )
+    (my_skill / "SKILL.md").write_text("---\nname: demo\ndescription: Demo skill\n---\n\nBody.\n")
 
     discoverer = ClaudeCodeDiscoverer()
     cti = await discoverer.discover(tmp_path)
@@ -154,6 +184,26 @@ async def test_claude_code_discoverer_discover_returns_none_when_not_installed(t
     cti = await discoverer.discover(tmp_path)
 
     assert cti is None
+
+
+# --- ABC enforcement ---
+
+
+def test_agent_discoverer_subclass_without_name_raises():
+    """A subclass that forgets to set 'name' must fail at class-definition time."""
+    from agent_scan.agent_discovery import AgentDiscoverer
+
+    with pytest.raises(TypeError, match="must set a non-empty 'name'"):
+
+        class BrokenDiscoverer(AgentDiscoverer):
+            def client_exists(self, home_directory):
+                return None
+
+            async def discover_mcp_servers(self, home_directory):
+                return {}
+
+            def discover_skills(self, home_directory):
+                return {}
 
 
 # --- get_discoverer factory ---

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -893,97 +893,6 @@ def test_find_discoverers_returns_empty_when_no_agents_installed(tmp_path):
     assert found == []
 
 
-# --- _dedup_mcp_servers (load-bearing helper) ---
-
-
-def test_dedup_mcp_servers_keeps_each_server_in_latest_inserted_key():
-    """Server names appearing in multiple keys are retained only under the latest one."""
-    from agent_scan.pipelines import _dedup_mcp_servers
-
-    srv1_a = StdioServer(command="a")
-    srv1_b = StdioServer(command="b")
-    srv2 = StdioServer(command="c")
-    cti = ClientToInspect(
-        name="claude code",
-        client_path="/home/alice/.claude",
-        mcp_configs={
-            "/home/alice/.claude.json": [("srv1", srv1_a), ("srv2", srv2)],
-            "/work/repo": [("srv1", srv1_b)],
-        },
-        skills_dirs={},
-    )
-
-    _dedup_mcp_servers(cti)
-
-    assert cti.mcp_configs["/home/alice/.claude.json"] == [("srv2", srv2)]
-    assert cti.mcp_configs["/work/repo"] == [("srv1", srv1_b)]
-
-
-def test_dedup_mcp_servers_preserves_error_type_entries():
-    """Error-type values (e.g., CouldNotParseMCPConfig) are not modified by dedup."""
-    from agent_scan.pipelines import _dedup_mcp_servers
-
-    err = CouldNotParseMCPConfig(message="boom", traceback="tb", is_failure=True)
-    srv = StdioServer(command="x")
-    cti = ClientToInspect(
-        name="claude code",
-        client_path="/home/alice/.claude",
-        mcp_configs={
-            "/home/alice/.claude.json": err,
-            "/work/repo": [("srv", srv)],
-        },
-        skills_dirs={},
-    )
-
-    _dedup_mcp_servers(cti)
-
-    assert cti.mcp_configs["/home/alice/.claude.json"] is err
-    assert cti.mcp_configs["/work/repo"] == [("srv", srv)]
-
-
-def test_dedup_mcp_servers_drops_key_emptied_by_dedup():
-    """A key whose every server was shadowed by a later key is removed entirely."""
-    from agent_scan.pipelines import _dedup_mcp_servers
-
-    srv_legacy = StdioServer(command="legacy")
-    srv_abc = StdioServer(command="abc")
-    cti = ClientToInspect(
-        name="claude code",
-        client_path="/home/alice/.claude",
-        mcp_configs={
-            "/home/alice/.claude.json": [("srv", srv_legacy)],
-            "/work/repo": [("srv", srv_abc)],
-        },
-        skills_dirs={},
-    )
-
-    _dedup_mcp_servers(cti)
-
-    assert "/home/alice/.claude.json" not in cti.mcp_configs
-    assert cti.mcp_configs["/work/repo"] == [("srv", srv_abc)]
-
-
-def test_dedup_mcp_servers_preserves_originally_empty_lists():
-    """A list that was already empty before dedup is left in place (no servers were lost)."""
-    from agent_scan.pipelines import _dedup_mcp_servers
-
-    srv = StdioServer(command="x")
-    cti = ClientToInspect(
-        name="claude code",
-        client_path="/home/alice/.claude",
-        mcp_configs={
-            "/home/alice/.claude.json": [],
-            "/work/repo": [("srv", srv)],
-        },
-        skills_dirs={},
-    )
-
-    _dedup_mcp_servers(cti)
-
-    assert cti.mcp_configs["/home/alice/.claude.json"] == []
-    assert cti.mcp_configs["/work/repo"] == [("srv", srv)]
-
-
 # --- Pipeline dispatch: legacy for all + ABC merge phase ---
 
 
@@ -1024,8 +933,8 @@ async def test_discover_clients_to_inspect_runs_legacy_for_claude_code(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_discover_clients_to_inspect_merges_abc_into_legacy_cti_and_dedups_servers(tmp_path):
-    """One CTI per (name, username); legacy + ABC keys both present; servers deduped to latest key."""
+async def test_discover_clients_to_inspect_merges_abc_into_legacy_cti_keeping_both_keys(tmp_path):
+    """One CTI per (name, username); legacy and ABC keys for the same server both survive."""
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
@@ -1054,21 +963,78 @@ async def test_discover_clients_to_inspect_merges_abc_into_legacy_cti_and_dedups
     merged = claude_ctis[0]
 
     keys = list(merged.mcp_configs)
+    legacy_key = next(k for k in keys if k.endswith("/.claude.json"))
     abc_key = next(k for k in keys if k == "/work/repo")
-    # Legacy's ~/.claude.json key held only "srv", which dedup moved into the ABC
-    # per-project key. The now-empty legacy key is dropped (would otherwise display
-    # as "0 servers in ~/.claude.json").
-    assert not any(k.endswith("/.claude.json") for k in keys)
 
+    legacy_entries = merged.mcp_configs[legacy_key]
     abc_entries = merged.mcp_configs[abc_key]
+    assert isinstance(legacy_entries, list)
     assert isinstance(abc_entries, list)
-    # The single server "srv" survives only under the ABC's per-project key.
+    # Without by-name dedup, "srv" is preserved in both phases' keys. Each represents
+    # a distinct discovery source (legacy flattens projects.* into ~/.claude.json;
+    # ABC reports it under the project path) and downstream scanning treats each
+    # (key, name) pair on its own merits.
+    assert [name for name, _ in legacy_entries] == ["srv"]
     assert [name for name, _ in abc_entries] == ["srv"]
     assert all(isinstance(s, StdioServer) for _, s in abc_entries)
 
 
 @pytest.mark.asyncio
-async def test_discover_clients_to_inspect_dedup_keeps_global_only_servers_in_legacy_key(tmp_path):
+async def test_discover_clients_to_inspect_preserves_same_named_server_across_projects(tmp_path):
+    """Two projects each registering the same server name (different configs) both survive.
+
+    This is the canonical multi-project case (e.g. `github` configured per-repo with
+    different tokens). Treating same-name registrations as duplicates would silently
+    drop one project's config; we want each project's entry to reach the inspector.
+    """
+    from agent_scan.models import CandidateClient
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"projects": {'
+        '"/work/repo-a": {"mcpServers": {"github": {"command": "gh-mcp", "args": ["--token", "orgA"]}}},'
+        '"/work/repo-b": {"mcpServers": {"github": {"command": "gh-mcp", "args": ["--token", "orgB"]}}}'
+        "}}"
+    )
+
+    candidate = CandidateClient(
+        name="claude code",
+        client_exists_paths=["~/.claude"],
+        mcp_config_paths=["~/.claude.json"],
+        skills_dir_paths=["~/.claude/skills"],
+    )
+
+    with (
+        patch(
+            "agent_scan.pipelines.get_readable_home_directories",
+            return_value=[(tmp_path, "alice")],
+        ),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+    ):
+        args = InspectArgs(timeout=10, tokens=[], paths=[])
+        ctis, _, _ = await discover_clients_to_inspect(args)
+
+    claude_ctis = [c for c in ctis if c.name == "claude code"]
+    assert len(claude_ctis) == 1
+    cti = claude_ctis[0]
+
+    repo_a = cti.mcp_configs["/work/repo-a"]
+    repo_b = cti.mcp_configs["/work/repo-b"]
+    assert isinstance(repo_a, list)
+    assert isinstance(repo_b, list)
+    assert [name for name, _ in repo_a] == ["github"]
+    assert [name for name, _ in repo_b] == ["github"]
+
+    ((_, a_server),) = repo_a
+    ((_, b_server),) = repo_b
+    assert isinstance(a_server, StdioServer) and isinstance(b_server, StdioServer)
+    assert a_server.args == ["--token", "orgA"]
+    assert b_server.args == ["--token", "orgB"]
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_keeps_legacy_key_when_abc_adds_nothing(tmp_path):
     """When ABC produces no project entries, legacy's ~/.claude.json entry is untouched."""
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
@@ -1102,7 +1068,7 @@ async def test_discover_clients_to_inspect_dedup_keeps_global_only_servers_in_le
 
 @pytest.mark.asyncio
 async def test_discover_clients_to_inspect_abc_wins_on_same_key_collision(tmp_path):
-    """Both paths produce a ~/.claude.json key; ABC's value wins after merge+dedup."""
+    """Both paths produce a ~/.claude.json key; ABC's value wins via dict-union merge."""
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
@@ -1136,9 +1102,12 @@ async def test_discover_clients_to_inspect_abc_wins_on_same_key_collision(tmp_pa
     legacy_key = next(k for k in merged.mcp_configs if k.endswith("/.claude.json"))
     entries = merged.mcp_configs[legacy_key]
     assert isinstance(entries, list)
-    # After ABC's value overrides legacy under ~/.claude.json AND dedup moves "proj"
-    # into /work/repo, the legacy key retains only the global "top".
+    # Legacy stored "proj" under .claude.json (its ClaudeCodeConfigFile flattening
+    # of projects.*). ABC stored "top" under .claude.json (top-level mcpServers).
+    # Dict-union merge picks ABC's value on the colliding key, so .claude.json now
+    # holds only "top"; "proj" lives under ABC's /work/repo key.
     assert [name for name, _ in entries] == ["top"]
+    assert merged.mcp_configs["/work/repo"] == [("proj", merged.mcp_configs["/work/repo"][0][1])]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -602,6 +602,56 @@ def test_claude_code_discoverer_discover_skills_includes_plugin_skills(tmp_path)
     assert len(plugin_keys) == 1
 
 
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_plugin_mcp_servers_scans_repos_dir(tmp_path):
+    """Plugins staged under ~/.claude/plugins/repos/**/ are also discovered."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    repo_plugin = tmp_path / ".claude" / "plugins" / "repos" / "owner" / "plugin-repo"
+    repo_plugin.mkdir(parents=True)
+    (repo_plugin / ".mcp.json").write_text('{"repo-srv": {"command": "r"}}')
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    repos_keys = [k for k in mcp_configs if "/plugins/repos/" in k]
+    assert len(repos_keys) == 1
+    entries = mcp_configs[repos_keys[0]]
+    assert isinstance(entries, list) and entries[0][0] == "repo-srv"
+
+
+def test_claude_code_discoverer_plugin_skills_scans_repos_dir(tmp_path):
+    """Plugin skills staged under ~/.claude/plugins/repos/**/ are also discovered."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    skills_dir = tmp_path / ".claude" / "plugins" / "repos" / "owner" / "plugin" / "skills" / "rs"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\nname: rs\ndescription: r\n---\n\nB.\n")
+
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_skills()
+
+    repos_keys = [k for k in skills_dirs if "/plugins/repos/" in k]
+    assert len(repos_keys) == 1
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_repos(tmp_path):
+    """Both cache and repos contribute, keyed by their distinct file paths."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    cache_plugin = tmp_path / ".claude" / "plugins" / "cache" / "c" / "p"
+    cache_plugin.mkdir(parents=True)
+    (cache_plugin / ".mcp.json").write_text('{"c-srv": {"command": "c"}}')
+
+    repo_plugin = tmp_path / ".claude" / "plugins" / "repos" / "r" / "p"
+    repo_plugin.mkdir(parents=True)
+    (repo_plugin / ".mcp.json").write_text('{"r-srv": {"command": "r"}}')
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    assert any("/plugins/cache/" in k for k in mcp_configs)
+    assert any("/plugins/repos/" in k for k in mcp_configs)
+
+
 # --- ClaudeCodeDiscoverer: end-to-end discover() ---
 
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -19,8 +19,7 @@ def test_claude_code_discoverer_detects_installation(tmp_path):
 
     (tmp_path / ".claude").mkdir()
 
-    discoverer = ClaudeCodeDiscoverer()
-    result = discoverer.client_exists(tmp_path)
+    result = ClaudeCodeDiscoverer(tmp_path).client_exists()
 
     assert result is not None
     assert result.endswith("/.claude")
@@ -29,8 +28,7 @@ def test_claude_code_discoverer_detects_installation(tmp_path):
 def test_claude_code_discoverer_returns_none_when_absent(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
-    discoverer = ClaudeCodeDiscoverer()
-    result = discoverer.client_exists(tmp_path)
+    result = ClaudeCodeDiscoverer(tmp_path).client_exists()
 
     assert result is None
 
@@ -45,8 +43,7 @@ async def test_claude_code_discoverer_parses_mcp_servers(tmp_path):
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text('{"mcpServers": {"my-server": {"command": "echo", "args": ["hi"]}}}')
 
-    discoverer = ClaudeCodeDiscoverer()
-    mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     assert len(mcp_configs) == 1
     config_path = next(iter(mcp_configs))
@@ -68,8 +65,7 @@ async def test_claude_code_discoverer_returns_empty_when_json_has_no_mcp_fields(
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text('{"unrelated": "data"}')
 
-    discoverer = ClaudeCodeDiscoverer()
-    mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     assert mcp_configs == {}
 
@@ -82,8 +78,7 @@ async def test_claude_code_discoverer_records_could_not_parse_on_invalid_json(tm
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text("{not valid json")
 
-    discoverer = ClaudeCodeDiscoverer()
-    mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     assert len(mcp_configs) == 1
     entry = next(iter(mcp_configs.values()))
@@ -99,8 +94,7 @@ async def test_claude_code_discoverer_returns_empty_when_mcp_config_missing(tmp_
     (tmp_path / ".claude").mkdir()
     # no ~/.claude.json on disk
 
-    discoverer = ClaudeCodeDiscoverer()
-    mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     # Missing config files are silently skipped (matches legacy behavior when
     # create_file_not_found_error=False).
@@ -119,8 +113,7 @@ def test_claude_code_discoverer_parses_skills(tmp_path):
     my_skill.mkdir()
     (my_skill / "SKILL.md").write_text("---\nname: my-skill\ndescription: A test skill\n---\n\nBody.\n")
 
-    discoverer = ClaudeCodeDiscoverer()
-    skills_dirs = discoverer.discover_skills(tmp_path)
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path).discover_skills()
 
     assert len(skills_dirs) == 1
     dir_path = next(iter(skills_dirs))
@@ -139,8 +132,7 @@ def test_claude_code_discoverer_skills_returns_empty_when_dir_missing(tmp_path):
     (tmp_path / ".claude").mkdir()
     # no ~/.claude/skills on disk
 
-    discoverer = ClaudeCodeDiscoverer()
-    skills_dirs = discoverer.discover_skills(tmp_path)
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path).discover_skills()
 
     assert skills_dirs == {}
 
@@ -151,7 +143,7 @@ def test_claude_code_discoverer_skills_returns_empty_when_dir_missing(tmp_path):
 def test_claude_code_discoverer_global_folders_returns_claude_dir(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
-    folders = ClaudeCodeDiscoverer()._discover_global_folders(tmp_path)
+    folders = ClaudeCodeDiscoverer(tmp_path)._discover_global_folders()
 
     assert len(folders) == 1
     assert folders[0].as_posix().endswith("/.claude")
@@ -165,7 +157,7 @@ def test_claude_code_discoverer_project_folders_lists_project_paths(tmp_path):
         '{"projects": {"/Users/alice/repo-a": {"mcpServers": {}}, "/Users/alice/repo-b": {"mcpServers": {}}}}'
     )
 
-    folders = ClaudeCodeDiscoverer()._discover_project_folders(tmp_path)
+    folders = ClaudeCodeDiscoverer(tmp_path)._discover_project_folders()
 
     folder_strs = {f.as_posix() for f in folders}
     assert folder_strs == {"/Users/alice/repo-a", "/Users/alice/repo-b"}
@@ -177,7 +169,7 @@ def test_claude_code_discoverer_project_folders_empty_when_no_projects_key(tmp_p
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text('{"mcpServers": {}}')
 
-    folders = ClaudeCodeDiscoverer()._discover_project_folders(tmp_path)
+    folders = ClaudeCodeDiscoverer(tmp_path)._discover_project_folders()
 
     assert folders == []
 
@@ -185,7 +177,7 @@ def test_claude_code_discoverer_project_folders_empty_when_no_projects_key(tmp_p
 def test_claude_code_discoverer_project_folders_empty_when_config_missing(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
-    folders = ClaudeCodeDiscoverer()._discover_project_folders(tmp_path)
+    folders = ClaudeCodeDiscoverer(tmp_path)._discover_project_folders()
 
     assert folders == []
 
@@ -206,7 +198,7 @@ async def test_claude_code_discoverer_parses_project_mcp_servers(tmp_path):
         "}}"
     )
 
-    mcp_configs = await ClaudeCodeDiscoverer()._discover_project_mcp_servers(tmp_path)
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
 
     assert set(mcp_configs) == {"/work/repo-a", "/work/repo-b"}
     entries_a = mcp_configs["/work/repo-a"]
@@ -230,7 +222,7 @@ async def test_claude_code_discoverer_project_mcp_servers_skips_projects_without
         "}}"
     )
 
-    mcp_configs = await ClaudeCodeDiscoverer()._discover_project_mcp_servers(tmp_path)
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
 
     assert set(mcp_configs) == {"/work/with-servers"}
 
@@ -246,11 +238,10 @@ async def test_claude_code_discoverer_discover_mcp_servers_combines_global_and_p
         '"projects": {"/work/repo": {"mcpServers": {"proj-srv": {"command": "p"}}}}}'
     )
 
-    mcp_configs = await ClaudeCodeDiscoverer().discover_mcp_servers(tmp_path)
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     # Two keys: one for the global file path, one for the project path.
     assert len(mcp_configs) == 2
-    # Find the global entry by key suffix
     global_keys = [k for k in mcp_configs if k.endswith("/.claude.json")]
     project_keys = [k for k in mcp_configs if k == "/work/repo"]
     assert len(global_keys) == 1 and len(project_keys) == 1
@@ -275,7 +266,7 @@ def test_claude_code_discoverer_project_skills_scans_per_project_dotclaude(tmp_p
     )
     (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
 
-    skills_dirs = ClaudeCodeDiscoverer()._discover_project_skills(tmp_path)
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_project_skills()
 
     assert len(skills_dirs) == 1
     key = next(iter(skills_dirs))
@@ -294,7 +285,7 @@ def test_claude_code_discoverer_project_skills_skips_missing_project_folders(tmp
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text('{"projects": {"/nonexistent/path/that/wont/be/here": {"mcpServers": {}}}}')
 
-    skills_dirs = ClaudeCodeDiscoverer()._discover_project_skills(tmp_path)
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_project_skills()
 
     assert skills_dirs == {}
 
@@ -314,7 +305,7 @@ def test_claude_code_discoverer_discover_skills_combines_global_and_project(tmp_
     )
     (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
 
-    skills_dirs = ClaudeCodeDiscoverer().discover_skills(tmp_path)
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path).discover_skills()
 
     assert len(skills_dirs) == 2  # one global, one project
 
@@ -332,8 +323,7 @@ async def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_p
     my_skill.mkdir(parents=True)
     (my_skill / "SKILL.md").write_text("---\nname: demo\ndescription: Demo skill\n---\n\nBody.\n")
 
-    discoverer = ClaudeCodeDiscoverer()
-    cti = await discoverer.discover(tmp_path)
+    cti = await ClaudeCodeDiscoverer(tmp_path).discover()
 
     assert cti is not None
     assert isinstance(cti, ClientToInspect)
@@ -347,8 +337,7 @@ async def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_p
 async def test_claude_code_discoverer_discover_returns_none_when_not_installed(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
-    discoverer = ClaudeCodeDiscoverer()
-    cti = await discoverer.discover(tmp_path)
+    cti = await ClaudeCodeDiscoverer(tmp_path).discover()
 
     assert cti is None
 
@@ -363,35 +352,35 @@ def test_agent_discoverer_subclass_without_name_raises():
     with pytest.raises(TypeError, match="must set a non-empty 'name'"):
 
         class BrokenDiscoverer(AgentDiscoverer):
-            def client_exists(self, home_directory):
+            def client_exists(self):
                 return None
 
-            async def discover_mcp_servers(self, home_directory):
+            async def discover_mcp_servers(self):
                 return {}
 
-            def discover_skills(self, home_directory):
+            def discover_skills(self):
                 return {}
 
 
-# --- get_discoverer factory ---
+# --- get_discoverer_class factory ---
 
 
-def test_get_discoverer_returns_claude_code_discoverer():
-    from agent_scan.agent_discovery import ClaudeCodeDiscoverer, get_discoverer
+def test_get_discoverer_class_returns_claude_code_class():
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer, get_discoverer_class
 
-    discoverer = get_discoverer("claude code")
-    assert isinstance(discoverer, ClaudeCodeDiscoverer)
+    cls = get_discoverer_class("claude code")
+    assert cls is ClaudeCodeDiscoverer
 
 
 @pytest.mark.parametrize(
     "agent_name",
     ["cursor", "vscode", "windsurf", "claude", "codex", "gemini cli", "amp", "kiro"],
 )
-def test_get_discoverer_raises_not_implemented_for_unregistered_agent(agent_name):
-    from agent_scan.agent_discovery import get_discoverer
+def test_get_discoverer_class_raises_not_implemented_for_unregistered_agent(agent_name):
+    from agent_scan.agent_discovery import get_discoverer_class
 
     with pytest.raises(NotImplementedError):
-        get_discoverer(agent_name)
+        get_discoverer_class(agent_name)
 
 
 # --- Pipeline dispatch: ABC for Claude Code, legacy for everything else ---
@@ -399,7 +388,7 @@ def test_get_discoverer_raises_not_implemented_for_unregistered_agent(agent_name
 
 @pytest.mark.asyncio
 async def test_discover_clients_to_inspect_uses_abc_for_claude_code(tmp_path):
-    """Claude Code should be discovered via ClaudeCodeDiscoverer.discover, not the legacy path."""
+    """Claude Code should be discovered via ClaudeCodeDiscoverer, not the legacy path."""
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
@@ -428,6 +417,42 @@ async def test_discover_clients_to_inspect_uses_abc_for_claude_code(tmp_path):
     assert len(ctis) == 1
     assert ctis[0].name == "claude code"
     assert ctis[0].username == "alice"
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_iterates_all_home_dirs_for_claude_code(tmp_path):
+    """With multiple home dirs, the dispatcher constructs one discoverer per user."""
+    from agent_scan.models import CandidateClient
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    alice_home = tmp_path / "alice"
+    bob_home = tmp_path / "bob"
+    (alice_home / ".claude").mkdir(parents=True)
+    (alice_home / ".claude.json").write_text('{"mcpServers": {}}')
+    (bob_home / ".claude").mkdir(parents=True)
+    (bob_home / ".claude.json").write_text('{"mcpServers": {}}')
+
+    candidate = CandidateClient(
+        name="claude code",
+        client_exists_paths=["~/.claude"],
+        mcp_config_paths=["~/.claude.json"],
+        skills_dir_paths=["~/.claude/skills"],
+    )
+
+    with (
+        patch(
+            "agent_scan.pipelines.get_readable_home_directories",
+            return_value=[(alice_home, "alice"), (bob_home, "bob")],
+        ),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+    ):
+        args = InspectArgs(timeout=10, tokens=[], paths=[], all_users=True)
+        ctis, _, _ = await discover_clients_to_inspect(args)
+
+    usernames = sorted(cti.username for cti in ctis)
+    assert usernames == ["alice", "bob"]
+    for cti in ctis:
+        assert cti.name == "claude code"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -36,14 +36,13 @@ def test_claude_code_discoverer_returns_none_when_absent(tmp_path):
 # --- ClaudeCodeDiscoverer: discover_mcp_servers ---
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_parses_mcp_servers(tmp_path):
+def test_claude_code_discoverer_parses_mcp_servers(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text('{"mcpServers": {"my-server": {"command": "echo", "args": ["hi"]}}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     assert len(mcp_configs) == 1
     config_path = next(iter(mcp_configs))
@@ -57,28 +56,26 @@ async def test_claude_code_discoverer_parses_mcp_servers(tmp_path):
     assert server.command == "echo"
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_returns_empty_when_json_has_no_mcp_fields(tmp_path):
+def test_claude_code_discoverer_returns_empty_when_json_has_no_mcp_fields(tmp_path):
     """JSON without top-level mcpServers and without projects returns no entries."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text('{"unrelated": "data"}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     assert mcp_configs == {}
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_records_could_not_parse_on_invalid_json(tmp_path):
+def test_claude_code_discoverer_records_could_not_parse_on_invalid_json(tmp_path):
     """Malformed JSON in ~/.claude.json becomes CouldNotParseMCPConfig with traceback."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text("{not valid json")
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     assert len(mcp_configs) == 1
     entry = next(iter(mcp_configs.values()))
@@ -87,14 +84,13 @@ async def test_claude_code_discoverer_records_could_not_parse_on_invalid_json(tm
     assert entry.traceback
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_returns_empty_when_mcp_config_missing(tmp_path):
+def test_claude_code_discoverer_returns_empty_when_mcp_config_missing(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
     # no ~/.claude.json on disk
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     # Missing config files are silently skipped (matches legacy behavior when
     # create_file_not_found_error=False).
@@ -305,8 +301,7 @@ def test_claude_code_discoverer_project_skills_dedups_shared_ancestor_skills(tmp
 # --- ClaudeCodeDiscoverer: project MCP servers ---
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_parses_project_mcp_servers(tmp_path):
+def test_claude_code_discoverer_parses_project_mcp_servers(tmp_path):
     """Each project's mcpServers becomes its own entry keyed by the project path."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -318,7 +313,7 @@ async def test_claude_code_discoverer_parses_project_mcp_servers(tmp_path):
         "}}"
     )
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
 
     assert set(mcp_configs) == {"/work/repo-a", "/work/repo-b"}
     entries_a = mcp_configs["/work/repo-a"]
@@ -328,8 +323,7 @@ async def test_claude_code_discoverer_parses_project_mcp_servers(tmp_path):
     assert isinstance(server_a, StdioServer)
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_project_mcp_servers_skips_projects_without_mcp(tmp_path):
+def test_claude_code_discoverer_project_mcp_servers_skips_projects_without_mcp(tmp_path):
     """Projects with no mcpServers key (or empty) don't produce entries."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -342,13 +336,12 @@ async def test_claude_code_discoverer_project_mcp_servers_skips_projects_without
         "}}"
     )
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
 
     assert set(mcp_configs) == {"/work/with-servers"}
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_project_mcp_servers_reads_dotmcp_file(tmp_path):
+def test_claude_code_discoverer_project_mcp_servers_reads_dotmcp_file(tmp_path):
     """A <project>/.mcp.json file is parsed as an additional MCP source for that project."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -358,7 +351,7 @@ async def test_claude_code_discoverer_project_mcp_servers_reads_dotmcp_file(tmp_
     (project_root / ".mcp.json").write_text('{"mcpServers": {"file-srv": {"command": "f"}}}')
     (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
 
     file_keys = [k for k in mcp_configs if k.endswith("/repo/.mcp.json")]
     assert len(file_keys) == 1
@@ -369,8 +362,7 @@ async def test_claude_code_discoverer_project_mcp_servers_reads_dotmcp_file(tmp_
     assert isinstance(server, StdioServer)
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_project_mcp_servers_reads_ancestor_dotmcp(tmp_path):
+def test_claude_code_discoverer_project_mcp_servers_reads_ancestor_dotmcp(tmp_path):
     """A <ancestor>/.mcp.json is also discovered while walking up from a project."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -380,7 +372,7 @@ async def test_claude_code_discoverer_project_mcp_servers_reads_ancestor_dotmcp(
     (tmp_path / "work" / ".mcp.json").write_text('{"mcpServers": {"anc-srv": {"command": "a"}}}')
     (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
 
     file_keys = [k for k in mcp_configs if k.endswith("/work/.mcp.json")]
     assert len(file_keys) == 1
@@ -388,8 +380,7 @@ async def test_claude_code_discoverer_project_mcp_servers_reads_ancestor_dotmcp(
     assert isinstance(entries, list) and entries[0][0] == "anc-srv"
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_project_mcp_servers_records_could_not_parse_for_dotmcp(tmp_path):
+def test_claude_code_discoverer_project_mcp_servers_records_could_not_parse_for_dotmcp(tmp_path):
     """A malformed <project>/.mcp.json becomes a CouldNotParseMCPConfig entry."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -399,7 +390,7 @@ async def test_claude_code_discoverer_project_mcp_servers_records_could_not_pars
     (project_root / ".mcp.json").write_text("{not valid json")
     (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
 
     file_keys = [k for k in mcp_configs if k.endswith("/.mcp.json")]
     assert len(file_keys) == 1
@@ -409,8 +400,57 @@ async def test_claude_code_discoverer_project_mcp_servers_records_could_not_pars
     assert entry.traceback
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_discover_mcp_servers_combines_global_and_project(tmp_path):
+def test_claude_code_discoverer_project_mcp_servers_reads_flat_format_dotmcp(tmp_path):
+    """A flat-format ``<project>/.mcp.json`` is also parsed via _select_servers_payload.
+
+    Previously a flat-format project file was silently dropped (no top-level
+    "mcpServers" key). The shared payload selector now recognises it.
+    """
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    project_root = tmp_path / "work" / "repo"
+    project_root.mkdir(parents=True)
+    (project_root / ".mcp.json").write_text('{"flat-srv": {"command": "echo", "args": ["f"]}}')
+    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+
+    file_keys = [k for k in mcp_configs if k.endswith("/.mcp.json")]
+    assert len(file_keys) == 1
+    entries = mcp_configs[file_keys[0]]
+    assert isinstance(entries, list) and len(entries) == 1
+    name, server = entries[0]
+    assert name == "flat-srv"
+    assert isinstance(server, StdioServer)
+    assert server.command == "echo"
+
+
+def test_claude_code_discoverer_project_mcp_servers_flat_dotmcp_with_server_named_mcpServers(tmp_path):
+    """A flat-format ``<project>/.mcp.json`` whose single server is literally named
+    "mcpServers" is parsed as flat (not misread as a wrapped payload)."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    project_root = tmp_path / "work" / "repo"
+    project_root.mkdir(parents=True)
+    (project_root / ".mcp.json").write_text('{"mcpServers": {"command": "echo", "args": ["adv"]}}')
+    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+
+    file_keys = [k for k in mcp_configs if k.endswith("/.mcp.json")]
+    assert len(file_keys) == 1
+    entries = mcp_configs[file_keys[0]]
+    assert isinstance(entries, list) and len(entries) == 1
+    name, server = entries[0]
+    assert name == "mcpServers"
+    assert isinstance(server, StdioServer)
+    assert server.command == "echo"
+    assert server.args == ["adv"]
+
+
+def test_claude_code_discoverer_discover_mcp_servers_combines_global_and_project(tmp_path):
     """The public discover_mcp_servers merges global + project results."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -420,7 +460,7 @@ async def test_claude_code_discoverer_discover_mcp_servers_combines_global_and_p
         '"projects": {"/work/repo": {"mcpServers": {"proj-srv": {"command": "p"}}}}}'
     )
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     # Two keys: one for the global file path, one for the project path.
     assert len(mcp_configs) == 2
@@ -495,8 +535,7 @@ def test_claude_code_discoverer_discover_skills_combines_global_and_project(tmp_
 # --- ClaudeCodeDiscoverer: plugin MCP + skills ---
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_plugin_mcp_servers_parses_flat_format(tmp_path):
+def test_claude_code_discoverer_plugin_mcp_servers_parses_flat_format(tmp_path):
     """Plugin .mcp.json files use the flat {name: serverConfig} format."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -504,7 +543,7 @@ async def test_claude_code_discoverer_plugin_mcp_servers_parses_flat_format(tmp_
     plugin_dir.mkdir(parents=True)
     (plugin_dir / ".mcp.json").write_text('{"plugin-srv": {"command": "echo", "args": ["p"]}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
 
     assert len(mcp_configs) == 1
     key = next(iter(mcp_configs))
@@ -516,26 +555,96 @@ async def test_claude_code_discoverer_plugin_mcp_servers_parses_flat_format(tmp_
     assert isinstance(server, StdioServer)
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_plugin_mcp_servers_empty_when_cache_missing(tmp_path):
+def test_claude_code_discoverer_plugin_mcp_flat_format_with_server_named_mcpServers(tmp_path):
+    """Flat-format plugin where the single server is literally named "mcpServers".
+
+    The wrapper-vs-flat detector inspects the inner dict's keys: a wrapped
+    payload's value is a server *map* and won't contain server-config keys
+    (``command``/``url``/``serverUrl``), while a flat-format payload here has
+    ``command`` at the top level of the inner dict. We must take the flat
+    interpretation and produce a single server named "mcpServers".
+    """
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    plugin_dir = tmp_path / ".claude" / "plugins" / "cache" / "vendor" / "weird-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".mcp.json").write_text('{"mcpServers": {"command": "echo", "args": ["x"]}}')
+
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entries = next(iter(mcp_configs.values()))
+    assert isinstance(entries, list) and len(entries) == 1
+    name, server = entries[0]
+    assert name == "mcpServers"
+    assert isinstance(server, StdioServer)
+    assert server.command == "echo"
+    assert server.args == ["x"]
+
+
+def test_claude_code_discoverer_plugin_mcp_wrapped_format_still_works(tmp_path):
+    """The wrapped format ``{"mcpServers": {<name>: <server-config>}}`` still parses
+    correctly — i.e., the detection didn't break the common case."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    plugin_dir = tmp_path / ".claude" / "plugins" / "cache" / "vendor" / "wrapped-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".mcp.json").write_text('{"mcpServers": {"real-srv": {"command": "echo", "args": ["w"]}}}')
+
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entries = next(iter(mcp_configs.values()))
+    assert isinstance(entries, list) and len(entries) == 1
+    name, server = entries[0]
+    assert name == "real-srv"
+    assert isinstance(server, StdioServer)
+    assert server.command == "echo"
+
+
+def test_select_servers_payload_flat_remote_server_named_mcpServers():
+    """A flat-format payload with a single RemoteServer named "mcpServers"
+    (``url`` discriminator instead of ``command``) is also detected as flat."""
+    from agent_scan.agent_discovery import _select_servers_payload
+
+    file_data = {"mcpServers": {"url": "https://example.com/mcp", "type": "http"}}
+
+    payload = _select_servers_payload(file_data)
+
+    # Whole file returned (flat); the inner dict is the RemoteServer config.
+    assert payload is file_data
+
+
+def test_select_servers_payload_wrapped_when_inner_has_no_discriminators():
+    """When file_data["mcpServers"] has no server-config discriminator keys at its
+    top level, it's a server map → wrapped."""
+    from agent_scan.agent_discovery import _select_servers_payload
+
+    file_data = {"mcpServers": {"srv-a": {"command": "a"}, "srv-b": {"url": "https://b"}}}
+
+    payload = _select_servers_payload(file_data)
+
+    assert payload is file_data["mcpServers"]
+
+
+def test_claude_code_discoverer_plugin_mcp_servers_empty_when_cache_missing(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
 
     assert mcp_configs == {}
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_plugin_mcp_records_could_not_parse(tmp_path):
+def test_claude_code_discoverer_plugin_mcp_records_could_not_parse(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     plugin_dir = tmp_path / ".claude" / "plugins" / "cache" / "bad" / "plugin"
     plugin_dir.mkdir(parents=True)
     (plugin_dir / ".mcp.json").write_text("{not valid json")
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
 
     assert len(mcp_configs) == 1
     entry = next(iter(mcp_configs.values()))
@@ -572,8 +681,7 @@ def test_claude_code_discoverer_plugin_skills_empty_when_cache_missing(tmp_path)
     assert skills_dirs == {}
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_discover_mcp_includes_plugin_servers(tmp_path):
+def test_claude_code_discoverer_discover_mcp_includes_plugin_servers(tmp_path):
     """Plugin MCP entries flow through public discover_mcp_servers."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -582,7 +690,7 @@ async def test_claude_code_discoverer_discover_mcp_includes_plugin_servers(tmp_p
     plugin_dir.mkdir(parents=True)
     (plugin_dir / ".mcp.json").write_text('{"plug": {"command": "x"}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     plugin_keys = [k for k in mcp_configs if k.endswith("/p/.mcp.json")]
     assert len(plugin_keys) == 1
@@ -602,8 +710,7 @@ def test_claude_code_discoverer_discover_skills_includes_plugin_skills(tmp_path)
     assert len(plugin_keys) == 1
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_plugin_mcp_servers_scans_repos_dir(tmp_path):
+def test_claude_code_discoverer_plugin_mcp_servers_scans_repos_dir(tmp_path):
     """Plugins staged under ~/.claude/plugins/repos/**/ are also discovered."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -611,7 +718,7 @@ async def test_claude_code_discoverer_plugin_mcp_servers_scans_repos_dir(tmp_pat
     repo_plugin.mkdir(parents=True)
     (repo_plugin / ".mcp.json").write_text('{"repo-srv": {"command": "r"}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
 
     repos_keys = [k for k in mcp_configs if "/plugins/repos/" in k]
     assert len(repos_keys) == 1
@@ -633,8 +740,7 @@ def test_claude_code_discoverer_plugin_skills_scans_repos_dir(tmp_path):
     assert len(repos_keys) == 1
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_repos(tmp_path):
+def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_repos(tmp_path):
     """Both cache and repos contribute, keyed by their distinct file paths."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -646,7 +752,7 @@ async def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_re
     repo_plugin.mkdir(parents=True)
     (repo_plugin / ".mcp.json").write_text('{"r-srv": {"command": "r"}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
 
     assert any("/plugins/cache/" in k for k in mcp_configs)
     assert any("/plugins/repos/" in k for k in mcp_configs)
@@ -655,8 +761,7 @@ async def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_re
 # --- ClaudeCodeDiscoverer: end-to-end discover() ---
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_path):
+def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
@@ -665,7 +770,7 @@ async def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_p
     my_skill.mkdir(parents=True)
     (my_skill / "SKILL.md").write_text("---\nname: demo\ndescription: Demo skill\n---\n\nBody.\n")
 
-    cti = await ClaudeCodeDiscoverer(tmp_path).discover()
+    cti = ClaudeCodeDiscoverer(tmp_path).discover()
 
     assert cti is not None
     assert isinstance(cti, ClientToInspect)
@@ -675,11 +780,10 @@ async def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_p
     assert len(cti.skills_dirs) == 1
 
 
-@pytest.mark.asyncio
-async def test_claude_code_discoverer_discover_returns_none_when_not_installed(tmp_path):
+def test_claude_code_discoverer_discover_returns_none_when_not_installed(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
-    cti = await ClaudeCodeDiscoverer(tmp_path).discover()
+    cti = ClaudeCodeDiscoverer(tmp_path).discover()
 
     assert cti is None
 
@@ -973,8 +1077,7 @@ async def test_discover_clients_to_inspect_falls_back_to_legacy_for_non_claude(t
 # --- Plugin discovery depth cap ---
 
 
-@pytest.mark.asyncio
-async def test_plugin_mcp_servers_respects_max_depth_cap(tmp_path):
+def test_plugin_mcp_servers_respects_max_depth_cap(tmp_path):
     """Plugin .mcp.json files deeper than _MAX_PLUGIN_RGLOB_DEPTH are not discovered.
 
     Depth is counted as ``len(match.relative_to(base).parts)`` where ``base``
@@ -992,7 +1095,7 @@ async def test_plugin_mcp_servers_respects_max_depth_cap(tmp_path):
     too_deep_dir.mkdir(parents=True)
     (too_deep_dir / ".mcp.json").write_text('{"too-deep-srv": {"command": "x"}}')
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
 
     server_names = {name for entries in mcp_configs.values() if isinstance(entries, list) for name, _ in entries}
     assert "allowed-srv" in server_names
@@ -1024,8 +1127,7 @@ def test_plugin_skills_respects_max_depth_cap(tmp_path):
 # --- JSON5 parsing (comments + empty-file short-circuit) ---
 
 
-@pytest.mark.asyncio
-async def test_load_json_file_accepts_json5_comments_and_trailing_commas(tmp_path):
+def test_load_json_file_accepts_json5_comments_and_trailing_commas(tmp_path):
     """A ~/.claude.json with // comments and a trailing comma parses successfully."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
@@ -1039,7 +1141,7 @@ async def test_load_json_file_accepts_json5_comments_and_trailing_commas(tmp_pat
         "}\n"
     )
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     assert len(mcp_configs) == 1
     entries = next(iter(mcp_configs.values()))
@@ -1047,15 +1149,14 @@ async def test_load_json_file_accepts_json5_comments_and_trailing_commas(tmp_pat
     assert [name for name, _ in entries] == ["my-server"]
 
 
-@pytest.mark.asyncio
-async def test_load_json_file_treats_empty_file_as_empty_config(tmp_path):
+def test_load_json_file_treats_empty_file_as_empty_config(tmp_path):
     """An empty (or whitespace-only) ~/.claude.json returns no entries, not a parse error."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".claude.json").write_text("   \n  \n")
 
-    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     assert mcp_configs == {}
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -182,6 +182,126 @@ def test_claude_code_discoverer_project_folders_empty_when_config_missing(tmp_pa
     assert folders == []
 
 
+# --- ClaudeCodeDiscoverer: _project_paths_with_ancestors ---
+
+
+def test_project_paths_with_ancestors_empty_when_no_projects(tmp_path):
+    """No projects listed in ~/.claude.json → empty list."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"projects": {}}')
+
+    paths = ClaudeCodeDiscoverer(tmp_path)._project_paths_with_ancestors()
+
+    assert paths == []
+
+
+def test_project_paths_with_ancestors_walks_up_to_filesystem_root(tmp_path):
+    """A single project fans out into itself + every ancestor up to '/'."""
+    from pathlib import Path
+
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"projects": {"/a/b/c/d": {"mcpServers": {}}}}')
+
+    paths = set(ClaudeCodeDiscoverer(tmp_path)._project_paths_with_ancestors())
+
+    assert Path("/a/b/c/d") in paths
+    assert Path("/a/b/c") in paths
+    assert Path("/a/b") in paths
+    assert Path("/a") in paths
+    assert Path("/") in paths
+
+
+def test_project_paths_with_ancestors_dedups_shared_ancestors(tmp_path):
+    """Two sibling projects sharing ancestors yield each ancestor only once."""
+    from pathlib import Path
+
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"projects": {"/a/b/c/d": {"mcpServers": {}}, "/a/b/x/y": {"mcpServers": {}}}}'
+    )
+
+    paths = ClaudeCodeDiscoverer(tmp_path)._project_paths_with_ancestors()
+
+    assert len(paths) == len(set(paths))  # no duplicates
+    as_set = set(paths)
+    assert {
+        Path("/a/b/c/d"),
+        Path("/a/b/c"),
+        Path("/a/b/x/y"),
+        Path("/a/b/x"),
+        Path("/a/b"),
+        Path("/a"),
+        Path("/"),
+    } <= as_set
+
+
+def test_project_paths_with_ancestors_terminates_at_root(tmp_path):
+    """Walk terminates at filesystem root (no infinite loop)."""
+    from pathlib import Path
+
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"projects": {"/": {"mcpServers": {}}}}')
+
+    paths = ClaudeCodeDiscoverer(tmp_path)._project_paths_with_ancestors()
+
+    assert paths == [Path("/")]
+
+
+# --- ClaudeCodeDiscoverer: skill discovery walks ancestors ---
+
+
+def test_claude_code_discoverer_project_skills_walks_ancestors(tmp_path):
+    """An ancestor of a project with a .claude/skills dir is also scanned."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    project_root = tmp_path / "work" / "repo"
+    project_root.mkdir(parents=True)
+    # skills live at the *parent* of the project root, not the project itself
+    ancestor_skills = tmp_path / "work" / ".claude" / "skills" / "ancestor-skill"
+    ancestor_skills.mkdir(parents=True)
+    (ancestor_skills / "SKILL.md").write_text(
+        "---\nname: ancestor-skill\ndescription: An ancestor skill\n---\n\nBody.\n"
+    )
+    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_project_skills()
+
+    keys = list(skills_dirs)
+    assert any(k.endswith("/work/.claude/skills") for k in keys)
+
+
+def test_claude_code_discoverer_project_skills_dedups_shared_ancestor_skills(tmp_path):
+    """Two sibling projects whose shared ancestor has skills produce a single entry."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    repo_a = tmp_path / "work" / "repo-a"
+    repo_b = tmp_path / "work" / "repo-b"
+    repo_a.mkdir(parents=True)
+    repo_b.mkdir(parents=True)
+    shared_skill = tmp_path / "work" / ".claude" / "skills" / "shared"
+    shared_skill.mkdir(parents=True)
+    (shared_skill / "SKILL.md").write_text("---\nname: shared\ndescription: s\n---\n\nB.\n")
+    (tmp_path / ".claude.json").write_text(
+        f'{{"projects": {{"{repo_a.as_posix()}": {{"mcpServers": {{}}}}, '
+        f'"{repo_b.as_posix()}": {{"mcpServers": {{}}}}}}}}'
+    )
+
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_project_skills()
+
+    shared_keys = [k for k in skills_dirs if k.endswith("/work/.claude/skills")]
+    assert len(shared_keys) == 1
+
+
 # --- ClaudeCodeDiscoverer: project MCP servers ---
 
 
@@ -225,6 +345,68 @@ async def test_claude_code_discoverer_project_mcp_servers_skips_projects_without
     mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
 
     assert set(mcp_configs) == {"/work/with-servers"}
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_project_mcp_servers_reads_dotmcp_file(tmp_path):
+    """A <project>/.mcp.json file is parsed as an additional MCP source for that project."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    project_root = tmp_path / "work" / "repo"
+    project_root.mkdir(parents=True)
+    (project_root / ".mcp.json").write_text('{"mcpServers": {"file-srv": {"command": "f"}}}')
+    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+
+    file_keys = [k for k in mcp_configs if k.endswith("/repo/.mcp.json")]
+    assert len(file_keys) == 1
+    entries = mcp_configs[file_keys[0]]
+    assert isinstance(entries, list) and len(entries) == 1
+    name, server = entries[0]
+    assert name == "file-srv"
+    assert isinstance(server, StdioServer)
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_project_mcp_servers_reads_ancestor_dotmcp(tmp_path):
+    """A <ancestor>/.mcp.json is also discovered while walking up from a project."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    project_root = tmp_path / "work" / "repo"
+    project_root.mkdir(parents=True)
+    (tmp_path / "work" / ".mcp.json").write_text('{"mcpServers": {"anc-srv": {"command": "a"}}}')
+    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+
+    file_keys = [k for k in mcp_configs if k.endswith("/work/.mcp.json")]
+    assert len(file_keys) == 1
+    entries = mcp_configs[file_keys[0]]
+    assert isinstance(entries, list) and entries[0][0] == "anc-srv"
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_project_mcp_servers_records_could_not_parse_for_dotmcp(tmp_path):
+    """A malformed <project>/.mcp.json becomes a CouldNotParseMCPConfig entry."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    project_root = tmp_path / "work" / "repo"
+    project_root.mkdir(parents=True)
+    (project_root / ".mcp.json").write_text("{not valid json")
+    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_project_mcp_servers()
+
+    file_keys = [k for k in mcp_configs if k.endswith("/.mcp.json")]
+    assert len(file_keys) == 1
+    entry = mcp_configs[file_keys[0]]
+    assert isinstance(entry, CouldNotParseMCPConfig)
+    assert entry.is_failure is True
+    assert entry.traceback
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -627,6 +627,62 @@ def test_select_servers_payload_wrapped_when_inner_has_no_discriminators():
     assert payload is file_data["mcpServers"]
 
 
+def test_select_servers_payload_wrapped_when_server_is_named_after_discriminator():
+    """A wrapped-format payload whose server is *named* "command" / "url" / "serverUrl"
+    must NOT be misread as flat. The inner discriminator key maps to a dict (the server
+    config), never a string (which only a real top-level server config would have).
+    """
+    from agent_scan.agent_discovery import _select_servers_payload
+
+    for discriminator in ("command", "url", "serverUrl"):
+        file_data = {"mcpServers": {discriminator: {"command": "/bin/echo"}}}
+
+        payload = _select_servers_payload(file_data)
+
+        assert payload is file_data["mcpServers"], (
+            f"Wrapped server named {discriminator!r} was misread as flat — "
+            f"detector must inspect value types, not just key presence"
+        )
+
+
+def test_select_servers_payload_wrapped_multiple_servers_one_named_after_discriminator():
+    """A wrapped-format payload with multiple servers, one of which happens to be
+    named "command", still parses as wrapped (the inner "command" value is a dict)."""
+    from agent_scan.agent_discovery import _select_servers_payload
+
+    file_data = {
+        "mcpServers": {
+            "command": {"command": "/bin/cmd"},
+            "other": {"command": "/bin/other"},
+        }
+    }
+
+    payload = _select_servers_payload(file_data)
+
+    assert payload is file_data["mcpServers"]
+
+
+def test_claude_code_discoverer_plugin_mcp_wrapped_server_named_command(tmp_path):
+    """End-to-end: a wrapped plugin .mcp.json with a server *named* "command" parses
+    as wrapped (single server named "command"), not as flat."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    plugin_dir = tmp_path / ".claude" / "plugins" / "cache" / "vendor" / "wrapped-cmd-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".mcp.json").write_text('{"mcpServers": {"command": {"command": "/bin/echo", "args": ["c"]}}}')
+
+    mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entries = next(iter(mcp_configs.values()))
+    assert isinstance(entries, list) and len(entries) == 1
+    name, server = entries[0]
+    assert name == "command"
+    assert isinstance(server, StdioServer)
+    assert server.command == "/bin/echo"
+    assert server.args == ["c"]
+
+
 def test_claude_code_discoverer_plugin_mcp_servers_empty_when_cache_missing(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -9,7 +9,6 @@ from agent_scan.models import (
     CouldNotParseMCPConfig,
     SkillServer,
     StdioServer,
-    UnknownConfigFormat,
 )
 
 # --- ClaudeCodeDiscoverer: client_exists ---
@@ -62,23 +61,17 @@ async def test_claude_code_discoverer_parses_mcp_servers(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_claude_code_discoverer_marks_unknown_config_format(tmp_path):
-    """Valid JSON that doesn't match any known MCP schema becomes UnknownConfigFormat."""
+async def test_claude_code_discoverer_returns_empty_when_json_has_no_mcp_fields(tmp_path):
+    """JSON without top-level mcpServers and without projects returns no entries."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
-    # Has an `mcp` field but in a shape no specific model accepts —
-    # scan_mcp_config_file returns UnknownMCPConfig, which the discoverer
-    # converts to UnknownConfigFormat.
-    (tmp_path / ".claude.json").write_text('{"mcp": {"foo": "bar"}}')
+    (tmp_path / ".claude.json").write_text('{"unrelated": "data"}')
 
     discoverer = ClaudeCodeDiscoverer()
     mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
 
-    assert len(mcp_configs) == 1
-    entry = next(iter(mcp_configs.values()))
-    assert isinstance(entry, UnknownConfigFormat)
-    assert entry.is_failure is False
+    assert mcp_configs == {}
 
 
 @pytest.mark.asyncio
@@ -150,6 +143,180 @@ def test_claude_code_discoverer_skills_returns_empty_when_dir_missing(tmp_path):
     skills_dirs = discoverer.discover_skills(tmp_path)
 
     assert skills_dirs == {}
+
+
+# --- ClaudeCodeDiscoverer: private folder enumeration ---
+
+
+def test_claude_code_discoverer_global_folders_returns_claude_dir(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    folders = ClaudeCodeDiscoverer()._discover_global_folders(tmp_path)
+
+    assert len(folders) == 1
+    assert folders[0].as_posix().endswith("/.claude")
+
+
+def test_claude_code_discoverer_project_folders_lists_project_paths(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"projects": {"/Users/alice/repo-a": {"mcpServers": {}}, "/Users/alice/repo-b": {"mcpServers": {}}}}'
+    )
+
+    folders = ClaudeCodeDiscoverer()._discover_project_folders(tmp_path)
+
+    folder_strs = {f.as_posix() for f in folders}
+    assert folder_strs == {"/Users/alice/repo-a", "/Users/alice/repo-b"}
+
+
+def test_claude_code_discoverer_project_folders_empty_when_no_projects_key(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"mcpServers": {}}')
+
+    folders = ClaudeCodeDiscoverer()._discover_project_folders(tmp_path)
+
+    assert folders == []
+
+
+def test_claude_code_discoverer_project_folders_empty_when_config_missing(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    folders = ClaudeCodeDiscoverer()._discover_project_folders(tmp_path)
+
+    assert folders == []
+
+
+# --- ClaudeCodeDiscoverer: project MCP servers ---
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_parses_project_mcp_servers(tmp_path):
+    """Each project's mcpServers becomes its own entry keyed by the project path."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"projects": {'
+        '"/work/repo-a": {"mcpServers": {"srv-a": {"command": "echo", "args": ["a"]}}}, '
+        '"/work/repo-b": {"mcpServers": {"srv-b": {"command": "echo", "args": ["b"]}}}'
+        "}}"
+    )
+
+    mcp_configs = await ClaudeCodeDiscoverer()._discover_project_mcp_servers(tmp_path)
+
+    assert set(mcp_configs) == {"/work/repo-a", "/work/repo-b"}
+    entries_a = mcp_configs["/work/repo-a"]
+    assert isinstance(entries_a, list) and len(entries_a) == 1
+    name_a, server_a = entries_a[0]
+    assert name_a == "srv-a"
+    assert isinstance(server_a, StdioServer)
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_project_mcp_servers_skips_projects_without_mcp(tmp_path):
+    """Projects with no mcpServers key (or empty) don't produce entries."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"projects": {'
+        '"/work/with-servers": {"mcpServers": {"srv": {"command": "echo"}}}, '
+        '"/work/empty": {"mcpServers": {}}, '
+        '"/work/no-key": {"otherField": 1}'
+        "}}"
+    )
+
+    mcp_configs = await ClaudeCodeDiscoverer()._discover_project_mcp_servers(tmp_path)
+
+    assert set(mcp_configs) == {"/work/with-servers"}
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_discover_mcp_servers_combines_global_and_project(tmp_path):
+    """The public discover_mcp_servers merges global + project results."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"mcpServers": {"global-srv": {"command": "g"}}, '
+        '"projects": {"/work/repo": {"mcpServers": {"proj-srv": {"command": "p"}}}}}'
+    )
+
+    mcp_configs = await ClaudeCodeDiscoverer().discover_mcp_servers(tmp_path)
+
+    # Two keys: one for the global file path, one for the project path.
+    assert len(mcp_configs) == 2
+    # Find the global entry by key suffix
+    global_keys = [k for k in mcp_configs if k.endswith("/.claude.json")]
+    project_keys = [k for k in mcp_configs if k == "/work/repo"]
+    assert len(global_keys) == 1 and len(project_keys) == 1
+    global_entry = mcp_configs[global_keys[0]]
+    project_entry = mcp_configs[project_keys[0]]
+    assert isinstance(global_entry, list) and global_entry[0][0] == "global-srv"
+    assert isinstance(project_entry, list) and project_entry[0][0] == "proj-srv"
+
+
+# --- ClaudeCodeDiscoverer: project skills ---
+
+
+def test_claude_code_discoverer_project_skills_scans_per_project_dotclaude(tmp_path):
+    """For each project listed in ~/.claude.json, scan <project>/.claude/skills."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    project_root = tmp_path / "work" / "repo"
+    (project_root / ".claude" / "skills" / "proj-skill").mkdir(parents=True)
+    (project_root / ".claude" / "skills" / "proj-skill" / "SKILL.md").write_text(
+        "---\nname: proj-skill\ndescription: A project skill\n---\n\nBody.\n"
+    )
+    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+    skills_dirs = ClaudeCodeDiscoverer()._discover_project_skills(tmp_path)
+
+    assert len(skills_dirs) == 1
+    key = next(iter(skills_dirs))
+    assert key.endswith("/.claude/skills")
+    entries = skills_dirs[key]
+    assert isinstance(entries, list) and len(entries) == 1
+    skill_name, skill = entries[0]
+    assert skill_name == "proj-skill"
+    assert isinstance(skill, SkillServer)
+
+
+def test_claude_code_discoverer_project_skills_skips_missing_project_folders(tmp_path):
+    """Projects whose folders don't exist on disk are silently skipped."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"projects": {"/nonexistent/path/that/wont/be/here": {"mcpServers": {}}}}')
+
+    skills_dirs = ClaudeCodeDiscoverer()._discover_project_skills(tmp_path)
+
+    assert skills_dirs == {}
+
+
+def test_claude_code_discoverer_discover_skills_combines_global_and_project(tmp_path):
+    """The public discover_skills merges global + project results."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude" / "skills" / "global-skill").mkdir(parents=True)
+    (tmp_path / ".claude" / "skills" / "global-skill" / "SKILL.md").write_text(
+        "---\nname: global-skill\ndescription: g\n---\n\nB.\n"
+    )
+    project_root = tmp_path / "work" / "repo"
+    (project_root / ".claude" / "skills" / "proj-skill").mkdir(parents=True)
+    (project_root / ".claude" / "skills" / "proj-skill" / "SKILL.md").write_text(
+        "---\nname: proj-skill\ndescription: p\n---\n\nB.\n"
+    )
+    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project_root.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+    skills_dirs = ClaudeCodeDiscoverer().discover_skills(tmp_path)
+
+    assert len(skills_dirs) == 2  # one global, one project
 
 
 # --- ClaudeCodeDiscoverer: end-to-end discover() ---

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -968,3 +968,154 @@ async def test_discover_clients_to_inspect_falls_back_to_legacy_for_non_claude(t
     assert len(ctis) == 1
     assert ctis[0].name == "cursor"
     assert ctis[0].username == "alice"
+
+
+# --- Plugin discovery depth cap ---
+
+
+@pytest.mark.asyncio
+async def test_plugin_mcp_servers_respects_max_depth_cap(tmp_path):
+    """Plugin .mcp.json files deeper than _MAX_PLUGIN_RGLOB_DEPTH are not discovered.
+
+    Depth is counted as ``len(match.relative_to(base).parts)`` where ``base``
+    is ``~/.claude/plugins/cache``. A file directly in ``cache/`` is depth 1.
+    """
+    from agent_scan.agent_discovery import _MAX_PLUGIN_RGLOB_DEPTH, ClaudeCodeDiscoverer
+
+    cache = tmp_path / ".claude" / "plugins" / "cache"
+    # Depth = _MAX_PLUGIN_RGLOB_DEPTH (allowed): N-1 intermediate dirs + the file.
+    allowed_dir = cache.joinpath(*[f"d{i}" for i in range(_MAX_PLUGIN_RGLOB_DEPTH - 1)])
+    allowed_dir.mkdir(parents=True)
+    (allowed_dir / ".mcp.json").write_text('{"allowed-srv": {"command": "a"}}')
+    # Depth = _MAX_PLUGIN_RGLOB_DEPTH + 1 (skipped).
+    too_deep_dir = cache.joinpath(*[f"x{i}" for i in range(_MAX_PLUGIN_RGLOB_DEPTH)])
+    too_deep_dir.mkdir(parents=True)
+    (too_deep_dir / ".mcp.json").write_text('{"too-deep-srv": {"command": "x"}}')
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
+
+    server_names = {name for entries in mcp_configs.values() if isinstance(entries, list) for name, _ in entries}
+    assert "allowed-srv" in server_names
+    assert "too-deep-srv" not in server_names
+
+
+def test_plugin_skills_respects_max_depth_cap(tmp_path):
+    """Plugin skills/ dirs deeper than _MAX_PLUGIN_RGLOB_DEPTH are not discovered."""
+    from agent_scan.agent_discovery import _MAX_PLUGIN_RGLOB_DEPTH, ClaudeCodeDiscoverer
+
+    cache = tmp_path / ".claude" / "plugins" / "cache"
+    # The "skills" dir itself counts as one part, so put it at the allowed boundary.
+    allowed_parent = cache.joinpath(*[f"d{i}" for i in range(_MAX_PLUGIN_RGLOB_DEPTH - 1)])
+    allowed_skill = allowed_parent / "skills" / "allowed-skill"
+    allowed_skill.mkdir(parents=True)
+    (allowed_skill / "SKILL.md").write_text("---\nname: allowed-skill\ndescription: a\n---\n\nB.\n")
+    too_deep_parent = cache.joinpath(*[f"x{i}" for i in range(_MAX_PLUGIN_RGLOB_DEPTH)])
+    too_deep_skill = too_deep_parent / "skills" / "too-deep-skill"
+    too_deep_skill.mkdir(parents=True)
+    (too_deep_skill / "SKILL.md").write_text("---\nname: too-deep-skill\ndescription: x\n---\n\nB.\n")
+
+    skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_skills()
+
+    keys = list(skills_dirs)
+    assert any(k.endswith(f"/{allowed_parent.name}/skills") for k in keys)
+    assert not any(k.endswith(f"/{too_deep_parent.name}/skills") for k in keys)
+
+
+# --- JSON5 parsing (comments + empty-file short-circuit) ---
+
+
+@pytest.mark.asyncio
+async def test_load_json_file_accepts_json5_comments_and_trailing_commas(tmp_path):
+    """A ~/.claude.json with // comments and a trailing comma parses successfully."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        "{\n"
+        "  // top-level comment\n"
+        '  "mcpServers": {\n'
+        '    "my-server": {"command": "echo", "args": ["hi"]},\n'  # trailing comma below
+        "  },\n"
+        "}\n"
+    )
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entries = next(iter(mcp_configs.values()))
+    assert isinstance(entries, list)
+    assert [name for name, _ in entries] == ["my-server"]
+
+
+@pytest.mark.asyncio
+async def test_load_json_file_treats_empty_file_as_empty_config(tmp_path):
+    """An empty (or whitespace-only) ~/.claude.json returns no entries, not a parse error."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text("   \n  \n")
+
+    mcp_configs = await ClaudeCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert mcp_configs == {}
+
+
+# --- _validate_servers writes check_server_signature result back into the dict ---
+
+
+def test_validate_servers_writes_check_server_signature_result_into_dict(tmp_path):
+    """_validate_servers must replace each stdio entry with the value returned by
+    check_server_signature — not just rely on in-place mutation of the input."""
+    from unittest.mock import patch as mock_patch
+
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    replacement = StdioServer(command="replacement", binary_identifier="sig-from-mock")
+
+    with mock_patch(
+        "agent_scan.agent_discovery.check_server_signature",
+        return_value=replacement,
+    ) as signature_mock:
+        result = ClaudeCodeDiscoverer(tmp_path)._validate_servers({"srv": {"command": "original"}}, source="test")
+
+    assert signature_mock.called
+    assert isinstance(result, list)
+    assert len(result) == 1
+    name, server = result[0]
+    assert name == "srv"
+    assert server is replacement
+
+
+# --- find_discoverers exception safety ---
+
+
+def test_find_discoverers_skips_discoverer_that_raises_unexpected_exception(tmp_path):
+    """A discoverer whose client_exists() raises must not crash find_discoverers."""
+    from agent_scan.agent_discovery import (
+        DISCOVERERS,
+        AgentDiscoverer,
+        ClaudeCodeDiscoverer,
+        find_discoverers,
+    )
+
+    class ExplodingDiscoverer(AgentDiscoverer):
+        name = "exploding"
+
+        def client_exists(self):
+            raise RuntimeError("boom")
+
+        async def discover_mcp_servers(self):
+            return {}
+
+        def discover_skills(self):
+            return {}
+
+    (tmp_path / ".claude").mkdir()
+    DISCOVERERS["exploding"] = ExplodingDiscoverer
+    try:
+        found = find_discoverers(tmp_path)
+    finally:
+        del DISCOVERERS["exploding"]
+
+    assert len(found) == 1
+    assert isinstance(found[0], ClaudeCodeDiscoverer)

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -817,13 +817,7 @@ def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_repos(tm
 # --- ClaudeCodeDiscoverer: end-to-end discover() ---
 
 
-def test_claude_code_discoverer_discover_groups_by_parent_folder(tmp_path):
-    """discover() emits one CTI per unique parent folder of the discovered paths.
-
-    With ~/.claude.json (parent = tmp_path) and ~/.claude/skills (parent = ~/.claude),
-    we expect two CTIs — one bucketed under tmp_path holding the mcp config and one
-    under ~/.claude holding the skills dir.
-    """
+def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
@@ -832,64 +826,22 @@ def test_claude_code_discoverer_discover_groups_by_parent_folder(tmp_path):
     my_skill.mkdir(parents=True)
     (my_skill / "SKILL.md").write_text("---\nname: demo\ndescription: Demo skill\n---\n\nBody.\n")
 
-    ctis = ClaudeCodeDiscoverer(tmp_path).discover()
+    cti = ClaudeCodeDiscoverer(tmp_path).discover()
 
-    assert isinstance(ctis, list)
-    assert all(isinstance(cti, ClientToInspect) for cti in ctis)
-    assert all(cti.name == "claude code" for cti in ctis)
-
-    by_path = {cti.client_path: cti for cti in ctis}
-    home_cti = by_path[tmp_path.as_posix()]
-    install_cti = by_path[(tmp_path / ".claude").as_posix()]
-
-    assert list(home_cti.mcp_configs) == [(tmp_path / ".claude.json").as_posix()]
-    assert home_cti.skills_dirs == {}
-
-    assert install_cti.mcp_configs == {}
-    assert list(install_cti.skills_dirs) == [(tmp_path / ".claude" / "skills").as_posix()]
+    assert cti is not None
+    assert isinstance(cti, ClientToInspect)
+    assert cti.name == "claude code"
+    assert cti.client_path.endswith("/.claude")
+    assert len(cti.mcp_configs) == 1
+    assert len(cti.skills_dirs) == 1
 
 
-def test_claude_code_discoverer_discover_pairs_mcp_and_skills_under_same_parent(tmp_path):
-    """When .mcp.json and skills/ share the SAME parent (plugin layout), they land in one CTI."""
+def test_claude_code_discoverer_discover_returns_none_when_not_installed(tmp_path):
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
-    plugin = tmp_path / ".claude" / "plugins" / "cache" / "my-plugin"
-    plugin.mkdir(parents=True)
-    (plugin / ".mcp.json").write_text('{"plugin-srv": {"command": "p"}}')
-    skill = plugin / "skills" / "demo"
-    skill.mkdir(parents=True)
-    (skill / "SKILL.md").write_text("---\nname: demo\ndescription: d\n---\n\nB.\n")
+    cti = ClaudeCodeDiscoverer(tmp_path).discover()
 
-    ctis = ClaudeCodeDiscoverer(tmp_path).discover()
-
-    plugin_ctis = [c for c in ctis if c.client_path == plugin.as_posix()]
-    assert len(plugin_ctis) == 1
-    cti = plugin_ctis[0]
-    assert list(cti.mcp_configs) == [(plugin / ".mcp.json").as_posix()]
-    assert list(cti.skills_dirs) == [(plugin / "skills").as_posix()]
-
-
-def test_claude_code_discoverer_discover_emits_install_path_cti_when_empty(tmp_path):
-    """Agent is installed but nothing discovered — still emit one CTI keyed at install path."""
-    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
-
-    (tmp_path / ".claude").mkdir()
-
-    ctis = ClaudeCodeDiscoverer(tmp_path).discover()
-
-    assert len(ctis) == 1
-    assert ctis[0].name == "claude code"
-    assert ctis[0].client_path == (tmp_path / ".claude").as_posix()
-    assert ctis[0].mcp_configs == {}
-    assert ctis[0].skills_dirs == {}
-
-
-def test_claude_code_discoverer_discover_returns_empty_list_when_not_installed(tmp_path):
-    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
-
-    ctis = ClaudeCodeDiscoverer(tmp_path).discover()
-
-    assert ctis == []
+    assert cti is None
 
 
 # --- ABC enforcement ---
@@ -981,13 +933,8 @@ async def test_discover_clients_to_inspect_runs_legacy_for_claude_code(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_discover_clients_to_inspect_legacy_and_abc_emit_separate_ctis_by_client_path(tmp_path):
-    """Legacy and ABC emit CTIs with distinct client_paths; both survive as separate entries.
-
-    Match is now by (name, username, client_path): legacy CTI's client_path is the
-    install root (~/.claude), while ABC's project-scope CTI is bucketed under the
-    project's parent folder (/work for /work/repo). Distinct client_paths → distinct CTIs.
-    """
+async def test_discover_clients_to_inspect_merges_abc_into_legacy_cti_keeping_both_keys(tmp_path):
+    """One CTI per (name, username); legacy and ABC keys for the same server both survive."""
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
@@ -1012,14 +959,21 @@ async def test_discover_clients_to_inspect_legacy_and_abc_emit_separate_ctis_by_
         ctis, _, _ = await discover_clients_to_inspect(args)
 
     claude_ctis = [c for c in ctis if c.name == "claude code" and c.username == "alice"]
-    legacy_cti = next(c for c in claude_ctis if c.client_path == (tmp_path / ".claude").as_posix())
-    abc_cti = next(c for c in claude_ctis if c.client_path == "/work")
+    assert len(claude_ctis) == 1
+    merged = claude_ctis[0]
 
-    legacy_key = next(k for k in legacy_cti.mcp_configs if k.endswith("/.claude.json"))
-    legacy_entries = legacy_cti.mcp_configs[legacy_key]
-    abc_entries = abc_cti.mcp_configs["/work/repo"]
+    keys = list(merged.mcp_configs)
+    legacy_key = next(k for k in keys if k.endswith("/.claude.json"))
+    abc_key = next(k for k in keys if k == "/work/repo")
+
+    legacy_entries = merged.mcp_configs[legacy_key]
+    abc_entries = merged.mcp_configs[abc_key]
     assert isinstance(legacy_entries, list)
     assert isinstance(abc_entries, list)
+    # Without by-name dedup, "srv" is preserved in both phases' keys. Each represents
+    # a distinct discovery source (legacy flattens projects.* into ~/.claude.json;
+    # ABC reports it under the project path) and downstream scanning treats each
+    # (key, name) pair on its own merits.
     assert [name for name, _ in legacy_entries] == ["srv"]
     assert [name for name, _ in abc_entries] == ["srv"]
     assert all(isinstance(s, StdioServer) for _, s in abc_entries)
@@ -1062,12 +1016,11 @@ async def test_discover_clients_to_inspect_preserves_same_named_server_across_pr
         ctis, _, _ = await discover_clients_to_inspect(args)
 
     claude_ctis = [c for c in ctis if c.name == "claude code"]
-    # /work/repo-a and /work/repo-b share parent /work, so ABC emits one CTI for both
-    # (alongside legacy's install-path CTI).
-    work_cti = next(c for c in claude_ctis if c.client_path == "/work")
+    assert len(claude_ctis) == 1
+    cti = claude_ctis[0]
 
-    repo_a = work_cti.mcp_configs["/work/repo-a"]
-    repo_b = work_cti.mcp_configs["/work/repo-b"]
+    repo_a = cti.mcp_configs["/work/repo-a"]
+    repo_b = cti.mcp_configs["/work/repo-b"]
     assert isinstance(repo_a, list)
     assert isinstance(repo_b, list)
     assert [name for name, _ in repo_a] == ["github"]
@@ -1107,25 +1060,15 @@ async def test_discover_clients_to_inspect_keeps_legacy_key_when_abc_adds_nothin
         ctis, _, _ = await discover_clients_to_inspect(args)
 
     claude_ctis = [c for c in ctis if c.name == "claude code"]
-    # Legacy emits one CTI at install root with ~/.claude.json. ABC's discover() finds
-    # no global mcp servers and no projects, so it emits a single empty CTI at the
-    # install path, which merges with legacy's CTI (same client_path).
     assert len(claude_ctis) == 1
     keys = list(claude_ctis[0].mcp_configs)
+    # Only legacy keys present (no project keys from ABC to dedup against).
     assert keys == [k for k in keys if k.endswith("/.claude.json")]
 
 
 @pytest.mark.asyncio
-async def test_discover_clients_to_inspect_legacy_and_abc_partition_by_client_path(tmp_path):
-    """Legacy + ABC results stay in distinct CTIs partitioned by client_path.
-
-    Legacy emits ONE CTI at the install root with both top-level and flattened-project
-    servers under ~/.claude.json. ABC emits separate CTIs grouped by parent folder of
-    each discovered config path:
-
-      * tmp_path (parent of ~/.claude.json) — top-level mcpServers
-      * /work    (parent of /work/repo)     — project's mcpServers
-    """
+async def test_discover_clients_to_inspect_abc_wins_on_same_key_collision(tmp_path):
+    """Both paths produce a ~/.claude.json key; ABC's value wins via dict-union merge."""
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
@@ -1153,27 +1096,18 @@ async def test_discover_clients_to_inspect_legacy_and_abc_partition_by_client_pa
         ctis, _, _ = await discover_clients_to_inspect(args)
 
     claude_ctis = [c for c in ctis if c.name == "claude code"]
-    by_path = {c.client_path: c for c in claude_ctis}
+    assert len(claude_ctis) == 1
+    merged = claude_ctis[0]
 
-    legacy = by_path[(tmp_path / ".claude").as_posix()]
-    abc_global = by_path[tmp_path.as_posix()]
-    abc_project = by_path["/work"]
-
-    legacy_key = next(k for k in legacy.mcp_configs if k.endswith("/.claude.json"))
-    legacy_entries = legacy.mcp_configs[legacy_key]
-    assert isinstance(legacy_entries, list)
-    # ClaudeCodeConfigFile (legacy parser's first match for files with `projects`)
-    # only flattens project servers; top-level `mcpServers` is dropped — picked up
-    # by ABC instead.
-    assert {name for name, _ in legacy_entries} == {"proj"}
-
-    abc_global_entries = abc_global.mcp_configs[(tmp_path / ".claude.json").as_posix()]
-    assert isinstance(abc_global_entries, list)
-    assert [name for name, _ in abc_global_entries] == ["top"]
-
-    abc_project_entries = abc_project.mcp_configs["/work/repo"]
-    assert isinstance(abc_project_entries, list)
-    assert [name for name, _ in abc_project_entries] == ["proj"]
+    legacy_key = next(k for k in merged.mcp_configs if k.endswith("/.claude.json"))
+    entries = merged.mcp_configs[legacy_key]
+    assert isinstance(entries, list)
+    # Legacy stored "proj" under .claude.json (its ClaudeCodeConfigFile flattening
+    # of projects.*). ABC stored "top" under .claude.json (top-level mcpServers).
+    # Dict-union merge picks ABC's value on the colliding key, so .claude.json now
+    # holds only "top"; "proj" lives under ABC's /work/repo key.
+    assert [name for name, _ in entries] == ["top"]
+    assert merged.mcp_configs["/work/repo"] == [("proj", merged.mcp_configs["/work/repo"][0][1])]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -817,7 +817,13 @@ def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_repos(tm
 # --- ClaudeCodeDiscoverer: end-to-end discover() ---
 
 
-def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_path):
+def test_claude_code_discoverer_discover_groups_by_parent_folder(tmp_path):
+    """discover() emits one CTI per unique parent folder of the discovered paths.
+
+    With ~/.claude.json (parent = tmp_path) and ~/.claude/skills (parent = ~/.claude),
+    we expect two CTIs — one bucketed under tmp_path holding the mcp config and one
+    under ~/.claude holding the skills dir.
+    """
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
     (tmp_path / ".claude").mkdir()
@@ -826,22 +832,64 @@ def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_path):
     my_skill.mkdir(parents=True)
     (my_skill / "SKILL.md").write_text("---\nname: demo\ndescription: Demo skill\n---\n\nBody.\n")
 
-    cti = ClaudeCodeDiscoverer(tmp_path).discover()
+    ctis = ClaudeCodeDiscoverer(tmp_path).discover()
 
-    assert cti is not None
-    assert isinstance(cti, ClientToInspect)
-    assert cti.name == "claude code"
-    assert cti.client_path.endswith("/.claude")
-    assert len(cti.mcp_configs) == 1
-    assert len(cti.skills_dirs) == 1
+    assert isinstance(ctis, list)
+    assert all(isinstance(cti, ClientToInspect) for cti in ctis)
+    assert all(cti.name == "claude code" for cti in ctis)
+
+    by_path = {cti.client_path: cti for cti in ctis}
+    home_cti = by_path[tmp_path.as_posix()]
+    install_cti = by_path[(tmp_path / ".claude").as_posix()]
+
+    assert list(home_cti.mcp_configs) == [(tmp_path / ".claude.json").as_posix()]
+    assert home_cti.skills_dirs == {}
+
+    assert install_cti.mcp_configs == {}
+    assert list(install_cti.skills_dirs) == [(tmp_path / ".claude" / "skills").as_posix()]
 
 
-def test_claude_code_discoverer_discover_returns_none_when_not_installed(tmp_path):
+def test_claude_code_discoverer_discover_pairs_mcp_and_skills_under_same_parent(tmp_path):
+    """When .mcp.json and skills/ share the SAME parent (plugin layout), they land in one CTI."""
     from agent_scan.agent_discovery import ClaudeCodeDiscoverer
 
-    cti = ClaudeCodeDiscoverer(tmp_path).discover()
+    plugin = tmp_path / ".claude" / "plugins" / "cache" / "my-plugin"
+    plugin.mkdir(parents=True)
+    (plugin / ".mcp.json").write_text('{"plugin-srv": {"command": "p"}}')
+    skill = plugin / "skills" / "demo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: demo\ndescription: d\n---\n\nB.\n")
 
-    assert cti is None
+    ctis = ClaudeCodeDiscoverer(tmp_path).discover()
+
+    plugin_ctis = [c for c in ctis if c.client_path == plugin.as_posix()]
+    assert len(plugin_ctis) == 1
+    cti = plugin_ctis[0]
+    assert list(cti.mcp_configs) == [(plugin / ".mcp.json").as_posix()]
+    assert list(cti.skills_dirs) == [(plugin / "skills").as_posix()]
+
+
+def test_claude_code_discoverer_discover_emits_install_path_cti_when_empty(tmp_path):
+    """Agent is installed but nothing discovered — still emit one CTI keyed at install path."""
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+
+    ctis = ClaudeCodeDiscoverer(tmp_path).discover()
+
+    assert len(ctis) == 1
+    assert ctis[0].name == "claude code"
+    assert ctis[0].client_path == (tmp_path / ".claude").as_posix()
+    assert ctis[0].mcp_configs == {}
+    assert ctis[0].skills_dirs == {}
+
+
+def test_claude_code_discoverer_discover_returns_empty_list_when_not_installed(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    ctis = ClaudeCodeDiscoverer(tmp_path).discover()
+
+    assert ctis == []
 
 
 # --- ABC enforcement ---
@@ -933,8 +981,13 @@ async def test_discover_clients_to_inspect_runs_legacy_for_claude_code(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_discover_clients_to_inspect_merges_abc_into_legacy_cti_keeping_both_keys(tmp_path):
-    """One CTI per (name, username); legacy and ABC keys for the same server both survive."""
+async def test_discover_clients_to_inspect_legacy_and_abc_emit_separate_ctis_by_client_path(tmp_path):
+    """Legacy and ABC emit CTIs with distinct client_paths; both survive as separate entries.
+
+    Match is now by (name, username, client_path): legacy CTI's client_path is the
+    install root (~/.claude), while ABC's project-scope CTI is bucketed under the
+    project's parent folder (/work for /work/repo). Distinct client_paths → distinct CTIs.
+    """
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
@@ -959,21 +1012,14 @@ async def test_discover_clients_to_inspect_merges_abc_into_legacy_cti_keeping_bo
         ctis, _, _ = await discover_clients_to_inspect(args)
 
     claude_ctis = [c for c in ctis if c.name == "claude code" and c.username == "alice"]
-    assert len(claude_ctis) == 1
-    merged = claude_ctis[0]
+    legacy_cti = next(c for c in claude_ctis if c.client_path == (tmp_path / ".claude").as_posix())
+    abc_cti = next(c for c in claude_ctis if c.client_path == "/work")
 
-    keys = list(merged.mcp_configs)
-    legacy_key = next(k for k in keys if k.endswith("/.claude.json"))
-    abc_key = next(k for k in keys if k == "/work/repo")
-
-    legacy_entries = merged.mcp_configs[legacy_key]
-    abc_entries = merged.mcp_configs[abc_key]
+    legacy_key = next(k for k in legacy_cti.mcp_configs if k.endswith("/.claude.json"))
+    legacy_entries = legacy_cti.mcp_configs[legacy_key]
+    abc_entries = abc_cti.mcp_configs["/work/repo"]
     assert isinstance(legacy_entries, list)
     assert isinstance(abc_entries, list)
-    # Without by-name dedup, "srv" is preserved in both phases' keys. Each represents
-    # a distinct discovery source (legacy flattens projects.* into ~/.claude.json;
-    # ABC reports it under the project path) and downstream scanning treats each
-    # (key, name) pair on its own merits.
     assert [name for name, _ in legacy_entries] == ["srv"]
     assert [name for name, _ in abc_entries] == ["srv"]
     assert all(isinstance(s, StdioServer) for _, s in abc_entries)
@@ -1016,11 +1062,12 @@ async def test_discover_clients_to_inspect_preserves_same_named_server_across_pr
         ctis, _, _ = await discover_clients_to_inspect(args)
 
     claude_ctis = [c for c in ctis if c.name == "claude code"]
-    assert len(claude_ctis) == 1
-    cti = claude_ctis[0]
+    # /work/repo-a and /work/repo-b share parent /work, so ABC emits one CTI for both
+    # (alongside legacy's install-path CTI).
+    work_cti = next(c for c in claude_ctis if c.client_path == "/work")
 
-    repo_a = cti.mcp_configs["/work/repo-a"]
-    repo_b = cti.mcp_configs["/work/repo-b"]
+    repo_a = work_cti.mcp_configs["/work/repo-a"]
+    repo_b = work_cti.mcp_configs["/work/repo-b"]
     assert isinstance(repo_a, list)
     assert isinstance(repo_b, list)
     assert [name for name, _ in repo_a] == ["github"]
@@ -1060,15 +1107,25 @@ async def test_discover_clients_to_inspect_keeps_legacy_key_when_abc_adds_nothin
         ctis, _, _ = await discover_clients_to_inspect(args)
 
     claude_ctis = [c for c in ctis if c.name == "claude code"]
+    # Legacy emits one CTI at install root with ~/.claude.json. ABC's discover() finds
+    # no global mcp servers and no projects, so it emits a single empty CTI at the
+    # install path, which merges with legacy's CTI (same client_path).
     assert len(claude_ctis) == 1
     keys = list(claude_ctis[0].mcp_configs)
-    # Only legacy keys present (no project keys from ABC to dedup against).
     assert keys == [k for k in keys if k.endswith("/.claude.json")]
 
 
 @pytest.mark.asyncio
-async def test_discover_clients_to_inspect_abc_wins_on_same_key_collision(tmp_path):
-    """Both paths produce a ~/.claude.json key; ABC's value wins via dict-union merge."""
+async def test_discover_clients_to_inspect_legacy_and_abc_partition_by_client_path(tmp_path):
+    """Legacy + ABC results stay in distinct CTIs partitioned by client_path.
+
+    Legacy emits ONE CTI at the install root with both top-level and flattened-project
+    servers under ~/.claude.json. ABC emits separate CTIs grouped by parent folder of
+    each discovered config path:
+
+      * tmp_path (parent of ~/.claude.json) — top-level mcpServers
+      * /work    (parent of /work/repo)     — project's mcpServers
+    """
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
@@ -1096,18 +1153,27 @@ async def test_discover_clients_to_inspect_abc_wins_on_same_key_collision(tmp_pa
         ctis, _, _ = await discover_clients_to_inspect(args)
 
     claude_ctis = [c for c in ctis if c.name == "claude code"]
-    assert len(claude_ctis) == 1
-    merged = claude_ctis[0]
+    by_path = {c.client_path: c for c in claude_ctis}
 
-    legacy_key = next(k for k in merged.mcp_configs if k.endswith("/.claude.json"))
-    entries = merged.mcp_configs[legacy_key]
-    assert isinstance(entries, list)
-    # Legacy stored "proj" under .claude.json (its ClaudeCodeConfigFile flattening
-    # of projects.*). ABC stored "top" under .claude.json (top-level mcpServers).
-    # Dict-union merge picks ABC's value on the colliding key, so .claude.json now
-    # holds only "top"; "proj" lives under ABC's /work/repo key.
-    assert [name for name, _ in entries] == ["top"]
-    assert merged.mcp_configs["/work/repo"] == [("proj", merged.mcp_configs["/work/repo"][0][1])]
+    legacy = by_path[(tmp_path / ".claude").as_posix()]
+    abc_global = by_path[tmp_path.as_posix()]
+    abc_project = by_path["/work"]
+
+    legacy_key = next(k for k in legacy.mcp_configs if k.endswith("/.claude.json"))
+    legacy_entries = legacy.mcp_configs[legacy_key]
+    assert isinstance(legacy_entries, list)
+    # ClaudeCodeConfigFile (legacy parser's first match for files with `projects`)
+    # only flattens project servers; top-level `mcpServers` is dropped — picked up
+    # by ABC instead.
+    assert {name for name, _ in legacy_entries} == {"proj"}
+
+    abc_global_entries = abc_global.mcp_configs[(tmp_path / ".claude.json").as_posix()]
+    assert isinstance(abc_global_entries, list)
+    assert [name for name, _ in abc_global_entries] == ["top"]
+
+    abc_project_entries = abc_project.mcp_configs["/work/repo"]
+    assert isinstance(abc_project_entries, list)
+    assert [name for name, _ in abc_project_entries] == ["proj"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -1,0 +1,244 @@
+"""Tests for the per-agent discovery ABC (agent_discovery module)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_scan.models import (
+    ClientToInspect,
+    SkillServer,
+    StdioServer,
+)
+
+
+# --- ClaudeCodeDiscoverer: client_exists ---
+
+
+def test_claude_code_discoverer_detects_installation(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+
+    discoverer = ClaudeCodeDiscoverer()
+    result = discoverer.client_exists(tmp_path)
+
+    assert result is not None
+    assert result.endswith("/.claude")
+
+
+def test_claude_code_discoverer_returns_none_when_absent(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    discoverer = ClaudeCodeDiscoverer()
+    result = discoverer.client_exists(tmp_path)
+
+    assert result is None
+
+
+# --- ClaudeCodeDiscoverer: discover_mcp_servers ---
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_parses_mcp_servers(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"mcpServers": {"my-server": {"command": "echo", "args": ["hi"]}}}'
+    )
+
+    discoverer = ClaudeCodeDiscoverer()
+    mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
+
+    assert len(mcp_configs) == 1
+    config_path = next(iter(mcp_configs))
+    assert config_path.endswith("/.claude.json")
+    entries = mcp_configs[config_path]
+    assert isinstance(entries, list)
+    assert len(entries) == 1
+    name, server = entries[0]
+    assert name == "my-server"
+    assert isinstance(server, StdioServer)
+    assert server.command == "echo"
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_returns_empty_when_mcp_config_missing(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    # no ~/.claude.json on disk
+
+    discoverer = ClaudeCodeDiscoverer()
+    mcp_configs = await discoverer.discover_mcp_servers(tmp_path)
+
+    # Missing config files are silently skipped (matches legacy behavior when
+    # create_file_not_found_error=False).
+    assert mcp_configs == {}
+
+
+# --- ClaudeCodeDiscoverer: discover_skills ---
+
+
+def test_claude_code_discoverer_parses_skills(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    skills_dir = tmp_path / ".claude" / "skills"
+    skills_dir.mkdir(parents=True)
+    my_skill = skills_dir / "my-skill"
+    my_skill.mkdir()
+    (my_skill / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A test skill\n---\n\nBody.\n"
+    )
+
+    discoverer = ClaudeCodeDiscoverer()
+    skills_dirs = discoverer.discover_skills(tmp_path)
+
+    assert len(skills_dirs) == 1
+    dir_path = next(iter(skills_dirs))
+    assert dir_path.endswith("/.claude/skills")
+    skills = skills_dirs[dir_path]
+    assert isinstance(skills, list)
+    assert len(skills) == 1
+    skill_name, skill = skills[0]
+    assert skill_name == "my-skill"
+    assert isinstance(skill, SkillServer)
+
+
+def test_claude_code_discoverer_skills_returns_empty_when_dir_missing(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    # no ~/.claude/skills on disk
+
+    discoverer = ClaudeCodeDiscoverer()
+    skills_dirs = discoverer.discover_skills(tmp_path)
+
+    assert skills_dirs == {}
+
+
+# --- ClaudeCodeDiscoverer: end-to-end discover() ---
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_discover_assembles_client_to_inspect(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"mcpServers": {"toy": {"command": "echo", "args": []}}}'
+    )
+    my_skill = tmp_path / ".claude" / "skills" / "demo"
+    my_skill.mkdir(parents=True)
+    (my_skill / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo skill\n---\n\nBody.\n"
+    )
+
+    discoverer = ClaudeCodeDiscoverer()
+    cti = await discoverer.discover(tmp_path)
+
+    assert cti is not None
+    assert isinstance(cti, ClientToInspect)
+    assert cti.name == "claude code"
+    assert cti.client_path.endswith("/.claude")
+    assert len(cti.mcp_configs) == 1
+    assert len(cti.skills_dirs) == 1
+
+
+@pytest.mark.asyncio
+async def test_claude_code_discoverer_discover_returns_none_when_not_installed(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer
+
+    discoverer = ClaudeCodeDiscoverer()
+    cti = await discoverer.discover(tmp_path)
+
+    assert cti is None
+
+
+# --- get_discoverer factory ---
+
+
+def test_get_discoverer_returns_claude_code_discoverer():
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer, get_discoverer
+
+    discoverer = get_discoverer("claude code")
+    assert isinstance(discoverer, ClaudeCodeDiscoverer)
+
+
+@pytest.mark.parametrize(
+    "agent_name",
+    ["cursor", "vscode", "windsurf", "claude", "codex", "gemini cli", "amp", "kiro"],
+)
+def test_get_discoverer_raises_not_implemented_for_unregistered_agent(agent_name):
+    from agent_scan.agent_discovery import get_discoverer
+
+    with pytest.raises(NotImplementedError):
+        get_discoverer(agent_name)
+
+
+# --- Pipeline dispatch: ABC for Claude Code, legacy for everything else ---
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_uses_abc_for_claude_code(tmp_path):
+    """Claude Code should be discovered via ClaudeCodeDiscoverer.discover, not the legacy path."""
+    from agent_scan.models import CandidateClient
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"mcpServers": {}}')
+
+    candidate = CandidateClient(
+        name="claude code",
+        client_exists_paths=["~/.claude"],
+        mcp_config_paths=["~/.claude.json"],
+        skills_dir_paths=["~/.claude/skills"],
+    )
+
+    with (
+        patch(
+            "agent_scan.pipelines.get_readable_home_directories",
+            return_value=[(tmp_path, "alice")],
+        ),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+        patch("agent_scan.pipelines.get_mcp_config_per_client") as spy_legacy,
+    ):
+        args = InspectArgs(timeout=10, tokens=[], paths=[])
+        ctis, _, _ = await discover_clients_to_inspect(args)
+
+    assert not spy_legacy.called, "Legacy path must not be called for claude code"
+    assert len(ctis) == 1
+    assert ctis[0].name == "claude code"
+    assert ctis[0].username == "alice"
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_falls_back_to_legacy_for_non_claude(tmp_path):
+    """Non-Claude agents (e.g. cursor) should still go through get_mcp_config_per_client."""
+    from agent_scan.models import CandidateClient
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    (tmp_path / ".cursor").mkdir()
+    (tmp_path / ".cursor" / "mcp.json").write_text('{"mcpServers": {}}')
+
+    candidate = CandidateClient(
+        name="cursor",
+        client_exists_paths=["~/.cursor"],
+        mcp_config_paths=["~/.cursor/mcp.json"],
+        skills_dir_paths=[],
+    )
+
+    with (
+        patch(
+            "agent_scan.pipelines.get_readable_home_directories",
+            return_value=[(tmp_path, "alice")],
+        ),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+    ):
+        args = InspectArgs(timeout=10, tokens=[], paths=[])
+        ctis, _, _ = await discover_clients_to_inspect(args)
+
+    assert len(ctis) == 1
+    assert ctis[0].name == "cursor"
+    assert ctis[0].username == "alice"

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -885,6 +885,49 @@ def test_dedup_mcp_servers_preserves_error_type_entries():
     assert cti.mcp_configs["/work/repo"] == [("srv", srv)]
 
 
+def test_dedup_mcp_servers_drops_key_emptied_by_dedup():
+    """A key whose every server was shadowed by a later key is removed entirely."""
+    from agent_scan.pipelines import _dedup_mcp_servers
+
+    srv_legacy = StdioServer(command="legacy")
+    srv_abc = StdioServer(command="abc")
+    cti = ClientToInspect(
+        name="claude code",
+        client_path="/home/alice/.claude",
+        mcp_configs={
+            "/home/alice/.claude.json": [("srv", srv_legacy)],
+            "/work/repo": [("srv", srv_abc)],
+        },
+        skills_dirs={},
+    )
+
+    _dedup_mcp_servers(cti)
+
+    assert "/home/alice/.claude.json" not in cti.mcp_configs
+    assert cti.mcp_configs["/work/repo"] == [("srv", srv_abc)]
+
+
+def test_dedup_mcp_servers_preserves_originally_empty_lists():
+    """A list that was already empty before dedup is left in place (no servers were lost)."""
+    from agent_scan.pipelines import _dedup_mcp_servers
+
+    srv = StdioServer(command="x")
+    cti = ClientToInspect(
+        name="claude code",
+        client_path="/home/alice/.claude",
+        mcp_configs={
+            "/home/alice/.claude.json": [],
+            "/work/repo": [("srv", srv)],
+        },
+        skills_dirs={},
+    )
+
+    _dedup_mcp_servers(cti)
+
+    assert cti.mcp_configs["/home/alice/.claude.json"] == []
+    assert cti.mcp_configs["/work/repo"] == [("srv", srv)]
+
+
 # --- Pipeline dispatch: legacy for all + ABC merge phase ---
 
 
@@ -955,18 +998,17 @@ async def test_discover_clients_to_inspect_merges_abc_into_legacy_cti_and_dedups
     merged = claude_ctis[0]
 
     keys = list(merged.mcp_configs)
-    legacy_key = next(k for k in keys if k.endswith("/.claude.json"))
     abc_key = next(k for k in keys if k == "/work/repo")
-    assert legacy_key and abc_key
+    # Legacy's ~/.claude.json key held only "srv", which dedup moved into the ABC
+    # per-project key. The now-empty legacy key is dropped (would otherwise display
+    # as "0 servers in ~/.claude.json").
+    assert not any(k.endswith("/.claude.json") for k in keys)
 
     abc_entries = merged.mcp_configs[abc_key]
-    legacy_entries = merged.mcp_configs[legacy_key]
     assert isinstance(abc_entries, list)
-    assert isinstance(legacy_entries, list)
     # The single server "srv" survives only under the ABC's per-project key.
     assert [name for name, _ in abc_entries] == ["srv"]
     assert all(isinstance(s, StdioServer) for _, s in abc_entries)
-    assert legacy_entries == []
 
 
 @pytest.mark.asyncio
@@ -1124,6 +1166,78 @@ def test_plugin_skills_respects_max_depth_cap(tmp_path):
     assert not any(k.endswith(f"/{too_deep_parent.name}/skills") for k in keys)
 
 
+def test_server_config_discriminator_keys_match_model_required_fields():
+    """_SERVER_CONFIG_DISCRIMINATOR_KEYS must stay in sync with the required
+    top-level fields of StdioServer + RemoteServer (including validation aliases).
+
+    The flat-vs-wrapped detector in ``_select_servers_payload`` relies on these
+    keys to tell a single server config apart from a server-name map. If a new
+    required field lands on either model (e.g. a new ``protocol`` discriminator)
+    and isn't added to the constant, the detector goes blind to that shape and
+    silently misreads adversarial inputs as wrapped maps.
+    """
+    from pydantic import AliasChoices
+
+    from agent_scan.agent_discovery import _SERVER_CONFIG_DISCRIMINATOR_KEYS
+    from agent_scan.models import RemoteServer, StdioServer
+
+    expected: set[str] = set()
+    for model in (StdioServer, RemoteServer):
+        for field_name, field in model.model_fields.items():
+            if not field.is_required():
+                continue
+            expected.add(field_name)
+            alias = field.validation_alias
+            if isinstance(alias, str):
+                expected.add(alias)
+            elif isinstance(alias, AliasChoices):
+                expected.update(c for c in alias.choices if isinstance(c, str))
+
+    assert expected == set(_SERVER_CONFIG_DISCRIMINATOR_KEYS), (
+        f"Required model fields {expected} drifted from "
+        f"_SERVER_CONFIG_DISCRIMINATOR_KEYS {set(_SERVER_CONFIG_DISCRIMINATOR_KEYS)}. "
+        "Update the constant in agent_discovery.py so the flat-vs-wrapped detector "
+        "still recognises every required server-config key."
+    )
+
+
+def test_plugin_walk_prunes_traversal_beyond_cap(tmp_path, monkeypatch):
+    """Traversal must be pruned at the depth cap, not just filtered post-hoc:
+    ``os.walk`` is invoked once per plugin base dir and `dirs` is mutated so the
+    walker never descends past the cap. We verify by spying on ``os.walk`` and
+    asserting it never yields a root past the prune boundary.
+    """
+    from pathlib import Path
+
+    import agent_scan.agent_discovery as ad
+
+    cache = tmp_path / ".claude" / "plugins" / "cache"
+    # Build a tree 3x deeper than the cap. If pruning didn't work, os.walk would
+    # yield roots at all those levels.
+    too_deep_dir = cache.joinpath(*[f"x{i}" for i in range(ad._MAX_PLUGIN_RGLOB_DEPTH * 3)])
+    too_deep_dir.mkdir(parents=True)
+
+    seen_depths: list[int] = []
+    real_walk = ad.os.walk
+
+    def spy_walk(p, *a, **k):
+        for root, dirs, files in real_walk(p, *a, **k):
+            try:
+                depth = len(Path(root).relative_to(p).parts)
+            except ValueError:
+                depth = 0
+            seen_depths.append(depth)
+            yield root, dirs, files
+
+    monkeypatch.setattr(ad.os, "walk", spy_walk)
+    list(ad._walk_under_depth(cache, ".mcp.json", ad._MAX_PLUGIN_RGLOB_DEPTH, want_file=True))
+
+    # Walker should never see a root whose depth would yield a path past the cap.
+    # Roots at depth (cap - 1) are the last to be visited; deeper roots are pruned.
+    assert seen_depths, "walk must run at least once"
+    assert max(seen_depths) <= ad._MAX_PLUGIN_RGLOB_DEPTH - 1
+
+
 # --- JSON5 parsing (comments + empty-file short-circuit) ---
 
 
@@ -1220,3 +1334,56 @@ def test_find_discoverers_skips_discoverer_that_raises_unexpected_exception(tmp_
 
     assert len(found) == 1
     assert isinstance(found[0], ClaudeCodeDiscoverer)
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_skips_discoverer_whose_discover_raises(tmp_path):
+    """A discoverer whose discover() raises mid-pipeline must not abort the loop —
+    other discoverers' results (and the legacy CTI) still land in clients_to_inspect.
+    """
+    from agent_scan.agent_discovery import DISCOVERERS, AgentDiscoverer
+    from agent_scan.models import CandidateClient
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    class ExplodingMidPipelineDiscoverer(AgentDiscoverer):
+        name = "exploding-mid"
+
+        def client_exists(self):
+            # Returns truthy so it gets into find_discoverers' return list,
+            # then blows up inside discover_mcp_servers.
+            return "/fake/path"
+
+        def discover_mcp_servers(self):
+            raise RuntimeError("boom from discover_mcp_servers")
+
+        def discover_skills(self):
+            return {}
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"mcpServers": {}}')
+
+    candidate = CandidateClient(
+        name="claude code",
+        client_exists_paths=["~/.claude"],
+        mcp_config_paths=["~/.claude.json"],
+        skills_dir_paths=["~/.claude/skills"],
+    )
+
+    DISCOVERERS["exploding-mid"] = ExplodingMidPipelineDiscoverer
+    try:
+        with (
+            patch(
+                "agent_scan.pipelines.get_readable_home_directories",
+                return_value=[(tmp_path, "alice")],
+            ),
+            patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+        ):
+            args = InspectArgs(timeout=10, tokens=[], paths=[])
+            ctis, _, _ = await discover_clients_to_inspect(args)
+    finally:
+        del DISCOVERERS["exploding-mid"]
+
+    # The exploding discoverer's CTI is dropped, but Claude Code's still lands.
+    names = {c.name for c in ctis}
+    assert "claude code" in names
+    assert "exploding-mid" not in names

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -362,33 +362,90 @@ def test_agent_discoverer_subclass_without_name_raises():
                 return {}
 
 
-# --- get_discoverer_class factory ---
+# --- DISCOVERERS registry + find_discoverers ---
 
 
-def test_get_discoverer_class_returns_claude_code_class():
-    from agent_scan.agent_discovery import ClaudeCodeDiscoverer, get_discoverer_class
+def test_DISCOVERERS_registers_only_claude_code():
+    from agent_scan.agent_discovery import DISCOVERERS
 
-    cls = get_discoverer_class("claude code")
-    assert cls is ClaudeCodeDiscoverer
-
-
-@pytest.mark.parametrize(
-    "agent_name",
-    ["cursor", "vscode", "windsurf", "claude", "codex", "gemini cli", "amp", "kiro"],
-)
-def test_get_discoverer_class_raises_not_implemented_for_unregistered_agent(agent_name):
-    from agent_scan.agent_discovery import get_discoverer_class
-
-    with pytest.raises(NotImplementedError):
-        get_discoverer_class(agent_name)
+    assert set(DISCOVERERS) == {"claude code"}
 
 
-# --- Pipeline dispatch: ABC for Claude Code, legacy for everything else ---
+def test_find_discoverers_returns_claude_code_when_installed(tmp_path):
+    from agent_scan.agent_discovery import ClaudeCodeDiscoverer, find_discoverers
+
+    (tmp_path / ".claude").mkdir()
+
+    found = find_discoverers(tmp_path)
+
+    assert len(found) == 1
+    assert isinstance(found[0], ClaudeCodeDiscoverer)
+    assert found[0].home_directory == tmp_path
+
+
+def test_find_discoverers_returns_empty_when_no_agents_installed(tmp_path):
+    from agent_scan.agent_discovery import find_discoverers
+
+    found = find_discoverers(tmp_path)
+
+    assert found == []
+
+
+# --- _dedup_mcp_servers (load-bearing helper) ---
+
+
+def test_dedup_mcp_servers_keeps_each_server_in_latest_inserted_key():
+    """Server names appearing in multiple keys are retained only under the latest one."""
+    from agent_scan.pipelines import _dedup_mcp_servers
+
+    srv1_a = StdioServer(command="a")
+    srv1_b = StdioServer(command="b")
+    srv2 = StdioServer(command="c")
+    cti = ClientToInspect(
+        name="claude code",
+        client_path="/home/alice/.claude",
+        mcp_configs={
+            "/home/alice/.claude.json": [("srv1", srv1_a), ("srv2", srv2)],
+            "/work/repo": [("srv1", srv1_b)],
+        },
+        skills_dirs={},
+    )
+
+    _dedup_mcp_servers(cti)
+
+    assert cti.mcp_configs["/home/alice/.claude.json"] == [("srv2", srv2)]
+    assert cti.mcp_configs["/work/repo"] == [("srv1", srv1_b)]
+
+
+def test_dedup_mcp_servers_preserves_error_type_entries():
+    """Error-type values (e.g., CouldNotParseMCPConfig) are not modified by dedup."""
+    from agent_scan.pipelines import _dedup_mcp_servers
+
+    err = CouldNotParseMCPConfig(message="boom", traceback="tb", is_failure=True)
+    srv = StdioServer(command="x")
+    cti = ClientToInspect(
+        name="claude code",
+        client_path="/home/alice/.claude",
+        mcp_configs={
+            "/home/alice/.claude.json": err,
+            "/work/repo": [("srv", srv)],
+        },
+        skills_dirs={},
+    )
+
+    _dedup_mcp_servers(cti)
+
+    assert cti.mcp_configs["/home/alice/.claude.json"] is err
+    assert cti.mcp_configs["/work/repo"] == [("srv", srv)]
+
+
+# --- Pipeline dispatch: legacy for all + ABC merge phase ---
 
 
 @pytest.mark.asyncio
-async def test_discover_clients_to_inspect_uses_abc_for_claude_code(tmp_path):
-    """Claude Code should be discovered via ClaudeCodeDiscoverer, not the legacy path."""
+async def test_discover_clients_to_inspect_runs_legacy_for_claude_code(tmp_path):
+    """Legacy get_mcp_config_per_client is invoked for Claude Code (no longer bypassed)."""
+    from agent_scan.inspect import get_mcp_config_per_client as real_legacy
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
@@ -408,29 +465,27 @@ async def test_discover_clients_to_inspect_uses_abc_for_claude_code(tmp_path):
             return_value=[(tmp_path, "alice")],
         ),
         patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
-        patch("agent_scan.pipelines.get_mcp_config_per_client") as spy_legacy,
+        patch(
+            "agent_scan.pipelines.get_mcp_config_per_client",
+            side_effect=real_legacy,
+        ) as spy_legacy,
     ):
         args = InspectArgs(timeout=10, tokens=[], paths=[])
-        ctis, _, _ = await discover_clients_to_inspect(args)
+        await discover_clients_to_inspect(args)
 
-    assert not spy_legacy.called, "Legacy path must not be called for claude code"
-    assert len(ctis) == 1
-    assert ctis[0].name == "claude code"
-    assert ctis[0].username == "alice"
+    assert spy_legacy.called, "Legacy path must be called for claude code"
+    called_names = {call.args[0].name for call in spy_legacy.call_args_list}
+    assert "claude code" in called_names
 
 
 @pytest.mark.asyncio
-async def test_discover_clients_to_inspect_iterates_all_home_dirs_for_claude_code(tmp_path):
-    """With multiple home dirs, the dispatcher constructs one discoverer per user."""
+async def test_discover_clients_to_inspect_merges_abc_into_legacy_cti_and_dedups_servers(tmp_path):
+    """One CTI per (name, username); legacy + ABC keys both present; servers deduped to latest key."""
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
-    alice_home = tmp_path / "alice"
-    bob_home = tmp_path / "bob"
-    (alice_home / ".claude").mkdir(parents=True)
-    (alice_home / ".claude.json").write_text('{"mcpServers": {}}')
-    (bob_home / ".claude").mkdir(parents=True)
-    (bob_home / ".claude.json").write_text('{"mcpServers": {}}')
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"projects": {"/work/repo": {"mcpServers": {"srv": {"command": "echo"}}}}}')
 
     candidate = CandidateClient(
         name="claude code",
@@ -442,22 +497,109 @@ async def test_discover_clients_to_inspect_iterates_all_home_dirs_for_claude_cod
     with (
         patch(
             "agent_scan.pipelines.get_readable_home_directories",
-            return_value=[(alice_home, "alice"), (bob_home, "bob")],
+            return_value=[(tmp_path, "alice")],
         ),
         patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
     ):
-        args = InspectArgs(timeout=10, tokens=[], paths=[], all_users=True)
+        args = InspectArgs(timeout=10, tokens=[], paths=[])
         ctis, _, _ = await discover_clients_to_inspect(args)
 
-    usernames = sorted(cti.username for cti in ctis)
-    assert usernames == ["alice", "bob"]
-    for cti in ctis:
-        assert cti.name == "claude code"
+    claude_ctis = [c for c in ctis if c.name == "claude code" and c.username == "alice"]
+    assert len(claude_ctis) == 1
+    merged = claude_ctis[0]
+
+    keys = list(merged.mcp_configs)
+    legacy_key = next(k for k in keys if k.endswith("/.claude.json"))
+    abc_key = next(k for k in keys if k == "/work/repo")
+    assert legacy_key and abc_key
+
+    abc_entries = merged.mcp_configs[abc_key]
+    legacy_entries = merged.mcp_configs[legacy_key]
+    assert isinstance(abc_entries, list)
+    assert isinstance(legacy_entries, list)
+    # The single server "srv" survives only under the ABC's per-project key.
+    assert [name for name, _ in abc_entries] == ["srv"]
+    assert all(isinstance(s, StdioServer) for _, s in abc_entries)
+    assert legacy_entries == []
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_dedup_keeps_global_only_servers_in_legacy_key(tmp_path):
+    """When ABC produces no project entries, legacy's ~/.claude.json entry is untouched."""
+    from agent_scan.models import CandidateClient
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"projects": {}}')
+
+    candidate = CandidateClient(
+        name="claude code",
+        client_exists_paths=["~/.claude"],
+        mcp_config_paths=["~/.claude.json"],
+        skills_dir_paths=["~/.claude/skills"],
+    )
+
+    with (
+        patch(
+            "agent_scan.pipelines.get_readable_home_directories",
+            return_value=[(tmp_path, "alice")],
+        ),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+    ):
+        args = InspectArgs(timeout=10, tokens=[], paths=[])
+        ctis, _, _ = await discover_clients_to_inspect(args)
+
+    claude_ctis = [c for c in ctis if c.name == "claude code"]
+    assert len(claude_ctis) == 1
+    keys = list(claude_ctis[0].mcp_configs)
+    # Only legacy keys present (no project keys from ABC to dedup against).
+    assert keys == [k for k in keys if k.endswith("/.claude.json")]
+
+
+@pytest.mark.asyncio
+async def test_discover_clients_to_inspect_abc_wins_on_same_key_collision(tmp_path):
+    """Both paths produce a ~/.claude.json key; ABC's value wins after merge+dedup."""
+    from agent_scan.models import CandidateClient
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text(
+        '{"mcpServers": {"top": {"command": "from-top"}}, '
+        '"projects": {"/work/repo": {"mcpServers": {"proj": {"command": "from-proj"}}}}}'
+    )
+
+    candidate = CandidateClient(
+        name="claude code",
+        client_exists_paths=["~/.claude"],
+        mcp_config_paths=["~/.claude.json"],
+        skills_dir_paths=["~/.claude/skills"],
+    )
+
+    with (
+        patch(
+            "agent_scan.pipelines.get_readable_home_directories",
+            return_value=[(tmp_path, "alice")],
+        ),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+    ):
+        args = InspectArgs(timeout=10, tokens=[], paths=[])
+        ctis, _, _ = await discover_clients_to_inspect(args)
+
+    claude_ctis = [c for c in ctis if c.name == "claude code"]
+    assert len(claude_ctis) == 1
+    merged = claude_ctis[0]
+
+    legacy_key = next(k for k in merged.mcp_configs if k.endswith("/.claude.json"))
+    entries = merged.mcp_configs[legacy_key]
+    assert isinstance(entries, list)
+    # After ABC's value overrides legacy under ~/.claude.json AND dedup moves "proj"
+    # into /work/repo, the legacy key retains only the global "top".
+    assert [name for name, _ in entries] == ["top"]
 
 
 @pytest.mark.asyncio
 async def test_discover_clients_to_inspect_falls_back_to_legacy_for_non_claude(tmp_path):
-    """Non-Claude agents (e.g. cursor) should still go through get_mcp_config_per_client."""
+    """Non-Claude agents (e.g. cursor) still go through get_mcp_config_per_client."""
     from agent_scan.models import CandidateClient
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -278,6 +278,7 @@ async def test_get_tool_versions_runs_probes_concurrently(monkeypatch):
     assert started.is_set(), "probes did not run concurrently"
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only behavior")
 class TestGetReadableHomeDirectoriesWindowsTimeout:
     """`Get-CimInstance Win32_UserProfile` can hang indefinitely when WMI is
     stuck (corrupted repository, unresponsive WinMgmt service, slow domain
@@ -292,8 +293,6 @@ class TestGetReadableHomeDirectoriesWindowsTimeout:
 
     def test_windows_profile_query_timeout_does_not_hang(self, monkeypatch, caplog):
         from pathlib import Path
-
-        monkeypatch.setattr(utils_module.platform, "system", lambda: "Windows")
 
         def fake_run(cmd, **kwargs):
             assert "timeout" in kwargs, "PowerShell CIM call must be invoked with a timeout to prevent indefinite hang"
@@ -326,8 +325,6 @@ class TestGetReadableHomeDirectoriesWindowsTimeout:
         against a refactor that drops the kwarg while keeping the except
         TimeoutExpired branch (which would silently never fire)."""
 
-        monkeypatch.setattr(utils_module.platform, "system", lambda: "Windows")
-
         captured: dict = {}
 
         def fake_run(cmd, **kwargs):
@@ -346,6 +343,7 @@ class TestGetReadableHomeDirectoriesWindowsTimeout:
         assert captured["timeout"] > 0
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="pwd module is POSIX-only")
 class TestGetReadableHomeDirectoriesPosix:
     """Cover the Linux/Darwin branch of ``get_readable_home_directories``.
 
@@ -511,3 +509,184 @@ class TestGetReadableHomeDirectoriesPosix:
 
         usernames = {u for _p, u in result}
         assert usernames == {"alice"}, f"non-existent home must be dropped; got {usernames}"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only behavior")
+class TestGetReadableHomeDirectoriesWindows:
+    """Cover the Windows branch of ``get_readable_home_directories``.
+
+    Parallels :class:`TestGetReadableHomeDirectoriesPosix` for the Win32
+    profile enumeration path: every LocalPath emitted by Win32_UserProfile is
+    filtered through ``Path.is_dir()`` + ``os.access(R_OK)`` and the username
+    is derived from the directory's basename. WSL homes are merged in afterward
+    so a Windows-only run still picks up Linux-side scan targets.
+
+    Skipped on POSIX hosts — runs only on actual Windows CI so the platform
+    branch is exercised against real Windows path semantics, not via a
+    ``platform.system`` mock.
+    """
+
+    def _stub_subprocess_run_with_paths(self, monkeypatch, paths):
+        """Make ``subprocess.run`` return the given paths as Win32_UserProfile output."""
+        stdout = "\n".join(str(p) for p in paths) + "\n"
+
+        def fake_run(_cmd, **_kwargs):
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
+
+    def test_single_user_when_all_users_false(self, monkeypatch):
+        """Single-user mode on Windows must short-circuit before invoking the
+        PowerShell CIM query — a hung WMI must never block the default path."""
+        def boom(*_a, **_kw):
+            raise AssertionError("subprocess.run must NOT be invoked when all_users=False")
+
+        monkeypatch.setattr(utils_module.subprocess, "run", boom)
+
+        result = get_readable_home_directories(all_users=False)
+
+        assert len(result) == 1
+        home_path, _username = result[0]
+        assert str(home_path) == os.path.expanduser("~")
+
+    def test_all_users_enumerates_local_paths(self, monkeypatch, tmp_path):
+        """Every non-empty LocalPath line from Win32_UserProfile must surface as
+        a (path, username) tuple where the username is the directory basename."""
+        alice_home = tmp_path / "alice"
+        bob_home = tmp_path / "bob"
+        alice_home.mkdir()
+        bob_home.mkdir()
+
+        self._stub_subprocess_run_with_paths(monkeypatch, [alice_home, bob_home])
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+        monkeypatch.setattr(utils_module, "get_wsl_home_directories", lambda: [])
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice", "bob"}, f"expected both profiles enumerated; got {usernames}"
+
+    def test_all_users_excludes_inaccessible_profiles(self, monkeypatch, tmp_path):
+        """A profile whose directory fails ``os.access(R_OK)`` must be dropped —
+        without this filter, an unprivileged ``--scan-all-users`` run on Windows
+        would surface other users' profiles it cannot actually read."""
+        alice_home = tmp_path / "alice"
+        bob_home = tmp_path / "bob"
+        alice_home.mkdir()
+        bob_home.mkdir()
+
+        self._stub_subprocess_run_with_paths(monkeypatch, [alice_home, bob_home])
+        # Only alice's home is readable.
+        monkeypatch.setattr(utils_module.os, "access", lambda path, _mode: str(path) == str(alice_home))
+        monkeypatch.setattr(utils_module, "get_wsl_home_directories", lambda: [])
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice"}, f"inaccessible profile must be dropped; got {usernames}"
+
+    def test_all_users_excludes_missing_profile_dirs(self, monkeypatch, tmp_path):
+        """A LocalPath whose directory doesn't exist on disk must be dropped
+        (stale Win32_UserProfile entries, deprovisioned accounts)."""
+        alice_home = tmp_path / "alice"
+        alice_home.mkdir()
+        ghost_home = tmp_path / "ghost-never-created"  # not mkdir'd
+
+        self._stub_subprocess_run_with_paths(monkeypatch, [alice_home, ghost_home])
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+        monkeypatch.setattr(utils_module, "get_wsl_home_directories", lambda: [])
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice"}, f"non-existent profile must be dropped; got {usernames}"
+
+    def test_all_users_skips_blank_local_path_lines(self, monkeypatch, tmp_path):
+        """Win32_UserProfile output can include blank lines (trailing newline,
+        whitespace-only entries). These must be skipped, not coerced into a
+        ``Path('')`` which would resolve to the CWD."""
+        alice_home = tmp_path / "alice"
+        alice_home.mkdir()
+
+        def fake_run(_cmd, **_kwargs):
+            stdout = f"\n   \n{alice_home}\n\n"
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+        monkeypatch.setattr(utils_module, "get_wsl_home_directories", lambda: [])
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice"}, f"blank lines must be ignored; got {usernames}"
+
+    def test_all_users_merges_wsl_homes_alongside_win32_profiles(self, monkeypatch, tmp_path):
+        """WSL enumeration runs after Win32 profile collection; both result
+        sets must appear in the merged output so a Windows scan reaches
+        Linux-side agent state too."""
+        alice_home = tmp_path / "alice"
+        wsl_home = tmp_path / "wsl_ubuntu_alice"
+        alice_home.mkdir()
+        wsl_home.mkdir()
+
+        self._stub_subprocess_run_with_paths(monkeypatch, [alice_home])
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+        monkeypatch.setattr(
+            utils_module,
+            "get_wsl_home_directories",
+            lambda: [(wsl_home, "wsl_alice")],
+        )
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice", "wsl_alice"}, (
+            f"WSL homes must merge with Win32 profiles; got {usernames}"
+        )
+
+    def test_all_users_wsl_does_not_overwrite_existing_win32_path(self, monkeypatch, tmp_path):
+        """If WSL enumeration emits a path already covered by a Win32 profile,
+        the Win32 username (set first) must win — otherwise a stale WSL entry
+        could rename a legitimate Windows profile in scan output."""
+        shared_home = tmp_path / "alice"
+        shared_home.mkdir()
+
+        self._stub_subprocess_run_with_paths(monkeypatch, [shared_home])
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+        monkeypatch.setattr(
+            utils_module,
+            "get_wsl_home_directories",
+            lambda: [(shared_home, "wsl_alice_collision")],
+        )
+
+        result = get_readable_home_directories(all_users=True)
+
+        assert len(result) == 1, f"duplicate path must be deduped; got {result}"
+        _path, username = result[0]
+        assert username == "alice", f"Win32 username must win on collision; got {username!r}"
+
+    def test_all_users_subprocess_failure_still_returns_wsl_homes(self, monkeypatch, tmp_path):
+        """A PowerShell failure (CalledProcessError / FileNotFoundError) must
+        be logged and swallowed so WSL enumeration still runs — the two signal
+        sources are independent."""
+        wsl_home = tmp_path / "wsl_alice_home"
+        wsl_home.mkdir()
+
+        def fake_run(cmd, **_kwargs):
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+        monkeypatch.setattr(
+            utils_module,
+            "get_wsl_home_directories",
+            lambda: [(wsl_home, "wsl_alice")],
+        )
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"wsl_alice"}, (
+            f"WSL homes must still surface when CIM query fails; got {usernames}"
+        )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -344,3 +344,172 @@ class TestGetReadableHomeDirectoriesWindowsTimeout:
         )
         assert isinstance(captured["timeout"], int | float)
         assert captured["timeout"] > 0
+
+
+class TestGetReadableHomeDirectoriesPosix:
+    """Cover the Linux/Darwin branch of ``get_readable_home_directories``.
+
+    The ``--scan-all-users`` flag depends on this enumeration returning every
+    accessible human-user home. The previous coverage was Windows-only, so
+    regressions in the POSIX path (e.g. wrong UID threshold, dropping the
+    ``nobody`` filter, skipping the ``os.access`` gate) would silently
+    degrade multi-user scans.
+    """
+
+    def _fake_pwd_entry(self, name, uid, home):
+        return SimpleNamespace(pw_name=name, pw_uid=uid, pw_dir=home)
+
+    def test_single_user_when_all_users_false(self, monkeypatch):
+        """Single-user mode is the default and must return exactly the current
+        process's home — never call into pwd enumeration."""
+
+        def boom():
+            raise AssertionError("pwd.getpwall() must NOT be consulted when all_users=False")
+
+        import pwd as pwd_module
+
+        monkeypatch.setattr(pwd_module, "getpwall", boom)
+
+        result = get_readable_home_directories(all_users=False)
+
+        assert len(result) == 1
+        home_path, username = result[0]
+        assert home_path == os.path.expanduser("~") or str(home_path) == os.path.expanduser("~")
+
+    def test_all_users_linux_enumerates_above_uid_threshold(self, monkeypatch, tmp_path):
+        """Linux uses UID >= 1000 as the human-user threshold. System accounts
+        (root=0, daemon=1, etc.) must be excluded."""
+        monkeypatch.setattr(utils_module.platform, "system", lambda: "Linux")
+
+        alice_home = tmp_path / "alice"
+        bob_home = tmp_path / "bob"
+        alice_home.mkdir()
+        bob_home.mkdir()
+
+        import pwd as pwd_module
+
+        monkeypatch.setattr(
+            pwd_module,
+            "getpwall",
+            lambda: [
+                self._fake_pwd_entry("root", 0, "/root"),
+                self._fake_pwd_entry("daemon", 1, "/usr/sbin"),
+                self._fake_pwd_entry("alice", 1000, str(alice_home)),
+                self._fake_pwd_entry("bob", 1001, str(bob_home)),
+            ],
+        )
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice", "bob"}, f"system users must be filtered out; got {usernames}"
+
+    def test_all_users_darwin_uses_lower_uid_threshold(self, monkeypatch, tmp_path):
+        """macOS human UIDs start at 500, so a UID-501 user must be included
+        on Darwin but excluded on Linux (verified by the previous test)."""
+        monkeypatch.setattr(utils_module.platform, "system", lambda: "Darwin")
+
+        alice_home = tmp_path / "alice"
+        alice_home.mkdir()
+
+        import pwd as pwd_module
+
+        monkeypatch.setattr(
+            pwd_module,
+            "getpwall",
+            lambda: [
+                self._fake_pwd_entry("_some_macos_service", 200, "/var/empty"),
+                self._fake_pwd_entry("alice", 501, str(alice_home)),
+            ],
+        )
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice"}, f"UID-200 must be filtered, UID-501 kept; got {usernames}"
+
+    def test_all_users_excludes_nobody(self, monkeypatch, tmp_path):
+        """The ``nobody`` account often has a high UID (macOS: -2 / 4294967294,
+        Linux distros: 65534) and must be filtered by name regardless of UID."""
+        monkeypatch.setattr(utils_module.platform, "system", lambda: "Linux")
+
+        alice_home = tmp_path / "alice"
+        nobody_home = tmp_path / "nobody"
+        alice_home.mkdir()
+        nobody_home.mkdir()
+
+        import pwd as pwd_module
+
+        monkeypatch.setattr(
+            pwd_module,
+            "getpwall",
+            lambda: [
+                self._fake_pwd_entry("nobody", 65534, str(nobody_home)),
+                self._fake_pwd_entry("alice", 1000, str(alice_home)),
+            ],
+        )
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice"}, f"'nobody' must be filtered by name; got {usernames}"
+
+    def test_all_users_excludes_inaccessible_homes(self, monkeypatch, tmp_path):
+        """A user whose home fails ``os.access(R_OK | X_OK)`` must be dropped —
+        without this filter, an unprivileged ``--scan-all-users`` run would
+        attempt to read homes it cannot traverse and surface spurious errors."""
+        monkeypatch.setattr(utils_module.platform, "system", lambda: "Linux")
+
+        alice_home = tmp_path / "alice"
+        bob_home = tmp_path / "bob"
+        alice_home.mkdir()
+        bob_home.mkdir()
+
+        import pwd as pwd_module
+
+        monkeypatch.setattr(
+            pwd_module,
+            "getpwall",
+            lambda: [
+                self._fake_pwd_entry("alice", 1000, str(alice_home)),
+                self._fake_pwd_entry("bob", 1001, str(bob_home)),
+            ],
+        )
+        # Only alice's home is accessible.
+        monkeypatch.setattr(
+            utils_module.os, "access", lambda path, _mode: str(path) == str(alice_home)
+        )
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice"}, f"inaccessible home must be dropped; got {usernames}"
+
+    def test_all_users_excludes_missing_home_dirs(self, monkeypatch, tmp_path):
+        """A pwd entry whose ``pw_dir`` doesn't exist on disk must be dropped
+        (stale /etc/passwd entries, deprovisioned accounts)."""
+        monkeypatch.setattr(utils_module.platform, "system", lambda: "Linux")
+
+        alice_home = tmp_path / "alice"
+        alice_home.mkdir()
+        ghost_home = tmp_path / "ghost-never-created"  # not mkdir'd
+
+        import pwd as pwd_module
+
+        monkeypatch.setattr(
+            pwd_module,
+            "getpwall",
+            lambda: [
+                self._fake_pwd_entry("alice", 1000, str(alice_home)),
+                self._fake_pwd_entry("ghost", 1001, str(ghost_home)),
+            ],
+        )
+        monkeypatch.setattr(utils_module.os, "access", lambda *_a, **_k: True)
+
+        result = get_readable_home_directories(all_users=True)
+
+        usernames = {u for _p, u in result}
+        assert usernames == {"alice"}, f"non-existent home must be dropped; got {usernames}"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -479,9 +479,7 @@ class TestGetReadableHomeDirectoriesPosix:
             ],
         )
         # Only alice's home is accessible.
-        monkeypatch.setattr(
-            utils_module.os, "access", lambda path, _mode: str(path) == str(alice_home)
-        )
+        monkeypatch.setattr(utils_module.os, "access", lambda path, _mode: str(path) == str(alice_home))
 
         result = get_readable_home_directories(all_users=True)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -538,6 +538,7 @@ class TestGetReadableHomeDirectoriesWindows:
     def test_single_user_when_all_users_false(self, monkeypatch):
         """Single-user mode on Windows must short-circuit before invoking the
         PowerShell CIM query — a hung WMI must never block the default path."""
+
         def boom(*_a, **_kw):
             raise AssertionError("subprocess.run must NOT be invoked when all_users=False")
 
@@ -641,9 +642,7 @@ class TestGetReadableHomeDirectoriesWindows:
         result = get_readable_home_directories(all_users=True)
 
         usernames = {u for _p, u in result}
-        assert usernames == {"alice", "wsl_alice"}, (
-            f"WSL homes must merge with Win32 profiles; got {usernames}"
-        )
+        assert usernames == {"alice", "wsl_alice"}, f"WSL homes must merge with Win32 profiles; got {usernames}"
 
     def test_all_users_wsl_does_not_overwrite_existing_win32_path(self, monkeypatch, tmp_path):
         """If WSL enumeration emits a path already covered by a Win32 profile,
@@ -687,6 +686,4 @@ class TestGetReadableHomeDirectoriesWindows:
         result = get_readable_home_directories(all_users=True)
 
         usernames = {u for _p, u in result}
-        assert usernames == {"wsl_alice"}, (
-            f"WSL homes must still surface when CIM query fails; got {usernames}"
-        )
+        assert usernames == {"wsl_alice"}, f"WSL homes must still surface when CIM query fails; got {usernames}"


### PR DESCRIPTION
## Summary

- New `agent_scan/agent_discovery.py` module: `AgentDiscoverer` ABC plus a concrete `ClaudeCodeDiscoverer`. Each subclass encapsulates one agent's filesystem layout (install path, MCP-config file, skills dir) and produces a `ClientToInspect`. `ClaudeCodeDiscoverer` covers three scopes: user-global (`~/.claude.json` + `~/.claude/skills`), per-project (`projects.<path>.mcpServers` in `~/.claude.json`, `<project>/.mcp.json`, `<project>/.claude/skills` — walked through every ancestor of each registered project), and plugin (`~/.claude/plugins/{cache,repos}/**/.mcp.json` and `**/skills/`, with a depth-capped `os.walk`).
- `discover_clients_to_inspect()` now runs in two phases:
  - **Phase A — legacy.** `get_mcp_config_per_client` runs for every well-known client (including Claude Code), exactly as before. Non-Claude agents see zero behavioral change.
  - **Phase B — ABC.** `find_discoverers(home_directory)` returns every registered discoverer whose `client_exists()` is True (today: only `ClaudeCodeDiscoverer`). For each, `discover()` is called and the result is merged into the existing Claude Code CTI (matched by `(name, username)`). On dict union, ABC values win on key collision (e.g. both phases emit a server under `~/.claude.json`). Distinct keys from each phase coexist — same-name servers under different keys are preserved as separate registrations (e.g. the same `github` server configured in two projects must both reach the inspector).
- Net effect for Claude Code: same global servers as before, plus newly discovered per-project and plugin servers. Same-name registrations across distinct keys (per-project `github` with different tokens, etc.) survive intact; only true same-key collisions are resolved (ABC wins). Non-Claude agents go through Phase A only.

## Notes

- An earlier revision included a Phase C that deduplicated servers by name across `mcp_configs` keys. That has been removed: the by-name predicate silently dropped legitimate multi-project registrations (e.g. `github` configured per-repo with different `--token` args would lose all but the last-inserted project's config). The dict-union merge in Phase B already handles the only collision case that needs handling — same key, same name — and gives ABC the authoritative value. The trade-off: a symlinked `~/.claude.json` is now scanned twice (once per phase's key form, since legacy resolves and ABC does not). Fixing that is a separate concern about key normalization, not a reason to keep the over-aggressive dedup.