### PR TITLE
feat(inspect): dedup identical MCP server inspections per scan run

### DIFF
--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -385,14 +385,15 @@ async def inspect_client(
                     "Reusing cached signature for MCP server",
                     extra={"server_name": name, "mcp_config_path": mcp_config_path},
                 )
-                # Deep-copy so downstream in-place mutation (e.g. redact_server
-                # rewriting RemoteServer.headers/url or StdioServer.env/args)
-                # touches only this occurrence and never aliases siblings.
+                # Deep-copy both halves so downstream in-place mutation
+                # (redact_server rewriting RemoteServer.headers/url or
+                # StdioServer.env/args; future mutators of ServerSignature
+                # tools/prompts) touches only this occurrence.
                 extensions_for_mcp_config.append(
                     InspectedExtensions(
                         name=name,
                         config=cached_config.model_copy(deep=True),
-                        signature_or_error=cached_result,
+                        signature_or_error=cached_result.model_copy(deep=True),
                     )
                 )
                 continue

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -189,6 +189,23 @@ def find_relevant_token(tokens: list[TokenAndClientInfo], name: str) -> TokenAnd
     return None
 
 
+def _server_dedup_key(config: StdioServer | RemoteServer | SkillServer) -> tuple | None:
+    """Return a hashable key identifying the server config for inspection-cache dedup.
+
+    Two configs that produce the same key are assumed to launch the same
+    underlying server and yield the same signature, so the second occurrence
+    can reuse the first one's ``signature_or_error``. Returns ``None`` for
+    config kinds we do not dedup (skills are cheap local reads).
+    """
+    if isinstance(config, StdioServer):
+        env = tuple(sorted((config.env or {}).items()))
+        return ("stdio", config.command, tuple(config.args), env)
+    if isinstance(config, RemoteServer):
+        headers = tuple(sorted(config.headers.items()))
+        return ("remote", config.url, config.type, headers)
+    return None
+
+
 async def inspect_extension(
     name: str,
     config: StdioServer | RemoteServer | SkillServer,
@@ -298,6 +315,7 @@ async def inspect_client(
     *,
     stream_stderr: bool = False,
     declined_servers: set[tuple[str, str]] | None = None,
+    signature_cache: dict | None = None,
 ) -> InspectedClient:
     """
     Scan a client (Cursor, VSCode, etc.) and return a InspectedClient object.
@@ -305,6 +323,12 @@ async def inspect_client(
     declined_servers is an optional set of (mcp_config_path, server_name)
     pairs the user declined during the consent flow. Declined stdio servers are
     not started. They are recorded as errors with category user_declined.
+
+    signature_cache, if provided, dedupes inspections of identical server
+    configs across multiple calls: the first occurrence runs through
+    ``inspect_extension`` and stores its ``signature_or_error`` keyed by
+    ``_server_dedup_key(server)``; later occurrences reuse the cached value
+    without re-launching the server.
     """
     declined = declined_servers or set()
     extensions: dict[
@@ -353,6 +377,20 @@ async def inspect_client(
                     )
                 )
                 continue
+            dedup_key = _server_dedup_key(server) if signature_cache is not None else None
+            if signature_cache is not None and dedup_key is not None and dedup_key in signature_cache:
+                logger.debug(
+                    "Reusing cached signature for MCP server",
+                    extra={"server_name": name, "mcp_config_path": mcp_config_path},
+                )
+                extensions_for_mcp_config.append(
+                    InspectedExtensions(
+                        name=name,
+                        config=server,
+                        signature_or_error=signature_cache[dedup_key],
+                    )
+                )
+                continue
             extension = await inspect_extension(
                 name,
                 server,
@@ -361,6 +399,8 @@ async def inspect_client(
                 config_path=mcp_config_path,
                 stream_stderr=stream_stderr,
             )
+            if signature_cache is not None and dedup_key is not None:
+                signature_cache[dedup_key] = extension.signature_or_error
             extensions_for_mcp_config.append(extension)
         extensions[mcp_config_path] = extensions_for_mcp_config
 

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -385,10 +385,13 @@ async def inspect_client(
                     "Reusing cached signature for MCP server",
                     extra={"server_name": name, "mcp_config_path": mcp_config_path},
                 )
+                # Deep-copy so downstream in-place mutation (e.g. redact_server
+                # rewriting RemoteServer.headers/url or StdioServer.env/args)
+                # touches only this occurrence and never aliases siblings.
                 extensions_for_mcp_config.append(
                     InspectedExtensions(
                         name=name,
-                        config=cached_config,
+                        config=cached_config.model_copy(deep=True),
                         signature_or_error=cached_result,
                     )
                 )

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -38,7 +38,7 @@ from agent_scan.well_known_clients import expand_path
 
 logger = logging.getLogger(__name__)
 
-SignatureCache: TypeAlias = dict[
+InspectionCache: TypeAlias = dict[
     tuple,
     tuple[
         StdioServer | RemoteServer,
@@ -329,7 +329,7 @@ async def inspect_client(
     *,
     stream_stderr: bool = False,
     declined_servers: set[tuple[str, str]] | None = None,
-    signature_cache: SignatureCache | None = None,
+    inspection_cache: InspectionCache | None = None,
 ) -> InspectedClient:
     """
     Scan a client (Cursor, VSCode, etc.) and return a InspectedClient object.
@@ -338,7 +338,7 @@ async def inspect_client(
     pairs the user declined during the consent flow. Declined stdio servers are
     not started. They are recorded as errors with category user_declined.
 
-    signature_cache, if provided, dedupes inspections of identical server
+    inspection_cache, if provided, dedupes inspections of identical server
     configs across multiple calls: the first occurrence runs through
     ``inspect_extension`` and stores ``(resolved_config, signature_or_error)``
     keyed by ``_server_dedup_key(server)``; later occurrences reuse both the
@@ -392,9 +392,9 @@ async def inspect_client(
                     )
                 )
                 continue
-            dedup_key = _server_dedup_key(server) if signature_cache is not None else None
-            if signature_cache is not None and dedup_key is not None and dedup_key in signature_cache:
-                cached_config, cached_result = signature_cache[dedup_key]
+            dedup_key = _server_dedup_key(server) if inspection_cache is not None else None
+            if inspection_cache is not None and dedup_key is not None and dedup_key in inspection_cache:
+                cached_config, cached_result = inspection_cache[dedup_key]
                 logger.debug(
                     "Reusing cached signature for MCP server",
                     extra={"server_name": name, "mcp_config_path": mcp_config_path},
@@ -419,8 +419,8 @@ async def inspect_client(
                 config_path=mcp_config_path,
                 stream_stderr=stream_stderr,
             )
-            if signature_cache is not None and dedup_key is not None:
-                signature_cache[dedup_key] = (extension.config, extension.signature_or_error)
+            if inspection_cache is not None and dedup_key is not None:
+                inspection_cache[dedup_key] = (extension.config, extension.signature_or_error)
             extensions_for_mcp_config.append(extension)
         extensions[mcp_config_path] = extensions_for_mcp_config
 

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import traceback
 from pathlib import Path
+from typing import TypeAlias
 
 from httpx import HTTPStatusError
 
@@ -36,6 +37,19 @@ from agent_scan.traffic_capture import TrafficCapture
 from agent_scan.well_known_clients import expand_path
 
 logger = logging.getLogger(__name__)
+
+SignatureCache: TypeAlias = dict[
+    tuple,
+    tuple[
+        StdioServer | RemoteServer,
+        ServerSignature
+        | ServerStartupError
+        | ServerHTTPError
+        | SkillScannError
+        | UserDeclinedError
+        | SkippedByRuntimeConfigError,
+    ],
+]
 
 
 def _resolve_glob_with_depth(pattern: str, max_depth: int) -> list[str]:
@@ -315,7 +329,7 @@ async def inspect_client(
     *,
     stream_stderr: bool = False,
     declined_servers: set[tuple[str, str]] | None = None,
-    signature_cache: dict | None = None,
+    signature_cache: SignatureCache | None = None,
 ) -> InspectedClient:
     """
     Scan a client (Cursor, VSCode, etc.) and return a InspectedClient object.

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -326,9 +326,10 @@ async def inspect_client(
 
     signature_cache, if provided, dedupes inspections of identical server
     configs across multiple calls: the first occurrence runs through
-    ``inspect_extension`` and stores its ``signature_or_error`` keyed by
-    ``_server_dedup_key(server)``; later occurrences reuse the cached value
-    without re-launching the server.
+    ``inspect_extension`` and stores ``(resolved_config, signature_or_error)``
+    keyed by ``_server_dedup_key(server)``; later occurrences reuse both the
+    resolved config (e.g. a RemoteServer with type defaulted to "http") and
+    the cached result without re-launching the server.
     """
     declined = declined_servers or set()
     extensions: dict[
@@ -379,6 +380,7 @@ async def inspect_client(
                 continue
             dedup_key = _server_dedup_key(server) if signature_cache is not None else None
             if signature_cache is not None and dedup_key is not None and dedup_key in signature_cache:
+                cached_config, cached_result = signature_cache[dedup_key]
                 logger.debug(
                     "Reusing cached signature for MCP server",
                     extra={"server_name": name, "mcp_config_path": mcp_config_path},
@@ -386,8 +388,8 @@ async def inspect_client(
                 extensions_for_mcp_config.append(
                     InspectedExtensions(
                         name=name,
-                        config=server,
-                        signature_or_error=signature_cache[dedup_key],
+                        config=cached_config,
+                        signature_or_error=cached_result,
                     )
                 )
                 continue
@@ -400,7 +402,7 @@ async def inspect_client(
                 stream_stderr=stream_stderr,
             )
             if signature_cache is not None and dedup_key is not None:
-                signature_cache[dedup_key] = extension.signature_or_error
+                signature_cache[dedup_key] = (extension.config, extension.signature_or_error)
             extensions_for_mcp_config.append(extension)
         extensions[mcp_config_path] = extensions_for_mcp_config
 

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -152,6 +152,11 @@ async def inspect_pipeline(
         )
     scan_path_results: list[ScanPathResult] = list(precomputed_scan_path_results or [])
 
+    # Shared across all clients in this run so an identical server config that
+    # appears in more than one client (same `github` server in Cursor + Claude
+    # Code, or the same project ``.mcp.json`` referenced via multiple paths) is
+    # inspected once and its signature reused for every other occurrence.
+    signature_cache: dict = {}
     for client_to_inspect in clients_to_inspect:
         inspected_client = await inspect_client(
             client_to_inspect,
@@ -160,6 +165,7 @@ async def inspect_pipeline(
             inspect_args.scan_skills,
             stream_stderr=stream_stderr,
             declined_servers=declined_servers,
+            signature_cache=signature_cache,
         )
         scan_path_results.append(inspected_client_to_scan_path_result(inspected_client))
     return scan_path_results, scanned_usernames or []

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from agent_scan.agent_discovery import find_discoverers
 from agent_scan.direct_scanner import direct_scan_to_server_config, is_direct_scan
 from agent_scan.inspect import (
-    SignatureCache,
+    InspectionCache,
     get_mcp_config_per_client,
     inspect_client,
     inspected_client_to_scan_path_result,
@@ -157,7 +157,7 @@ async def inspect_pipeline(
     # appears in more than one client (same `github` server in Cursor + Claude
     # Code, or the same project ``.mcp.json`` referenced via multiple paths) is
     # inspected once and its signature reused for every other occurrence.
-    signature_cache: SignatureCache = {}
+    inspection_cache: InspectionCache = {}
     for client_to_inspect in clients_to_inspect:
         inspected_client = await inspect_client(
             client_to_inspect,
@@ -166,7 +166,7 @@ async def inspect_pipeline(
             inspect_args.scan_skills,
             stream_stderr=stream_stderr,
             declined_servers=declined_servers,
-            signature_cache=signature_cache,
+            inspection_cache=inspection_cache,
         )
         scan_path_results.append(inspected_client_to_scan_path_result(inspected_client))
     return scan_path_results, scanned_usernames or []

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from agent_scan.agent_discovery import find_discoverers
 from agent_scan.direct_scanner import direct_scan_to_server_config, is_direct_scan
 from agent_scan.inspect import (
+    SignatureCache,
     get_mcp_config_per_client,
     inspect_client,
     inspected_client_to_scan_path_result,
@@ -156,7 +157,7 @@ async def inspect_pipeline(
     # appears in more than one client (same `github` server in Cursor + Claude
     # Code, or the same project ``.mcp.json`` referenced via multiple paths) is
     # inspected once and its signature reused for every other occurrence.
-    signature_cache: dict = {}
+    signature_cache: SignatureCache = {}
     for client_to_inspect in clients_to_inspect:
         inspected_client = await inspect_client(
             client_to_inspect,

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -676,7 +676,7 @@ async def test_inspect_client_skips_server_per_runtime_config_without_starting_s
     assert call_names == ["other"]
 
 
-# --- signature cache dedup tests ---
+# --- inspection cache dedup tests ---
 
 
 def _make_signature(server_info_name: str = "x"):
@@ -725,7 +725,7 @@ async def test_inspect_client_dedup_same_stdio_config_under_two_paths():
     with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
         mock_ie.side_effect = _fake_inspect_extension_factory(calls, signature)
         cache: dict = {}
-        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache=cache)
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, inspection_cache=cache)
 
     assert len(calls) == 1
     a_ext = result.extensions["/a/.mcp.json"][0]
@@ -787,7 +787,7 @@ async def test_inspect_client_does_not_dedup_when_env_differs():
 
     with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
         mock_ie.side_effect = _fake_inspect_extension_factory(calls, _make_signature())
-        await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+        await inspect_client(client, timeout=10, tokens=[], scan_skills=False, inspection_cache={})
 
     assert len(calls) == 2
 
@@ -810,7 +810,7 @@ async def test_inspect_client_does_not_dedup_when_args_differ():
 
     with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
         mock_ie.side_effect = _fake_inspect_extension_factory(calls, _make_signature())
-        await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+        await inspect_client(client, timeout=10, tokens=[], scan_skills=False, inspection_cache={})
 
     assert len(calls) == 2
 
@@ -837,7 +837,7 @@ async def test_inspect_client_caches_errors_too():
     calls: list[str] = []
     with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
         mock_ie.side_effect = _fake_inspect_extension_factory(calls, error)
-        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, inspection_cache={})
 
     assert len(calls) == 1
     a_ext = result.extensions["/a.json"][0]
@@ -894,7 +894,7 @@ async def test_inspect_client_cached_entry_mirrors_resolved_config():
 
     with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
         mock_ie.side_effect = fake
-        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, inspection_cache={})
 
     assert result.extensions["/a.json"][0].config.type == "http"
     assert result.extensions["/b.json"][0].config.type == "http"
@@ -918,7 +918,7 @@ async def test_inspect_client_cached_configs_are_independent_instances():
 
     with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
         mock_ie.side_effect = _fake_inspect_extension_factory([], signature)
-        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, inspection_cache={})
 
     first = result.extensions["/a.json"][0].config
     second = result.extensions["/b.json"][0].config
@@ -948,7 +948,7 @@ async def test_inspect_client_cached_signatures_are_independent_instances():
 
     with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
         mock_ie.side_effect = _fake_inspect_extension_factory([], signature)
-        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, inspection_cache={})
 
     first_sig = result.extensions["/a.json"][0].signature_or_error
     second_sig = result.extensions["/b.json"][0].signature_or_error

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -730,8 +730,9 @@ async def test_inspect_client_dedup_same_stdio_config_under_two_paths():
     assert len(calls) == 1
     a_ext = result.extensions["/a/.mcp.json"][0]
     b_ext = result.extensions["/b/.mcp.json"][0]
-    assert a_ext.signature_or_error is signature
-    assert b_ext.signature_or_error is signature
+    assert a_ext.signature_or_error == signature
+    assert b_ext.signature_or_error == signature
+    assert a_ext.signature_or_error is not b_ext.signature_or_error
 
 
 @pytest.mark.asyncio
@@ -841,8 +842,9 @@ async def test_inspect_client_caches_errors_too():
     assert len(calls) == 1
     a_ext = result.extensions["/a.json"][0]
     b_ext = result.extensions["/b.json"][0]
-    assert a_ext.signature_or_error is error
-    assert b_ext.signature_or_error is error
+    assert a_ext.signature_or_error == error
+    assert b_ext.signature_or_error == error
+    assert a_ext.signature_or_error is not b_ext.signature_or_error
 
 
 def test_server_dedup_key_returns_none_for_skill_server():
@@ -926,3 +928,28 @@ async def test_inspect_client_cached_configs_are_independent_instances():
     first.env = {"TOKEN": "<REDACTED>"}
     assert isinstance(second, StdioServer)
     assert second.env == {"TOKEN": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_cached_signatures_are_independent_instances():
+    """The cached `signature_or_error` payload (ServerSignature is aliased into ServerScanResult.signature) must also be per-occurrence."""
+    a = StdioServer(command="uvx", args=["s"])
+    b = StdioServer(command="uvx", args=["s"])
+    client = ClientToInspect(
+        name="t",
+        client_path="/p",
+        mcp_configs={
+            "/a.json": [("s", a)],
+            "/b.json": [("s", b)],
+        },
+        skills_dirs={},
+    )
+    signature = _make_signature()
+
+    with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
+        mock_ie.side_effect = _fake_inspect_extension_factory([], signature)
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+
+    first_sig = result.extensions["/a.json"][0].signature_or_error
+    second_sig = result.extensions["/b.json"][0].signature_or_error
+    assert first_sig is not second_sig

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -862,3 +862,37 @@ def test_server_dedup_key_stable_for_remote_with_reordered_headers():
     a = RemoteServer(url="https://x", type="http", headers={"A": "1", "B": "2"})
     b = RemoteServer(url="https://x", type="http", headers={"B": "2", "A": "1"})
     assert _server_dedup_key(a) == _server_dedup_key(b)
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_cached_entry_mirrors_resolved_config():
+    """Cached occurrences should expose the same (post-`check_server`) config the first inspection produced.
+
+    `inspect_extension` may return a fixed_config (e.g. RemoteServer.type defaulted from None to "http").
+    The second hit reads the cached resolved config rather than the pre-fix loop variable.
+    """
+    from agent_scan.models import InspectedExtensions
+
+    a = RemoteServer(url="https://x", type=None, headers={})
+    b = RemoteServer(url="https://x", type=None, headers={})
+    client = ClientToInspect(
+        name="t",
+        client_path="/p",
+        mcp_configs={
+            "/a.json": [("s", a)],
+            "/b.json": [("s", b)],
+        },
+        skills_dirs={},
+    )
+    fixed = RemoteServer(url="https://x", type="http", headers={})
+    signature = _make_signature()
+
+    async def fake(name, server, *args, **kwargs):
+        return InspectedExtensions(name=name, config=fixed, signature_or_error=signature)
+
+    with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
+        mock_ie.side_effect = fake
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+
+    assert result.extensions["/a.json"][0].config.type == "http"
+    assert result.extensions["/b.json"][0].config.type == "http"

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -896,3 +896,33 @@ async def test_inspect_client_cached_entry_mirrors_resolved_config():
 
     assert result.extensions["/a.json"][0].config.type == "http"
     assert result.extensions["/b.json"][0].config.type == "http"
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_cached_configs_are_independent_instances():
+    """Each occurrence's config must be its own instance so in-place mutation (redaction) on one doesn't bleed into the others."""
+    a = StdioServer(command="uvx", args=["s"], env={"TOKEN": "abc"})
+    b = StdioServer(command="uvx", args=["s"], env={"TOKEN": "abc"})
+    client = ClientToInspect(
+        name="t",
+        client_path="/p",
+        mcp_configs={
+            "/a.json": [("s", a)],
+            "/b.json": [("s", b)],
+        },
+        skills_dirs={},
+    )
+    signature = _make_signature()
+
+    with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
+        mock_ie.side_effect = _fake_inspect_extension_factory([], signature)
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+
+    first = result.extensions["/a.json"][0].config
+    second = result.extensions["/b.json"][0].config
+    assert first is not second
+    # Simulate downstream redaction mutating one in-place; the other must be unaffected.
+    assert isinstance(first, StdioServer)
+    first.env = {"TOKEN": "<REDACTED>"}
+    assert isinstance(second, StdioServer)
+    assert second.env == {"TOKEN": "abc"}

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -6,11 +6,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from agent_scan.inspect import get_mcp_config_per_client, inspect_client
+from agent_scan.inspect import _server_dedup_key, get_mcp_config_per_client, inspect_client
 from agent_scan.mcp_client import scan_mcp_config_file
 from agent_scan.models import (
     CandidateClient,
     ClientToInspect,
+    RemoteServer,
+    ServerStartupError,
+    SkillServer,
     SkippedByRuntimeConfigError,
     StdioServer,
 )
@@ -671,3 +674,191 @@ async def test_inspect_client_skips_server_per_runtime_config_without_starting_s
     # Sanity: the non-skipped server did go through inspect_extension exactly once.
     call_names = [call.args[0] for call in mock_inspect_extension.call_args_list]
     assert call_names == ["other"]
+
+
+# --- signature cache dedup tests ---
+
+
+def _make_signature(server_info_name: str = "x"):
+    """Build a minimal ServerSignature for use as a fake inspect_extension return."""
+    from mcp.types import Implementation, InitializeResult
+
+    from agent_scan.models import ServerSignature
+
+    return ServerSignature(
+        metadata=InitializeResult(
+            protocolVersion="2024-11-05",
+            capabilities={},
+            serverInfo=Implementation(name=server_info_name, version="1"),
+        ),
+    )
+
+
+def _fake_inspect_extension_factory(counter: list[int], signature):
+    """Return an async fake of inspect_extension that records call count and returns InspectedExtensions."""
+    from agent_scan.models import InspectedExtensions
+
+    async def fake(name, server, *args, **kwargs):
+        counter.append(name)
+        return InspectedExtensions(name=name, config=server, signature_or_error=signature)
+
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_dedup_same_stdio_config_under_two_paths():
+    """Same StdioServer (command+args+env) under two config paths is inspected once; both occurrences share the signature."""
+    server_a = StdioServer(command="uvx", args=["my-server"], env={"TOKEN": "abc"})
+    server_b = StdioServer(command="uvx", args=["my-server"], env={"TOKEN": "abc"})
+    client = ClientToInspect(
+        name="test",
+        client_path="/some/path",
+        mcp_configs={
+            "/a/.mcp.json": [("github", server_a)],
+            "/b/.mcp.json": [("github", server_b)],
+        },
+        skills_dirs={},
+    )
+    signature = _make_signature()
+    calls: list[str] = []
+
+    with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
+        mock_ie.side_effect = _fake_inspect_extension_factory(calls, signature)
+        cache: dict = {}
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache=cache)
+
+    assert len(calls) == 1
+    a_ext = result.extensions["/a/.mcp.json"][0]
+    b_ext = result.extensions["/b/.mcp.json"][0]
+    assert a_ext.signature_or_error is signature
+    assert b_ext.signature_or_error is signature
+
+
+@pytest.mark.asyncio
+async def test_inspect_pipeline_dedup_across_clients():
+    """Same server config across two distinct ClientToInspect objects is inspected once per pipeline run."""
+    shared = StdioServer(command="uvx", args=["shared-server"], env=None)
+    client1 = ClientToInspect(
+        name="client-one",
+        client_path="/p1",
+        mcp_configs={"/p1/cfg.json": [("shared", shared.model_copy(deep=True))]},
+        skills_dirs={},
+    )
+    client2 = ClientToInspect(
+        name="client-two",
+        client_path="/p2",
+        mcp_configs={"/p2/cfg.json": [("shared", shared.model_copy(deep=True))]},
+        skills_dirs={},
+    )
+    signature = _make_signature()
+    calls: list[str] = []
+
+    with (
+        patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie,
+        patch(
+            "agent_scan.pipelines.discover_clients_to_inspect",
+            new_callable=AsyncMock,
+            return_value=([client1, client2], [], ["u"]),
+        ),
+    ):
+        mock_ie.side_effect = _fake_inspect_extension_factory(calls, signature)
+        args = InspectArgs(timeout=10, tokens=[], paths=[], all_users=False)
+        await inspect_pipeline(args)
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_does_not_dedup_when_env_differs():
+    """Same command+args but different env => not deduped; both calls happen."""
+    a = StdioServer(command="uvx", args=["server"], env={"TOKEN": "first"})
+    b = StdioServer(command="uvx", args=["server"], env={"TOKEN": "second"})
+    client = ClientToInspect(
+        name="test",
+        client_path="/p",
+        mcp_configs={
+            "/a.json": [("s", a)],
+            "/b.json": [("s", b)],
+        },
+        skills_dirs={},
+    )
+    calls: list[str] = []
+
+    with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
+        mock_ie.side_effect = _fake_inspect_extension_factory(calls, _make_signature())
+        await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_does_not_dedup_when_args_differ():
+    """Same command but different args => not deduped."""
+    a = StdioServer(command="uvx", args=["server", "--mode=a"])
+    b = StdioServer(command="uvx", args=["server", "--mode=b"])
+    client = ClientToInspect(
+        name="test",
+        client_path="/p",
+        mcp_configs={
+            "/a.json": [("s", a)],
+            "/b.json": [("s", b)],
+        },
+        skills_dirs={},
+    )
+    calls: list[str] = []
+
+    with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
+        mock_ie.side_effect = _fake_inspect_extension_factory(calls, _make_signature())
+        await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_inspect_client_caches_errors_too():
+    """A failed inspection is cached: a duplicate config doesn't re-call inspect_extension (avoid hammering broken servers)."""
+    server = StdioServer(command="uvx", args=["broken-server"])
+    client = ClientToInspect(
+        name="test",
+        client_path="/p",
+        mcp_configs={
+            "/a.json": [("broken", server.model_copy(deep=True))],
+            "/b.json": [("broken", server.model_copy(deep=True))],
+        },
+        skills_dirs={},
+    )
+    error = ServerStartupError(
+        message="could not start server",
+        traceback="",
+        sub_exception_message="boom",
+        is_failure=True,
+    )
+    calls: list[str] = []
+    with patch("agent_scan.inspect.inspect_extension", new_callable=AsyncMock) as mock_ie:
+        mock_ie.side_effect = _fake_inspect_extension_factory(calls, error)
+        result = await inspect_client(client, timeout=10, tokens=[], scan_skills=False, signature_cache={})
+
+    assert len(calls) == 1
+    a_ext = result.extensions["/a.json"][0]
+    b_ext = result.extensions["/b.json"][0]
+    assert a_ext.signature_or_error is error
+    assert b_ext.signature_or_error is error
+
+
+def test_server_dedup_key_returns_none_for_skill_server():
+    """Skill servers are local file reads; they bypass the cache."""
+    assert _server_dedup_key(SkillServer(path="/some/skill")) is None
+
+
+def test_server_dedup_key_distinguishes_stdio_from_remote_with_same_string():
+    """A remote URL equal to a stdio command must not collide in the cache key."""
+    stdio = StdioServer(command="https://example.com/mcp", args=[])
+    remote = RemoteServer(url="https://example.com/mcp", type="http")
+    assert _server_dedup_key(stdio) != _server_dedup_key(remote)
+
+
+def test_server_dedup_key_stable_for_remote_with_reordered_headers():
+    """Header dicts are unordered; the key must canonicalize them so reorderings hit the cache."""
+    a = RemoteServer(url="https://x", type="http", headers={"A": "1", "B": "2"})
+    b = RemoteServer(url="https://x", type="http", headers={"B": "2", "A": "1"})
+    assert _server_dedup_key(a) == _server_dedup_key(b)


### PR DESCRIPTION
## Summary
- When the same MCP server config (matched by `command`/`args`/`env` for stdio or `url`/`type`/`headers` for remote) appears under multiple config paths or across multiple clients in one scan, we now launch it once and reuse the `ServerSignature` for every other occurrence. Saves duplicate subprocess spawns and remote round-trips; eliminates duplicate consent prompts.
- Output shape unchanged — every config path still reports its server with the (shared) signature.
