### PR TITLE
Fix verbose scan crash on bracketed log content

### DIFF
--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -67,7 +67,7 @@ def setup_logging(verbose=False, log_to_stderr=False):
                 datefmt="[%X]",
                 force=True,
                 level=logging.DEBUG,
-                handlers=[RichHandler(markup=True, rich_tracebacks=True, console=stderr_console)],
+                handlers=[RichHandler(markup=False, rich_tracebacks=True, console=stderr_console)],
             )
             root_logger.debug("Verbose mode enabled, logging initialized to stderr")
         else:  # stdout logging
@@ -76,7 +76,7 @@ def setup_logging(verbose=False, log_to_stderr=False):
                 datefmt="[%X]",
                 force=True,
                 level=logging.DEBUG,
-                handlers=[RichHandler(markup=True, rich_tracebacks=True)],
+                handlers=[RichHandler(markup=False, rich_tracebacks=True)],
             )
             root_logger.debug("Logging initialized to stdout")
         root_logger.debug("Logging initialized")

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -59,6 +59,10 @@ def setup_logging(verbose=False, log_to_stderr=False):
         # Remove any existing handlers (including the NullHandler)
         for hdlr in root_logger.handlers:
             root_logger.removeHandler(hdlr)
+        # markup=False on both handlers: log messages carry arbitrary scanned
+        # data (payloads, file paths, server output) that can contain "[...]"
+        # which Rich would otherwise parse as console markup and raise
+        # MarkupError. Intentional styling goes through rich.print, not logging.
         if log_to_stderr:
             # stderr logging
             stderr_console = rich.console.Console(stderr=True)

--- a/tests/unit/test_cli_logging.py
+++ b/tests/unit/test_cli_logging.py
@@ -1,0 +1,51 @@
+"""Tests for verbose logging setup.
+
+Regression coverage for a crash where scanned content containing bracketed
+text (e.g. a discovered instructions path like
+``[/c:/Users/user/.copilot/instructions, /workspace/.github/instructions]``)
+was logged at DEBUG level in --verbose mode and the Rich logging handler tried
+to parse it as console markup, raising ``rich.errors.MarkupError`` from inside
+``RichHandler.emit`` and aborting the scan before results were pushed.
+"""
+
+import logging
+
+import pytest
+
+from agent_scan.cli import setup_logging
+
+# A payload fragment that Rich's markup parser reads as an unmatched closing
+# tag ("[/...]") — this is what crashed verbose scans.
+BRACKETED_MESSAGE = "Payload: [/c:/Users/user/.copilot/instructions, /workspace/.github/instructions]"
+
+
+@pytest.fixture
+def restore_root_logger():
+    """Save and restore the root logger's handlers and level.
+
+    ``setup_logging`` calls ``logging.basicConfig(force=True)``, which mutates
+    global logging state; this fixture keeps the change from leaking into other
+    tests.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        for hdlr in root.handlers[:]:
+            root.removeHandler(hdlr)
+        for hdlr in saved_handlers:
+            root.addHandler(hdlr)
+        root.setLevel(saved_level)
+
+
+@pytest.mark.parametrize("log_to_stderr", [False, True])
+def test_verbose_debug_log_with_brackets_does_not_raise(restore_root_logger, log_to_stderr):
+    """A DEBUG log containing "[/...]" must not crash the Rich handler."""
+    setup_logging(verbose=True, log_to_stderr=log_to_stderr)
+
+    logger = logging.getLogger("agent_scan.test_cli_logging")
+    # Must not raise rich.errors.MarkupError (or anything else).
+    logger.debug("%s", BRACKETED_MESSAGE)
+    logger.debug(BRACKETED_MESSAGE)


### PR DESCRIPTION
## Problem
A `scan --verbose` run aborts before pushing results when scanned content contains bracketed text like `[/c:/Users/user/.copilot/instructions, ...]`.

- In `--verbose` mode the root logger is DEBUG, so `verify_api.py:184` dumps the full payload JSON via `logger.debug`.
- The `RichHandler` was configured with `markup=True`, so Rich parsed `[/...]` as an unmatched closing tag and raised `rich.errors.MarkupError` inside `RichHandler.emit` (uncaught).
- The crash is in the analyze step, before the push loop — so nothing is uploaded to the control server.

## Fix
- Set `markup=False` on both `RichHandler` instances in `setup_logging` (`cli.py`). Log records carry arbitrary data and must not be treated as Rich markup; no `logger.*` call relies on markup styling.
- Add regression test reproducing the crash (DEBUG log with `[/...]`, asserts no raise).

Verified end-to-end: the original command now completes with `✅ Successfully uploaded scan results`.