### PR TITLE
fix: discover ~/.agents/skills by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Agent Scan auto-discovers agents and their capabilities (MCP servers or skills) 
 | Gemini CLI | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | OpenClaw | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
 | Amp | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
+| Agents | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
 | Kiro | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ |
 | OpenCode | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Antigravity | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ |

--- a/src/agent_scan/well_known_clients.py
+++ b/src/agent_scan/well_known_clients.py
@@ -71,6 +71,12 @@ MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
     ),
     CandidateClient(
+        name="agents",
+        client_exists_paths=["~/.agents"],
+        mcp_config_paths=[],
+        skills_dir_paths=["~/.agents/skills"],
+    ),
+    CandidateClient(
         name="kiro",
         client_exists_paths=["~/.kiro"],
         mcp_config_paths=["~/.kiro/settings/mcp.json"],
@@ -159,6 +165,12 @@ LINUX_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         client_exists_paths=["~/.config/agents", ".amp"],
         mcp_config_paths=[],
         skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
+    ),
+    CandidateClient(
+        name="agents",
+        client_exists_paths=["~/.agents"],
+        mcp_config_paths=[],
+        skills_dir_paths=["~/.agents/skills"],
     ),
     CandidateClient(
         name="kiro",
@@ -256,6 +268,12 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         client_exists_paths=["~/.config/agents", ".amp"],
         mcp_config_paths=[],
         skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
+    ),
+    CandidateClient(
+        name="agents",
+        client_exists_paths=["~/.agents"],
+        mcp_config_paths=[],
+        skills_dir_paths=["~/.agents/skills"],
     ),
     CandidateClient(
         name="kiro",

--- a/tests/unit/test_well_known_clients.py
+++ b/tests/unit/test_well_known_clients.py
@@ -1,0 +1,43 @@
+import pytest
+
+from agent_scan.inspect import get_mcp_config_per_client
+from agent_scan.well_known_clients import (
+    LINUX_WELL_KNOWN_CLIENTS,
+    MACOS_WELL_KNOWN_CLIENTS,
+    WINDOWS_WELL_KNOWN_CLIENTS,
+)
+
+
+def _agents_client(clients):
+    return next(client for client in clients if client.name == "agents")
+
+
+def test_agents_client_discovers_agents_skills_directory_on_all_platforms():
+    for clients in (MACOS_WELL_KNOWN_CLIENTS, LINUX_WELL_KNOWN_CLIENTS, WINDOWS_WELL_KNOWN_CLIENTS):
+        agents = _agents_client(clients)
+
+        assert "~/.agents" in agents.client_exists_paths
+        assert "~/.agents/skills" in agents.skills_dir_paths
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "clients",
+    [MACOS_WELL_KNOWN_CLIENTS, LINUX_WELL_KNOWN_CLIENTS, WINDOWS_WELL_KNOWN_CLIENTS],
+    ids=["macos", "linux", "windows"],
+)
+async def test_agents_skills_directory_is_scanned_from_default_home(tmp_path, clients):
+    home = tmp_path / "home"
+    skill_dir = home / ".agents" / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Demo Skill\n\nA test skill.", encoding="utf-8")
+
+    ctis = await get_mcp_config_per_client(_agents_client(clients), [(home, "test-user")])
+
+    skills_path = (home / ".agents" / "skills").resolve().as_posix()
+    assert len(ctis) == 1
+    assert ctis[0].username == "test-user"
+    assert skills_path in ctis[0].skills_dirs
+    skills = ctis[0].skills_dirs[skills_path]
+    assert isinstance(skills, list)
+    assert [(name, skill.path) for name, skill in skills] == [("demo-skill", skill_dir.as_posix())]


### PR DESCRIPTION
## Summary

Agent Scan currently auto-discovers Amp skills from `~/.config/agents/skills` and `.amp/skills`, but it does not discover skills installed under the generic `~/.agents/skills` directory unless the user passes that path explicitly.

This PR adds a separate well-known `agents` client for `~/.agents` on macOS, Linux, and Windows. Keeping it separate from `amp` avoids attributing a generic agents directory to Amp-specific scan results.

## Changes

- Add `~/.agents` as the install marker for a new `agents` well-known client.
- Add `~/.agents/skills` as that client's skills directory on macOS, Linux, and Windows.
- Add tests that cover both the platform definitions and the default home-directory discovery path.
- Update the README supported agents table to show the new skills discovery support.

## Scope / Risk

This only expands default local skills-directory discovery. It does not change MCP server startup, network behavior, consent handling, upload behavior, or skill analysis logic.

## Verification

```bash
make test tests/unit/test_well_known_clients.py
make test tests/unit/test_well_known_clients.py tests/unit/test_inspect.py tests/unit/test_cli_parsing.py ARGS="-q"
ruff check README.md src/agent_scan/well_known_clients.py tests/unit/test_well_known_clients.py
ruff format --check src/agent_scan/well_known_clients.py tests/unit/test_well_known_clients.py
```

Closes #317.
