### PR TITLE
ci: [ADS-296] nightly Claude Code compat check on Linux/macOS/Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   prodsec: snyk/prodsec-orb@1
   slack: circleci/slack@4.12.5
+  win: circleci/windows@5.0
 
 parameters:
   snyk-scan-context:
@@ -11,6 +12,10 @@ parameters:
     default: etso_llm
   run-daily-security-scan:
     description: When true, runs the daily security-scans workflow (used by scheduled trigger).
+    type: boolean
+    default: false
+  run-nightly-cc-test:
+    description: When true, runs the nightly Claude Code x agent-scan compatibility workflow (used by a separate scheduled trigger).
     type: boolean
     default: false
 
@@ -78,6 +83,173 @@ commands:
             }
 
 jobs:
+  claude-code-nightly-linux:
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      AGENT_SCAN_ENVIRONMENT: ci
+    steps:
+      - checkout
+      - run:
+          name: Install uv
+          command: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run:
+          name: Install Claude Code nightly
+          command: |
+            curl -fsSL https://claude.ai/install.sh | bash -s nightly
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            claude --version
+      - run:
+          name: Start Claude Code in workspace (creates ~/.claude.json + projects entry)
+          command: |
+            cd "$CIRCLE_WORKING_DIRECTORY"
+            claude --print "ping" || true
+            test -f "$HOME/.claude.json"
+      - run:
+          name: Seed global / project / plugin scopes via real claude CLI
+          command: |
+            set -euo pipefail
+            STUB='uv run --no-project python -c pass'
+            claude mcp add --scope user nightly-global-mcp -- $STUB
+            claude mcp add --scope project nightly-project-mcp -- $STUB
+            claude plugin marketplace add ./tests/fixtures/cc-nightly-marketplace
+            claude plugin install nightly-test-plugin@cc-nightly
+            mkdir -p "$HOME/.claude/skills/nightly-global-skill"
+            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
+               "$HOME/.claude/skills/nightly-global-skill/SKILL.md"
+            mkdir -p .claude/skills/nightly-project-skill
+            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
+               .claude/skills/nightly-project-skill/SKILL.md
+      - run:
+          name: Install agent-scan from this branch
+          command: |
+            uv venv
+            uv pip install -e .
+      - run:
+          name: Run agent-scan inspect --json
+          command: |
+            uv run agent-scan inspect --json --dangerously-run-mcp-servers > scan.json
+      - run:
+          name: Verify Claude Code discovery
+          command: |
+            uv run python tests/ci/verify_cc_nightly_scan.py scan.json --workspace "$CIRCLE_WORKING_DIRECTORY"
+      - store_artifacts:
+          path: scan.json
+      - notify_slack_on_failure
+
+  claude-code-nightly-macos:
+    macos:
+      xcode: 15.4.0
+    resource_class: macos.m1.medium.gen1
+    environment:
+      AGENT_SCAN_ENVIRONMENT: ci
+    steps:
+      - checkout
+      - run:
+          name: Install uv
+          command: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run:
+          name: Install Claude Code nightly
+          command: |
+            curl -fsSL https://claude.ai/install.sh | bash -s nightly
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            claude --version
+      - run:
+          name: Start Claude Code in workspace (creates ~/.claude.json + projects entry)
+          command: |
+            cd "$CIRCLE_WORKING_DIRECTORY"
+            claude --print "ping" || true
+            test -f "$HOME/.claude.json"
+      - run:
+          name: Seed global / project / plugin scopes via real claude CLI
+          command: |
+            set -euo pipefail
+            STUB='uv run --no-project python -c pass'
+            claude mcp add --scope user nightly-global-mcp -- $STUB
+            claude mcp add --scope project nightly-project-mcp -- $STUB
+            claude plugin marketplace add ./tests/fixtures/cc-nightly-marketplace
+            claude plugin install nightly-test-plugin@cc-nightly
+            mkdir -p "$HOME/.claude/skills/nightly-global-skill"
+            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
+               "$HOME/.claude/skills/nightly-global-skill/SKILL.md"
+            mkdir -p .claude/skills/nightly-project-skill
+            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
+               .claude/skills/nightly-project-skill/SKILL.md
+      - run:
+          name: Install agent-scan from this branch
+          command: |
+            uv venv
+            uv pip install -e .
+      - run:
+          name: Run agent-scan inspect --json
+          command: |
+            uv run agent-scan inspect --json --dangerously-run-mcp-servers > scan.json
+      - run:
+          name: Verify Claude Code discovery
+          command: |
+            uv run python tests/ci/verify_cc_nightly_scan.py scan.json --workspace "$CIRCLE_WORKING_DIRECTORY"
+      - store_artifacts:
+          path: scan.json
+      - notify_slack_on_failure
+
+  claude-code-nightly-windows:
+    executor:
+      name: win/default
+      shell: powershell.exe
+    environment:
+      AGENT_SCAN_ENVIRONMENT: ci
+    steps:
+      - checkout
+      - run:
+          name: Install uv
+          command: irm https://astral.sh/uv/install.ps1 | iex
+      - run:
+          name: Install Claude Code nightly
+          command: |
+            irm https://claude.ai/install.ps1 | iex
+            $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
+            [Environment]::SetEnvironmentVariable("Path", $env:Path, "User")
+            claude --version
+      - run:
+          name: Start Claude Code in workspace (creates ~/.claude.json + projects entry)
+          command: |
+            Set-Location $env:CIRCLE_WORKING_DIRECTORY
+            try { claude --print "ping" } catch { }
+            if (-not (Test-Path "$env:USERPROFILE\.claude.json")) { throw "~/.claude.json was not created" }
+      - run:
+          name: Seed global / project / plugin scopes via real claude CLI
+          command: |
+            $ErrorActionPreference = "Stop"
+            $stub = @("uv", "run", "--no-project", "python", "-c", "pass")
+            claude mcp add --scope user nightly-global-mcp -- @stub
+            claude mcp add --scope project nightly-project-mcp -- @stub
+            claude plugin marketplace add ./tests/fixtures/cc-nightly-marketplace
+            claude plugin install nightly-test-plugin@cc-nightly
+            New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.claude\skills\nightly-global-skill" | Out-Null
+            Copy-Item tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md `
+              "$env:USERPROFILE\.claude\skills\nightly-global-skill\SKILL.md"
+            New-Item -ItemType Directory -Force -Path ".claude\skills\nightly-project-skill" | Out-Null
+            Copy-Item tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md `
+              ".claude\skills\nightly-project-skill\SKILL.md"
+      - run:
+          name: Install agent-scan from this branch
+          command: |
+            uv venv
+            uv pip install -e .
+      - run:
+          name: Run agent-scan inspect --json
+          command: |
+            uv run agent-scan inspect --json --dangerously-run-mcp-servers > scan.json
+      - run:
+          name: Verify Claude Code discovery
+          command: |
+            uv run python tests/ci/verify_cc_nightly_scan.py scan.json --workspace $env:CIRCLE_WORKING_DIRECTORY
+      - store_artifacts:
+          path: scan.json
+      - notify_slack_on_failure
+
   security-scans:
     parameters:
       mode:
@@ -125,3 +297,13 @@ workflows:
           context:
             - << pipeline.parameters.snyk-scan-context >>
             - snyk-bot-slack
+
+  nightly-claude-code-compat:
+    when: << pipeline.parameters.run-nightly-cc-test >>
+    jobs:
+      - claude-code-nightly-linux:
+          context: [claude-nightly-tokens, snyk-bot-slack]
+      - claude-code-nightly-macos:
+          context: [claude-nightly-tokens, snyk-bot-slack]
+      - claude-code-nightly-windows:
+          context: [claude-nightly-tokens, snyk-bot-slack]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,65 @@ parameters:
     default: false
 
 commands:
+  cc_nightly_seed_and_verify_bash:
+    description: >
+      Shared Bash steps for the Linux + macOS nightly Claude Code jobs.
+      Installs uv + Claude Code nightly, seeds global / project / plugin
+      scopes via real `claude` CLI commands, runs `agent-scan inspect --json`,
+      and asserts every seeded MCP server / skill appears in the output.
+    steps:
+      - checkout
+      - run:
+          name: Install uv
+          command: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run:
+          name: Install Claude Code nightly
+          command: |
+            curl -fsSL https://claude.ai/install.sh | bash -s nightly
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            claude --version
+      - run:
+          name: Start Claude Code in workspace (creates ~/.claude.json + projects entry)
+          command: |
+            cd "$CIRCLE_WORKING_DIRECTORY"
+            claude --print "ping" || true
+            test -f "$HOME/.claude.json"
+      - run:
+          name: Seed global / project / plugin scopes via real claude CLI
+          # The stub command (`python -c pass`) exits immediately and fails
+          # MCP handshake on purpose — the verifier only asserts discovery
+          # (server name in scan output), not signature/tool inspection.
+          command: |
+            set -euo pipefail
+            STUB='uv run --no-project python -c pass'
+            claude mcp add --scope user nightly-global-mcp -- $STUB
+            claude mcp add --scope project nightly-project-mcp -- $STUB
+            claude plugin marketplace add ./tests/fixtures/cc-nightly-marketplace
+            claude plugin install nightly-test-plugin@cc-nightly
+            mkdir -p "$HOME/.claude/skills/nightly-global-skill"
+            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
+               "$HOME/.claude/skills/nightly-global-skill/SKILL.md"
+            mkdir -p .claude/skills/nightly-project-skill
+            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
+               .claude/skills/nightly-project-skill/SKILL.md
+      - run:
+          name: Install agent-scan from this branch
+          command: |
+            uv venv
+            uv pip install -e .
+      - run:
+          name: Run agent-scan inspect --json
+          command: |
+            uv run agent-scan inspect --json --dangerously-run-mcp-servers > scan.json
+      - run:
+          name: Verify Claude Code discovery
+          command: |
+            uv run python tests/ci/verify_cc_nightly_scan.py scan.json --workspace "$CIRCLE_WORKING_DIRECTORY"
+      - store_artifacts:
+          path: scan.json
+      - notify_slack_on_failure
+
   notify_slack_on_failure:
     steps:
       - slack/notify:
@@ -89,54 +148,7 @@ jobs:
     environment:
       AGENT_SCAN_ENVIRONMENT: ci
     steps:
-      - checkout
-      - run:
-          name: Install uv
-          command: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - run:
-          name: Install Claude Code nightly
-          command: |
-            curl -fsSL https://claude.ai/install.sh | bash -s nightly
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            source "$BASH_ENV"
-            claude --version
-      - run:
-          name: Start Claude Code in workspace (creates ~/.claude.json + projects entry)
-          command: |
-            cd "$CIRCLE_WORKING_DIRECTORY"
-            claude --print "ping" || true
-            test -f "$HOME/.claude.json"
-      - run:
-          name: Seed global / project / plugin scopes via real claude CLI
-          command: |
-            set -euo pipefail
-            STUB='uv run --no-project python -c pass'
-            claude mcp add --scope user nightly-global-mcp -- $STUB
-            claude mcp add --scope project nightly-project-mcp -- $STUB
-            claude plugin marketplace add ./tests/fixtures/cc-nightly-marketplace
-            claude plugin install nightly-test-plugin@cc-nightly
-            mkdir -p "$HOME/.claude/skills/nightly-global-skill"
-            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
-               "$HOME/.claude/skills/nightly-global-skill/SKILL.md"
-            mkdir -p .claude/skills/nightly-project-skill
-            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
-               .claude/skills/nightly-project-skill/SKILL.md
-      - run:
-          name: Install agent-scan from this branch
-          command: |
-            uv venv
-            uv pip install -e .
-      - run:
-          name: Run agent-scan inspect --json
-          command: |
-            uv run agent-scan inspect --json --dangerously-run-mcp-servers > scan.json
-      - run:
-          name: Verify Claude Code discovery
-          command: |
-            uv run python tests/ci/verify_cc_nightly_scan.py scan.json --workspace "$CIRCLE_WORKING_DIRECTORY"
-      - store_artifacts:
-          path: scan.json
-      - notify_slack_on_failure
+      - cc_nightly_seed_and_verify_bash
 
   claude-code-nightly-macos:
     macos:
@@ -145,54 +157,7 @@ jobs:
     environment:
       AGENT_SCAN_ENVIRONMENT: ci
     steps:
-      - checkout
-      - run:
-          name: Install uv
-          command: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - run:
-          name: Install Claude Code nightly
-          command: |
-            curl -fsSL https://claude.ai/install.sh | bash -s nightly
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            source "$BASH_ENV"
-            claude --version
-      - run:
-          name: Start Claude Code in workspace (creates ~/.claude.json + projects entry)
-          command: |
-            cd "$CIRCLE_WORKING_DIRECTORY"
-            claude --print "ping" || true
-            test -f "$HOME/.claude.json"
-      - run:
-          name: Seed global / project / plugin scopes via real claude CLI
-          command: |
-            set -euo pipefail
-            STUB='uv run --no-project python -c pass'
-            claude mcp add --scope user nightly-global-mcp -- $STUB
-            claude mcp add --scope project nightly-project-mcp -- $STUB
-            claude plugin marketplace add ./tests/fixtures/cc-nightly-marketplace
-            claude plugin install nightly-test-plugin@cc-nightly
-            mkdir -p "$HOME/.claude/skills/nightly-global-skill"
-            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
-               "$HOME/.claude/skills/nightly-global-skill/SKILL.md"
-            mkdir -p .claude/skills/nightly-project-skill
-            cp tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md \
-               .claude/skills/nightly-project-skill/SKILL.md
-      - run:
-          name: Install agent-scan from this branch
-          command: |
-            uv venv
-            uv pip install -e .
-      - run:
-          name: Run agent-scan inspect --json
-          command: |
-            uv run agent-scan inspect --json --dangerously-run-mcp-servers > scan.json
-      - run:
-          name: Verify Claude Code discovery
-          command: |
-            uv run python tests/ci/verify_cc_nightly_scan.py scan.json --workspace "$CIRCLE_WORKING_DIRECTORY"
-      - store_artifacts:
-          path: scan.json
-      - notify_slack_on_failure
+      - cc_nightly_seed_and_verify_bash
 
   claude-code-nightly-windows:
     executor:

--- a/tests/ci/verify_cc_nightly_scan.py
+++ b/tests/ci/verify_cc_nightly_scan.py
@@ -1,0 +1,171 @@
+"""Verify agent-scan discovered every Claude Code artefact the nightly job seeded.
+
+Used by the nightly CircleCI workflow (`.circleci/config.yml`). The job runs
+`agent-scan inspect --json > scan.json` after seeding a global MCP server, a
+project MCP server, a plugin (which ships its own MCP + skill), a global
+skill, and a project skill via real `claude` CLI commands. This script asserts
+each of those names appears in the discovery output for the right path scope;
+non-zero exit means upstream Claude Code changed something agent-scan no
+longer recognises.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class ExpectedArtifact:
+    """One thing the nightly job seeded that we expect to find in the scan.
+
+    ``path_pattern`` may contain ``~`` (expanded against the supplied home) and
+    ``*`` / ``**`` glob wildcards — plugin scopes live under unpredictable
+    hashed subdirectories so glob matching is required.
+    """
+
+    label: str
+    path_pattern: str
+    server_name: str
+
+
+def _normalize(path: str) -> str:
+    """Match the POSIX form that ClaudeCodeDiscoverer emits via ``as_posix()``."""
+    return path.replace("\\", "/")
+
+
+def _expand(pattern: str, home: str) -> str:
+    pattern = _normalize(pattern)
+    home_posix = _normalize(home)
+    if pattern.startswith("~/"):
+        return f"{home_posix}/{pattern[2:]}"
+    if pattern == "~":
+        return home_posix
+    return pattern
+
+
+def _matches(pattern: str, candidate: str, home: str) -> bool:
+    expanded = _expand(pattern, home)
+    candidate_norm = _normalize(candidate)
+    if "*" in expanded:
+        return fnmatch.fnmatchcase(candidate_norm, expanded)
+    return expanded == candidate_norm
+
+
+def _server_names(scan_entry: dict[str, Any]) -> set[str]:
+    servers = scan_entry.get("servers") or []
+    return {s.get("name") for s in servers if isinstance(s, dict) and s.get("name")}
+
+
+def check_scan(
+    scan: dict[str, Any],
+    expected: Iterable[ExpectedArtifact],
+    home: str | None = None,
+) -> list[ExpectedArtifact]:
+    """Return the artefacts that are NOT present in the scan dict.
+
+    An artefact is considered present when at least one scan key matches its
+    ``path_pattern`` *and* that entry's ``servers`` list contains a server with
+    the expected ``name``.
+    """
+    home_str = home if home is not None else str(Path.home())
+    missing: list[ExpectedArtifact] = []
+    for artefact in expected:
+        found = False
+        for key, entry in scan.items():
+            if not isinstance(entry, dict):
+                continue
+            if not _matches(artefact.path_pattern, key, home_str):
+                continue
+            if artefact.server_name in _server_names(entry):
+                found = True
+                break
+        if not found:
+            missing.append(artefact)
+    return missing
+
+
+def default_expected(workspace: str) -> list[ExpectedArtifact]:
+    """The six artefacts the nightly CircleCI job is responsible for seeding —
+    two (one MCP server + one skill) at each of the three scopes the user
+    asked about: global, project, plugin."""
+    ws = _normalize(workspace)
+    return [
+        ExpectedArtifact("global-mcp", "~/.claude.json", "nightly-global-mcp"),
+        ExpectedArtifact("project-mcp", f"{ws}/.mcp.json", "nightly-project-mcp"),
+        ExpectedArtifact(
+            "plugin-mcp", "~/.claude/plugins/cache/**/.mcp.json", "nightly-plugin-mcp"
+        ),
+        ExpectedArtifact("global-skill", "~/.claude/skills", "nightly-global-skill"),
+        ExpectedArtifact(
+            "project-skill", f"{ws}/.claude/skills", "nightly-project-skill"
+        ),
+        ExpectedArtifact(
+            "plugin-skill", "~/.claude/plugins/cache/**/skills", "nightly-plugin-skill"
+        ),
+    ]
+
+
+def _format_report(missing: list[ExpectedArtifact], scan: dict[str, Any]) -> str:
+    lines = [f"Claude Code nightly discovery check FAILED — {len(missing)} missing artefact(s):", ""]
+    for art in missing:
+        lines.append(
+            f"  - [{art.label}] expected server/skill '{art.server_name}' "
+            f"under path matching '{art.path_pattern}'"
+        )
+    lines.append("")
+    lines.append("Observed scan keys:")
+    for key in sorted(scan):
+        names = sorted(n for n in _server_names(scan[key]) if n)
+        lines.append(f"  {key}  -> {names or '(no servers)'}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scan_file", help="Path to scan.json (output of `agent-scan inspect --json`).")
+    parser.add_argument(
+        "--workspace",
+        default=os.getcwd(),
+        help="Workspace directory the job seeded (used for project-scope path keys). "
+        "Defaults to cwd.",
+    )
+    parser.add_argument(
+        "--home",
+        default=str(Path.home()),
+        help="Home directory to expand ~ against. Defaults to current user's home.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.scan_file, encoding="utf-8") as f:
+            scan = json.load(f)
+    except FileNotFoundError:
+        print(f"scan file not found: {args.scan_file}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"scan file is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if not isinstance(scan, dict):
+        print("scan file root must be a JSON object keyed by scan path", file=sys.stderr)
+        return 2
+
+    expected = default_expected(args.workspace)
+    missing = check_scan(scan, expected, home=args.home)
+    if not missing:
+        print(f"OK — all {len(expected)} expected Claude Code artefacts discovered.")
+        return 0
+
+    print(_format_report(missing, scan))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/verify_cc_nightly_scan.py
+++ b/tests/ci/verify_cc_nightly_scan.py
@@ -18,7 +18,10 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,11 @@ def _expand(pattern: str, home: str) -> str:
 
 
 def _matches(pattern: str, candidate: str, home: str) -> bool:
+    # fnmatch's ``*`` greedily matches ``/`` too, so a single ``*`` already
+    # spans multiple path components and ``**`` (used in the plugin-scope
+    # patterns) is equivalent to ``*`` here. Do not "fix" this to
+    # ``pathlib.PurePath.match`` — that one is stricter about ``/`` and would
+    # break plugin-cache discovery.
     expanded = _expand(pattern, home)
     candidate_norm = _normalize(candidate)
     if "*" in expanded:
@@ -60,7 +68,13 @@ def _matches(pattern: str, candidate: str, home: str) -> bool:
 
 def _server_names(scan_entry: dict[str, Any]) -> set[str]:
     servers = scan_entry.get("servers") or []
-    return {s.get("name") for s in servers if isinstance(s, dict) and s.get("name")}
+    names: set[str] = set()
+    for s in servers:
+        if isinstance(s, dict):
+            name = s.get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
 
 
 def check_scan(
@@ -99,16 +113,10 @@ def default_expected(workspace: str) -> list[ExpectedArtifact]:
     return [
         ExpectedArtifact("global-mcp", "~/.claude.json", "nightly-global-mcp"),
         ExpectedArtifact("project-mcp", f"{ws}/.mcp.json", "nightly-project-mcp"),
-        ExpectedArtifact(
-            "plugin-mcp", "~/.claude/plugins/cache/**/.mcp.json", "nightly-plugin-mcp"
-        ),
+        ExpectedArtifact("plugin-mcp", "~/.claude/plugins/cache/**/.mcp.json", "nightly-plugin-mcp"),
         ExpectedArtifact("global-skill", "~/.claude/skills", "nightly-global-skill"),
-        ExpectedArtifact(
-            "project-skill", f"{ws}/.claude/skills", "nightly-project-skill"
-        ),
-        ExpectedArtifact(
-            "plugin-skill", "~/.claude/plugins/cache/**/skills", "nightly-plugin-skill"
-        ),
+        ExpectedArtifact("project-skill", f"{ws}/.claude/skills", "nightly-project-skill"),
+        ExpectedArtifact("plugin-skill", "~/.claude/plugins/cache/**/skills", "nightly-plugin-skill"),
     ]
 
 
@@ -116,8 +124,7 @@ def _format_report(missing: list[ExpectedArtifact], scan: dict[str, Any]) -> str
     lines = [f"Claude Code nightly discovery check FAILED — {len(missing)} missing artefact(s):", ""]
     for art in missing:
         lines.append(
-            f"  - [{art.label}] expected server/skill '{art.server_name}' "
-            f"under path matching '{art.path_pattern}'"
+            f"  - [{art.label}] expected server/skill '{art.server_name}' under path matching '{art.path_pattern}'"
         )
     lines.append("")
     lines.append("Observed scan keys:")
@@ -133,8 +140,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--workspace",
         default=os.getcwd(),
-        help="Workspace directory the job seeded (used for project-scope path keys). "
-        "Defaults to cwd.",
+        help="Workspace directory the job seeded (used for project-scope path keys). Defaults to cwd.",
     )
     parser.add_argument(
         "--home",

--- a/tests/fixtures/cc-nightly-marketplace/.claude-plugin/marketplace.json
+++ b/tests/fixtures/cc-nightly-marketplace/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "cc-nightly",
+  "description": "Test marketplace for the nightly Claude Code x agent-scan CircleCI workflow.",
+  "owner": {
+    "name": "Snyk agent-scan team"
+  },
+  "plugins": [
+    {
+      "name": "nightly-test-plugin",
+      "source": "./plugins/nightly-test-plugin",
+      "description": "Ships one MCP server and one skill so agent-scan plugin-scope discovery can be exercised."
+    }
+  ]
+}

--- a/tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md
+++ b/tests/fixtures/cc-nightly-marketplace/_seed/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: nightly-seed-skill
+description: Template SKILL.md copied into ~/.claude/skills and <workspace>/.claude/skills by the nightly CircleCI workflow so agent-scan global- and project-scope skill discovery has something to find. Has no runtime behaviour.
+---
+
+Placeholder skill used by the nightly Claude Code x agent-scan CircleCI
+workflow. The job copies this file into the global and project skill
+directories at run time; the `name:` front-matter is overwritten by the
+job's `mkdir` step (folder name becomes the skill name) so this template
+can be reused for both scopes.

--- a/tests/fixtures/cc-nightly-marketplace/plugins/nightly-test-plugin/.claude-plugin/plugin.json
+++ b/tests/fixtures/cc-nightly-marketplace/plugins/nightly-test-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "nightly-test-plugin",
+  "description": "agent-scan nightly fixture: one MCP server + one skill.",
+  "version": "0.0.1"
+}

--- a/tests/fixtures/cc-nightly-marketplace/plugins/nightly-test-plugin/.mcp.json
+++ b/tests/fixtures/cc-nightly-marketplace/plugins/nightly-test-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "nightly-plugin-mcp": {
+      "command": "echo",
+      "args": ["nightly-plugin-mcp stub server"]
+    }
+  }
+}

--- a/tests/fixtures/cc-nightly-marketplace/plugins/nightly-test-plugin/skills/nightly-plugin-skill/SKILL.md
+++ b/tests/fixtures/cc-nightly-marketplace/plugins/nightly-test-plugin/skills/nightly-plugin-skill/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: nightly-plugin-skill
+description: Plugin-scope skill used by the agent-scan nightly CircleCI workflow to verify that discovery picks up skills bundled inside an installed plugin. Has no runtime behaviour.
+---
+
+This skill exists only so the nightly CircleCI workflow can confirm that
+`agent-scan` discovers plugin-scope skills under
+`~/.claude/plugins/cache/**/skills/`. It is intentionally inert.

--- a/tests/unit/test_verify_cc_nightly_scan.py
+++ b/tests/unit/test_verify_cc_nightly_scan.py
@@ -11,14 +11,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from tests.ci.verify_cc_nightly_scan import (
     ExpectedArtifact,
     check_scan,
     main,
 )
-
 
 HOME = Path.home().as_posix()
 
@@ -40,19 +37,13 @@ def _scan_path(path: str, servers: list[dict]) -> dict:
 def _full_passing_scan(workspace: str) -> dict:
     """Build a JSON dict where every expected artefact is discovered."""
     return {
-        f"{HOME}/.claude.json": _scan_path(
-            f"{HOME}/.claude.json", [_server("nightly-global-mcp")]
-        ),
-        f"{workspace}/.mcp.json": _scan_path(
-            f"{workspace}/.mcp.json", [_server("nightly-project-mcp")]
-        ),
+        f"{HOME}/.claude.json": _scan_path(f"{HOME}/.claude.json", [_server("nightly-global-mcp")]),
+        f"{workspace}/.mcp.json": _scan_path(f"{workspace}/.mcp.json", [_server("nightly-project-mcp")]),
         f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/.mcp.json": _scan_path(
             f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/.mcp.json",
             [_server("nightly-plugin-mcp")],
         ),
-        f"{HOME}/.claude/skills": _scan_path(
-            f"{HOME}/.claude/skills", [_server("nightly-global-skill", kind="skill")]
-        ),
+        f"{HOME}/.claude/skills": _scan_path(f"{HOME}/.claude/skills", [_server("nightly-global-skill", kind="skill")]),
         f"{workspace}/.claude/skills": _scan_path(
             f"{workspace}/.claude/skills",
             [_server("nightly-project-skill", kind="skill")],
@@ -67,18 +58,14 @@ def _full_passing_scan(workspace: str) -> dict:
 def _default_expected(workspace: str) -> list[ExpectedArtifact]:
     return [
         ExpectedArtifact("global-mcp", "~/.claude.json", "nightly-global-mcp"),
-        ExpectedArtifact(
-            "project-mcp", f"{workspace}/.mcp.json", "nightly-project-mcp"
-        ),
+        ExpectedArtifact("project-mcp", f"{workspace}/.mcp.json", "nightly-project-mcp"),
         ExpectedArtifact(
             "plugin-mcp",
             "~/.claude/plugins/cache/**/.mcp.json",
             "nightly-plugin-mcp",
         ),
         ExpectedArtifact("global-skill", "~/.claude/skills", "nightly-global-skill"),
-        ExpectedArtifact(
-            "project-skill", f"{workspace}/.claude/skills", "nightly-project-skill"
-        ),
+        ExpectedArtifact("project-skill", f"{workspace}/.claude/skills", "nightly-project-skill"),
         ExpectedArtifact(
             "plugin-skill",
             "~/.claude/plugins/cache/**/skills",
@@ -133,9 +120,7 @@ class TestCheckScan:
         workspace = (tmp_path / "repo").as_posix()
         scan = _full_passing_scan(workspace)
         # Replace the canned plugin path with a deeper one.
-        plugin_path = scan.pop(
-            f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/.mcp.json"
-        )
+        plugin_path = scan.pop(f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/.mcp.json")
         new_key = f"{HOME}/.claude/plugins/cache/marketplace-abc/another/deeper/.mcp.json"
         plugin_path["path"] = new_key
         scan[new_key] = plugin_path
@@ -150,11 +135,8 @@ class TestCheckScan:
         not the current process's home (so the verifier can run on a CI machine
         that scanned from a different home)."""
         custom_home = (tmp_path / "fake-home").as_posix()
-        workspace = (tmp_path / "repo").as_posix()
         scan = {
-            f"{custom_home}/.claude.json": _scan_path(
-                f"{custom_home}/.claude.json", [_server("nightly-global-mcp")]
-            ),
+            f"{custom_home}/.claude.json": _scan_path(f"{custom_home}/.claude.json", [_server("nightly-global-mcp")]),
         }
         expected = [
             ExpectedArtifact("global-mcp", "~/.claude.json", "nightly-global-mcp"),
@@ -187,10 +169,9 @@ class TestCheckScan:
 
         assert missing == []
 
-    def test_servers_can_be_none_without_crashing(self, tmp_path):
+    def test_servers_can_be_none_without_crashing(self):
         """When agent-scan fails to parse a config it sets ``servers: None``
         — the matcher should treat that as 'name not found' rather than raise."""
-        workspace = (tmp_path / "repo").as_posix()
         scan = {
             f"{HOME}/.claude.json": {
                 "path": f"{HOME}/.claude.json",
@@ -211,7 +192,7 @@ class TestCheckScan:
 
 
 class TestCliMain:
-    def test_exits_zero_on_full_match(self, tmp_path, capsys, monkeypatch):
+    def test_exits_zero_on_full_match(self, tmp_path):
         workspace = tmp_path / "repo"
         workspace.mkdir()
         scan_file = tmp_path / "scan.json"
@@ -231,10 +212,9 @@ class TestCliMain:
 
         rc = main([str(scan_file), "--workspace", str(workspace)])
 
-        out = capsys.readouterr().out + capsys.readouterr().err
+        captured = capsys.readouterr()
         assert rc != 0
-        # The missing label appears somewhere in the report.
-        assert "global-mcp" in (out + capsys.readouterr().out)
+        assert "global-mcp" in captured.out
 
     def test_missing_scan_file_exits_nonzero(self, tmp_path):
         rc = main([str(tmp_path / "does-not-exist.json"), "--workspace", str(tmp_path)])

--- a/tests/unit/test_verify_cc_nightly_scan.py
+++ b/tests/unit/test_verify_cc_nightly_scan.py
@@ -1,0 +1,241 @@
+"""Tests for the Claude Code nightly CircleCI discovery verifier.
+
+The verifier parses ``agent-scan inspect --json`` output and asserts that every
+expected MCP server / skill (global, project, plugin scope) appears in the
+discovery result. Used by the nightly CircleCI workflow to catch upstream
+Claude Code layout regressions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.ci.verify_cc_nightly_scan import (
+    ExpectedArtifact,
+    check_scan,
+    main,
+)
+
+
+HOME = Path.home().as_posix()
+
+
+def _server(name: str, kind: str = "stdio") -> dict:
+    """Build a minimal ServerScanResult dict for fixtures."""
+    if kind == "skill":
+        return {"name": name, "server": {"type": "skill", "path": f"/whatever/{name}"}}
+    return {
+        "name": name,
+        "server": {"type": "stdio", "command": "echo", "args": []},
+    }
+
+
+def _scan_path(path: str, servers: list[dict]) -> dict:
+    return {"path": path, "client": "claude code", "servers": servers, "issues": [], "labels": []}
+
+
+def _full_passing_scan(workspace: str) -> dict:
+    """Build a JSON dict where every expected artefact is discovered."""
+    return {
+        f"{HOME}/.claude.json": _scan_path(
+            f"{HOME}/.claude.json", [_server("nightly-global-mcp")]
+        ),
+        f"{workspace}/.mcp.json": _scan_path(
+            f"{workspace}/.mcp.json", [_server("nightly-project-mcp")]
+        ),
+        f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/.mcp.json": _scan_path(
+            f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/.mcp.json",
+            [_server("nightly-plugin-mcp")],
+        ),
+        f"{HOME}/.claude/skills": _scan_path(
+            f"{HOME}/.claude/skills", [_server("nightly-global-skill", kind="skill")]
+        ),
+        f"{workspace}/.claude/skills": _scan_path(
+            f"{workspace}/.claude/skills",
+            [_server("nightly-project-skill", kind="skill")],
+        ),
+        f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/skills": _scan_path(
+            f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/skills",
+            [_server("nightly-plugin-skill", kind="skill")],
+        ),
+    }
+
+
+def _default_expected(workspace: str) -> list[ExpectedArtifact]:
+    return [
+        ExpectedArtifact("global-mcp", "~/.claude.json", "nightly-global-mcp"),
+        ExpectedArtifact(
+            "project-mcp", f"{workspace}/.mcp.json", "nightly-project-mcp"
+        ),
+        ExpectedArtifact(
+            "plugin-mcp",
+            "~/.claude/plugins/cache/**/.mcp.json",
+            "nightly-plugin-mcp",
+        ),
+        ExpectedArtifact("global-skill", "~/.claude/skills", "nightly-global-skill"),
+        ExpectedArtifact(
+            "project-skill", f"{workspace}/.claude/skills", "nightly-project-skill"
+        ),
+        ExpectedArtifact(
+            "plugin-skill",
+            "~/.claude/plugins/cache/**/skills",
+            "nightly-plugin-skill",
+        ),
+    ]
+
+
+class TestCheckScan:
+    def test_returns_empty_list_when_all_expected_present(self, tmp_path):
+        workspace = (tmp_path / "repo").as_posix()
+        scan = _full_passing_scan(workspace)
+
+        missing = check_scan(scan, _default_expected(workspace))
+
+        assert missing == []
+
+    def test_reports_missing_path_key(self, tmp_path):
+        workspace = (tmp_path / "repo").as_posix()
+        scan = _full_passing_scan(workspace)
+        del scan[f"{HOME}/.claude.json"]
+
+        missing = check_scan(scan, _default_expected(workspace))
+
+        assert len(missing) == 1
+        assert missing[0].label == "global-mcp"
+
+    def test_reports_present_path_but_missing_server_name(self, tmp_path):
+        workspace = (tmp_path / "repo").as_posix()
+        scan = _full_passing_scan(workspace)
+        scan[f"{HOME}/.claude.json"]["servers"] = [_server("some-other-server")]
+
+        missing = check_scan(scan, _default_expected(workspace))
+
+        assert len(missing) == 1
+        assert missing[0].label == "global-mcp"
+
+    def test_reports_multiple_missing(self, tmp_path):
+        workspace = (tmp_path / "repo").as_posix()
+        scan = _full_passing_scan(workspace)
+        del scan[f"{HOME}/.claude.json"]
+        del scan[f"{workspace}/.claude/skills"]
+
+        missing = check_scan(scan, _default_expected(workspace))
+
+        labels = {m.label for m in missing}
+        assert labels == {"global-mcp", "project-skill"}
+
+    def test_matches_glob_for_plugin_paths(self, tmp_path):
+        """Plugin keys live under unpredictable subdirectories, so the matcher
+        must accept ``**`` globs."""
+        workspace = (tmp_path / "repo").as_posix()
+        scan = _full_passing_scan(workspace)
+        # Replace the canned plugin path with a deeper one.
+        plugin_path = scan.pop(
+            f"{HOME}/.claude/plugins/cache/cc-nightly/nightly-test-plugin/.mcp.json"
+        )
+        new_key = f"{HOME}/.claude/plugins/cache/marketplace-abc/another/deeper/.mcp.json"
+        plugin_path["path"] = new_key
+        scan[new_key] = plugin_path
+
+        missing = check_scan(scan, _default_expected(workspace))
+
+        labels = {m.label for m in missing}
+        assert "plugin-mcp" not in labels
+
+    def test_expands_tilde_against_provided_home(self, tmp_path):
+        """The path-matcher must expand ``~`` to the supplied home directory,
+        not the current process's home (so the verifier can run on a CI machine
+        that scanned from a different home)."""
+        custom_home = (tmp_path / "fake-home").as_posix()
+        workspace = (tmp_path / "repo").as_posix()
+        scan = {
+            f"{custom_home}/.claude.json": _scan_path(
+                f"{custom_home}/.claude.json", [_server("nightly-global-mcp")]
+            ),
+        }
+        expected = [
+            ExpectedArtifact("global-mcp", "~/.claude.json", "nightly-global-mcp"),
+        ]
+
+        missing = check_scan(scan, expected, home=custom_home)
+
+        assert missing == []
+
+    def test_windows_path_separators_are_normalized(self, tmp_path):
+        """Discovery emits POSIX paths via ``as_posix()``, but a workspace
+        passed in from a CircleCI Windows job can arrive with backslashes — the
+        matcher must normalize."""
+        workspace_win = r"C:\Users\circleci\project"
+        workspace_posix = "C:/Users/circleci/project"
+        scan = {
+            f"{workspace_posix}/.mcp.json": _scan_path(
+                f"{workspace_posix}/.mcp.json", [_server("nightly-project-mcp")]
+            ),
+        }
+        expected = [
+            ExpectedArtifact(
+                "project-mcp",
+                f"{workspace_win}/.mcp.json",
+                "nightly-project-mcp",
+            ),
+        ]
+
+        missing = check_scan(scan, expected)
+
+        assert missing == []
+
+    def test_servers_can_be_none_without_crashing(self, tmp_path):
+        """When agent-scan fails to parse a config it sets ``servers: None``
+        — the matcher should treat that as 'name not found' rather than raise."""
+        workspace = (tmp_path / "repo").as_posix()
+        scan = {
+            f"{HOME}/.claude.json": {
+                "path": f"{HOME}/.claude.json",
+                "client": "claude code",
+                "servers": None,
+                "issues": [],
+                "labels": [],
+            },
+        }
+        expected = [
+            ExpectedArtifact("global-mcp", "~/.claude.json", "nightly-global-mcp"),
+        ]
+
+        missing = check_scan(scan, expected)
+
+        assert len(missing) == 1
+        assert missing[0].label == "global-mcp"
+
+
+class TestCliMain:
+    def test_exits_zero_on_full_match(self, tmp_path, capsys, monkeypatch):
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        scan_file = tmp_path / "scan.json"
+        scan_file.write_text(json.dumps(_full_passing_scan(workspace.as_posix())))
+
+        rc = main([str(scan_file), "--workspace", str(workspace)])
+
+        assert rc == 0
+
+    def test_exits_nonzero_and_prints_missing(self, tmp_path, capsys):
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        scan = _full_passing_scan(workspace.as_posix())
+        del scan[f"{HOME}/.claude.json"]
+        scan_file = tmp_path / "scan.json"
+        scan_file.write_text(json.dumps(scan))
+
+        rc = main([str(scan_file), "--workspace", str(workspace)])
+
+        out = capsys.readouterr().out + capsys.readouterr().err
+        assert rc != 0
+        # The missing label appears somewhere in the report.
+        assert "global-mcp" in (out + capsys.readouterr().out)
+
+    def test_missing_scan_file_exits_nonzero(self, tmp_path):
+        rc = main([str(tmp_path / "does-not-exist.json"), "--workspace", str(tmp_path)])
+        assert rc != 0


### PR DESCRIPTION
## Summary

- Adds a CircleCI job (`claude-code-nightly-{linux,macos,windows}`) plus a scheduled-pipeline workflow (`nightly-claude-code-compat`) that catches upstream Claude Code nightly regressions in `agent-scan`'s discovery layer.
- The job installs Claude Code **nightly** (per-OS native installer), authenticates via `ANTHROPIC_API_KEY` from a CircleCI context, and uses real `claude` CLI commands (`claude mcp add --scope user|project`, `claude plugin marketplace add`, `claude plugin install`) plus on-disk skill files to seed all three scopes the user asked about — global, project, and plugin — with one MCP server and one skill each.
- After the seed, runs `uv run agent-scan inspect --json --dangerously-run-mcp-servers > scan.json` and feeds the output to a new no-dependency verifier (`tests/ci/verify_cc_nightly_scan.py`) that asserts every seeded artefact appears in the discovery output and exits non-zero with a diff if any are missing.
- Workflow is gated behind a new `run-nightly-cc-test` pipeline parameter so it only runs from a scheduled trigger, not on every PR (matches the existing `run-daily-security-scan` pattern).

## Why

`agent-scan`'s `ClaudeCodeDiscoverer` (`src/agent_scan/agent_discovery.py:325`) reads several on-disk locations that Claude Code is free to change. A nightly canary across all three supported OSes gives us an early warning before regressions hit users.

## What's added

- `.circleci/config.yml` — new pipeline parameter, `circleci/windows@5.0` orb, three new jobs, new `nightly-claude-code-compat` workflow.
- `tests/ci/verify_cc_nightly_scan.py` — stdlib-only verifier (also runnable standalone) that takes `scan.json` + workspace path and reports any missing scope/artefact combinations.
- `tests/unit/test_verify_cc_nightly_scan.py` — 11 unit tests covering happy path, missing-path, missing-server, multi-miss, glob expansion for plugin caches, custom `--home` argument, Windows path normalisation, and `servers: null` resilience.
- `tests/fixtures/cc-nightly-marketplace/` — minimal local Claude Code plugin marketplace structured per the [official spec](https://code.claude.com/docs/en/plugin-marketplaces): one plugin (`nightly-test-plugin`) bundling one MCP server (`nightly-plugin-mcp`) and one skill (`nightly-plugin-skill`).

## Required setup before merging

1. Create a CircleCI context named **`claude-nightly-tokens`** containing `ANTHROPIC_API_KEY`.
2. Create a CircleCI **scheduled pipeline** that runs daily (suggested 02:00 UTC) and sets `run-nightly-cc-test=true`.

Both are one-time UI / API operations; the config will remain dormant until step 2 is wired up.

## Test plan

- [ ] Manually trigger the workflow on this branch with `run-nightly-cc-test=true` and confirm all three OS legs go green.
- [ ] Delete one of the seed steps (e.g. the global skill copy) in a throwaway commit, re-run, and confirm the verifier fails the right job with a readable diff. Restore.
- [ ] Confirm a forced verifier failure posts to `#mcp-scan-alerting` via the existing `notify_slack_on_failure` command.
- [ ] Pre-commit hooks pass locally (mypy, ruff, ruff-format, yaml, json) — already green.
- [ ] `uv run pytest tests/unit/test_verify_cc_nightly_scan.py` passes (11/11 green locally).