### PR TITLE
fix: exclude ~/.claude/plugins/marketplaces from Claude Code plugin discovery

### DIFF
--- a/src/agent_scan/agents/claude_code.py
+++ b/src/agent_scan/agents/claude_code.py
@@ -59,12 +59,16 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     # discoverers.
     _project_skills_relative: tuple[str, ...] = (".claude/skills", ".agents/skills")
     # Subtrees under a plugin *root* (see ``_plugin_root_dirs``) that stage
-    # installed plugins. ``cache`` is the hydrated install tree and
-    # ``marketplaces`` the cloned marketplace sources (the current layout, per
-    # ``~/.claude/plugins`` and the plugin-marketplaces docs); ``repos`` is the
-    # legacy name kept for back-compat with older installs. All can host MCP
-    # servers / skills / commands.
-    _plugin_subdirs: tuple[str, ...] = ("cache", "marketplaces", "repos")
+    # *installed* plugins. ``cache`` is the current hydrated install tree;
+    # ``repos`` is the legacy name kept for back-compat with older installs.
+    # Both can host MCP servers / skills / commands.
+    #
+    # ``marketplaces`` is intentionally excluded: it holds the cloned marketplace
+    # *catalog* (the full set of plugins a marketplace makes *available*), not the
+    # subset the user installed. Installing a plugin hydrates it into ``cache``;
+    # the marketplace clone stays a catalog. Scanning it would over-report plugins
+    # that were never installed, so only the install trees are scanned.
+    _plugin_subdirs: tuple[str, ...] = ("cache", "repos")
 
     # --- public (override AgentDiscoverer abstracts) ---
 
@@ -254,8 +258,8 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     # --- private: plugin discovery ---
 
     def _plugin_root_dirs(self) -> list[Path]:
-        """Plugin *root* directories — each holds the ``cache``/``marketplaces``/
-        ``repos`` subtrees (see :attr:`_plugin_subdirs`).
+        """Plugin *root* directories — each holds the ``cache``/``repos``
+        subtrees (see :attr:`_plugin_subdirs`).
 
         The always-present root is ``<base>/plugins`` for each global folder
         (``base`` already honors ``CLAUDE_CONFIG_DIR``). Two env vars add *further*
@@ -268,7 +272,7 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         know another user's env:
 
         * ``CLAUDE_CODE_PLUGIN_CACHE_DIR`` — an additional plugins root (despite the
-          name it is the parent dir; ``cache``/``marketplaces`` live beneath it).
+          name it is the parent dir; ``cache``/``repos`` live beneath it).
         * ``CLAUDE_CODE_PLUGIN_SEED_DIR`` — ``os.pathsep``-separated read-only seed
           roots mirroring the plugins layout (container/CI pre-population).
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -996,11 +996,13 @@ def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_repos(tm
     assert any("/plugins/repos/" in k for k in mcp_configs)
 
 
-def test_claude_code_discoverer_plugin_mcp_servers_scans_marketplaces_dir(tmp_path):
-    """Plugins staged under ~/.claude/plugins/marketplaces/**/ are discovered.
+def test_claude_code_discoverer_plugin_mcp_servers_ignores_marketplaces_dir(tmp_path):
+    """Plugins staged under ~/.claude/plugins/marketplaces/**/ are NOT discovered.
 
-    ``marketplaces/`` is the current sibling of ``cache/`` (the legacy ``repos/``
-    was renamed); a plugin's source ``.mcp.json`` can live there."""
+    ``marketplaces/`` holds the cloned marketplace *catalog* — every plugin
+    *available* to install, not the ones the user actually installed. Installed
+    plugins are hydrated into ``cache/`` (legacy ``repos/``). Scanning
+    ``marketplaces/`` would over-report uninstalled plugins, so it is excluded."""
     from agent_scan.agents import ClaudeCodeDiscoverer
 
     mp_plugin = tmp_path / ".claude" / "plugins" / "marketplaces" / "official" / "plugin-x"
@@ -1010,13 +1012,11 @@ def test_claude_code_discoverer_plugin_mcp_servers_scans_marketplaces_dir(tmp_pa
     mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
 
     mp_keys = [k for k in mcp_configs if "/plugins/marketplaces/" in k]
-    assert len(mp_keys) == 1
-    entries = mcp_configs[mp_keys[0]]
-    assert isinstance(entries, list) and entries[0][0] == "mp-srv"
+    assert mp_keys == []
 
 
-def test_claude_code_discoverer_plugin_skills_scans_marketplaces_dir(tmp_path):
-    """Plugin skills staged under ~/.claude/plugins/marketplaces/**/ are discovered."""
+def test_claude_code_discoverer_plugin_skills_ignores_marketplaces_dir(tmp_path):
+    """Plugin skills staged under ~/.claude/plugins/marketplaces/**/ are NOT discovered."""
     from agent_scan.agents import ClaudeCodeDiscoverer
 
     skills_dir = tmp_path / ".claude" / "plugins" / "marketplaces" / "official" / "p" / "skills" / "ms"
@@ -1026,12 +1026,12 @@ def test_claude_code_discoverer_plugin_skills_scans_marketplaces_dir(tmp_path):
     skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_skills()
 
     mp_keys = [k for k in skills_dirs if "/plugins/marketplaces/" in k]
-    assert len(mp_keys) == 1
+    assert mp_keys == []
 
 
 def test_claude_code_honors_plugin_cache_dir_env_on_own_home_scan(tmp_path, monkeypatch):
     """CLAUDE_CODE_PLUGIN_CACHE_DIR relocates the plugins ROOT (cache/ and
-    marketplaces/ live beneath it). Honored only on an own-home scan."""
+    repos/ live beneath it). Honored only on an own-home scan."""
     from pathlib import Path
 
     from agent_scan.agents import ClaudeCodeDiscoverer
@@ -1041,14 +1041,14 @@ def test_claude_code_honors_plugin_cache_dir_env_on_own_home_scan(tmp_path, monk
     monkeypatch.setattr(Path, "home", lambda: home)
 
     plugin_root = tmp_path / "relocated-plugins"
-    plugin = plugin_root / "marketplaces" / "official" / "p"
+    plugin = plugin_root / "cache" / "official" / "p"
     plugin.mkdir(parents=True)
     (plugin / ".mcp.json").write_text('{"relocated-plugin": {"command": "p"}}')
     monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugin_root))
 
     mcp_configs = ClaudeCodeDiscoverer(home)._discover_plugin_mcp_servers()
 
-    keys = [k for k in mcp_configs if "/relocated-plugins/marketplaces/" in k]
+    keys = [k for k in mcp_configs if "/relocated-plugins/cache/" in k]
     assert len(keys) == 1, f"CLAUDE_CODE_PLUGIN_CACHE_DIR root must be scanned; got: {list(mcp_configs)}"
     assert mcp_configs[keys[0]][0][0] == "relocated-plugin"
 
@@ -1069,8 +1069,8 @@ def test_claude_code_honors_plugin_seed_dir_env_on_own_home_scan(tmp_path, monke
     seed_b = tmp_path / "seed-b"
     (seed_a / "cache" / "mp" / "p").mkdir(parents=True)
     (seed_a / "cache" / "mp" / "p" / ".mcp.json").write_text('{"seed-a-srv": {"command": "a"}}')
-    (seed_b / "marketplaces" / "mp" / "p").mkdir(parents=True)
-    (seed_b / "marketplaces" / "mp" / "p" / ".mcp.json").write_text('{"seed-b-srv": {"command": "b"}}')
+    (seed_b / "repos" / "mp" / "p").mkdir(parents=True)
+    (seed_b / "repos" / "mp" / "p" / ".mcp.json").write_text('{"seed-b-srv": {"command": "b"}}')
     monkeypatch.setenv("CLAUDE_CODE_PLUGIN_SEED_DIR", os.pathsep.join([str(seed_a), str(seed_b)]))
 
     mcp_configs = ClaudeCodeDiscoverer(home)._discover_plugin_mcp_servers()
@@ -1088,8 +1088,8 @@ def test_claude_code_ignores_plugin_env_dirs_under_multiuser_scan(tmp_path, monk
     from agent_scan.agents import ClaudeCodeDiscoverer
 
     rogue = tmp_path / "rogue-plugins"
-    (rogue / "marketplaces" / "mp" / "p").mkdir(parents=True)
-    (rogue / "marketplaces" / "mp" / "p" / ".mcp.json").write_text('{"should-not-appear": {"command": "x"}}')
+    (rogue / "cache" / "mp" / "p").mkdir(parents=True)
+    (rogue / "cache" / "mp" / "p" / ".mcp.json").write_text('{"should-not-appear": {"command": "x"}}')
     monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(rogue))
     monkeypatch.setenv("CLAUDE_CODE_PLUGIN_SEED_DIR", str(rogue) + os.pathsep)
 


### PR DESCRIPTION
## Summary

`ClaudeCodeDiscoverer` scanned three plugin subtrees under each plugin root: `cache`, `marketplaces`, and `repos`. This removes `marketplaces` from that list.

`marketplaces/` holds the cloned marketplace **catalog** — the full set of plugins a marketplace makes *available* (e.g. `~/.claude/plugins/marketplaces/claude-plugins-official/` clones 38+ plugins). Only the subset the user actually **installs** gets hydrated into `cache/` (legacy name: `repos/`); the marketplace clone stays a catalog. Scanning `marketplaces/` therefore over-reported MCP servers / skills / commands for plugins that were never installed.

After this change only the install trees (`cache/`, `repos/`) are scanned.

## Changes

- `src/agent_scan/agents/claude_code.py`: drop `"marketplaces"` from `_plugin_subdirs` → `("cache", "repos")`; update the comment and the two docstrings that described the `marketplaces` subtree.
- `tests/unit/test_agent_discovery.py`: invert the two `scans_marketplaces_dir` tests to `ignores_marketplaces_dir` (assert nothing under `marketplaces/` is discovered); move the env / seed / multiuser fixtures off the `marketplaces` subdir onto `cache`/`repos` so they remain valid.

## Testing

- `uv run pytest tests/unit/test_agent_discovery.py` → 288 passed.
- Full unit suite: only the 8 pre-existing, env-only `test_verify_api.py` failures (verified identical on a clean tree; unrelated to this change).
- `pre-commit run` on the changed files → clean.