### PR TITLE
chore: bump version to 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,4 @@
 - `0.5.4` Fix bug in parsing of skills. Cosmetic improvements to the CLI. Security fixes. Added agent-guard support for codex.
 - `0.5.5` Introduce bootstrap API and recursive check for mcp_config_globs and skills_dir_globs.
 - `0.5.6` Per-agent discovery refactor with Claude Code support. Bundle all detect_secrets plugins in PyInstaller binary. Starlette security update.
+- `0.5.7` Expand per-agent discovery to the VS Code family (VS Code, Cursor, Windsurf, Kiro, Antigravity); discover project-scoped MCP and skills in opened workspaces; close MCP/skills discovery gaps. Send username with scan metadata. Upgrade pyjwt dependency (security).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snyk-agent-scan"
-version = "0.5.6"
+version = "0.5.7"
 description = "Agent supply chain security scanner."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -2042,7 +2042,7 @@ wheels = [
 
 [[package]]
 name = "snyk-agent-scan"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What

Bumps the package version `0.5.6` → `0.5.7` and adds the corresponding `CHANGELOG.md` entry.

- `pyproject.toml`: `version = "0.5.7"`
- `uv.lock`: `snyk-agent-scan` `0.5.6` → `0.5.7`
- `CHANGELOG.md`: new `0.5.7` line

## Changelog entry

> `0.5.7` Expand per-agent discovery to the VS Code family (VS Code, Cursor, Windsurf, Kiro, Antigravity); discover project-scoped MCP and skills in opened workspaces; close MCP/skills discovery gaps. Send username with scan metadata. Upgrade pyjwt dependency (security).

## Why

The VS Code family discoverer work (#337) and subsequent fixes were squash-merged into `main`, but `main` is still at `0.5.6`. This PR carries the version bump that accompanies that work.