### PR TITLE
fix(claude-code): don't scan not-yet-installed marketplace plugins

### DIFF
--- a/src/agent_scan/agents/claude_code.py
+++ b/src/agent_scan/agents/claude_code.py
@@ -58,13 +58,21 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     # (verified that Claude Code also loads it), shared with the VS Code-family
     # discoverers.
     _project_skills_relative: tuple[str, ...] = (".claude/skills", ".agents/skills")
-    # Subtrees under a plugin *root* (see ``_plugin_root_dirs``) that stage
-    # installed plugins. ``cache`` is the hydrated install tree and
-    # ``marketplaces`` the cloned marketplace sources (the current layout, per
-    # ``~/.claude/plugins`` and the plugin-marketplaces docs); ``repos`` is the
-    # legacy name kept for back-compat with older installs. All can host MCP
-    # servers / skills / commands.
-    _plugin_subdirs: tuple[str, ...] = ("cache", "marketplaces", "repos")
+    # Subtrees under a plugin *root* (see ``_plugin_root_dirs``) that hold the
+    # user's *installed* plugins. ``cache`` is the hydrated install tree every
+    # installed plugin is copied into — regardless of user/project/local scope,
+    # per the plugins-reference "plugin cache" note
+    # (https://code.claude.com/docs/en/plugins-reference); ``repos`` is the legacy
+    # name kept for back-compat with older installs. Both can host MCP servers /
+    # skills / commands.
+    #
+    # ``marketplaces/`` is deliberately NOT scanned: it is the cloned marketplace
+    # *catalog* — every plugin a marketplace offers, almost all of which the user
+    # has not installed. Adding a marketplace clones the catalog but installs
+    # nothing; only plugins the user installs are copied into ``cache``/``repos``.
+    # Walking the catalog would surface skills/MCP for plugins that were never
+    # installed (see https://code.claude.com/docs/en/discover-plugins).
+    _plugin_subdirs: tuple[str, ...] = ("cache", "repos")
 
     # --- public (override AgentDiscoverer abstracts) ---
 
@@ -254,8 +262,9 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     # --- private: plugin discovery ---
 
     def _plugin_root_dirs(self) -> list[Path]:
-        """Plugin *root* directories — each holds the ``cache``/``marketplaces``/
-        ``repos`` subtrees (see :attr:`_plugin_subdirs`).
+        """Plugin *root* directories — each holds the installed-plugin ``cache``/
+        ``repos`` subtrees scanned per :attr:`_plugin_subdirs` (and the
+        ``marketplaces`` catalog clone, which that attribute deliberately skips).
 
         The always-present root is ``<base>/plugins`` for each global folder
         (``base`` already honors ``CLAUDE_CONFIG_DIR``). Two env vars add *further*
@@ -268,7 +277,8 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         know another user's env:
 
         * ``CLAUDE_CODE_PLUGIN_CACHE_DIR`` — an additional plugins root (despite the
-          name it is the parent dir; ``cache``/``marketplaces`` live beneath it).
+          name it is the parent dir; the ``cache``/``repos`` install subtrees live
+          beneath it).
         * ``CLAUDE_CODE_PLUGIN_SEED_DIR`` — ``os.pathsep``-separated read-only seed
           roots mirroring the plugins layout (container/CI pre-population).
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -996,42 +996,55 @@ def test_claude_code_discoverer_plugin_mcp_servers_scans_both_cache_and_repos(tm
     assert any("/plugins/repos/" in k for k in mcp_configs)
 
 
-def test_claude_code_discoverer_plugin_mcp_servers_scans_marketplaces_dir(tmp_path):
-    """Plugins staged under ~/.claude/plugins/marketplaces/**/ are discovered.
+def test_claude_code_discoverer_plugin_mcp_servers_skips_marketplaces_dir(tmp_path):
+    """Plugins staged under ~/.claude/plugins/marketplaces/**/ are NOT discovered.
 
-    ``marketplaces/`` is the current sibling of ``cache/`` (the legacy ``repos/``
-    was renamed); a plugin's source ``.mcp.json`` can live there."""
+    ``marketplaces/`` is the cloned marketplace *catalog* — every plugin the
+    marketplace offers, almost all of which the user has NOT installed. Installed
+    plugins are copied into ``cache/`` (and legacy ``repos/``), so only those are
+    scanned; the not-yet-installed catalog must be skipped. A sibling ``cache/``
+    plugin in the same scan confirms installed plugins are still picked up."""
     from agent_scan.agents import ClaudeCodeDiscoverer
 
     mp_plugin = tmp_path / ".claude" / "plugins" / "marketplaces" / "official" / "plugin-x"
     mp_plugin.mkdir(parents=True)
     (mp_plugin / ".mcp.json").write_text('{"mp-srv": {"command": "m"}}')
+    cache_plugin = tmp_path / ".claude" / "plugins" / "cache" / "official" / "plugin-y"
+    cache_plugin.mkdir(parents=True)
+    (cache_plugin / ".mcp.json").write_text('{"cache-srv": {"command": "c"}}')
 
     mcp_configs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_mcp_servers()
 
-    mp_keys = [k for k in mcp_configs if "/plugins/marketplaces/" in k]
-    assert len(mp_keys) == 1
-    entries = mcp_configs[mp_keys[0]]
-    assert isinstance(entries, list) and entries[0][0] == "mp-srv"
+    assert not [k for k in mcp_configs if "/plugins/marketplaces/" in k]
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "mp-srv" not in names
+    assert "cache-srv" in names
 
 
-def test_claude_code_discoverer_plugin_skills_scans_marketplaces_dir(tmp_path):
-    """Plugin skills staged under ~/.claude/plugins/marketplaces/**/ are discovered."""
+def test_claude_code_discoverer_plugin_skills_skips_marketplaces_dir(tmp_path):
+    """Plugin skills staged under ~/.claude/plugins/marketplaces/**/ are NOT discovered.
+
+    The marketplace catalog lists un-installed plugins; only ``cache/``/``repos/``
+    (installed) skills are scanned. A sibling ``cache/`` skill confirms installed
+    plugin skills are still surfaced."""
     from agent_scan.agents import ClaudeCodeDiscoverer
 
     skills_dir = tmp_path / ".claude" / "plugins" / "marketplaces" / "official" / "p" / "skills" / "ms"
     skills_dir.mkdir(parents=True)
     (skills_dir / "SKILL.md").write_text("---\nname: ms\ndescription: m\n---\n\nB.\n")
+    cache_skill = tmp_path / ".claude" / "plugins" / "cache" / "official" / "q" / "skills" / "cs"
+    cache_skill.mkdir(parents=True)
+    (cache_skill / "SKILL.md").write_text("---\nname: cs\ndescription: c\n---\n\nB.\n")
 
     skills_dirs = ClaudeCodeDiscoverer(tmp_path)._discover_plugin_skills()
 
-    mp_keys = [k for k in skills_dirs if "/plugins/marketplaces/" in k]
-    assert len(mp_keys) == 1
+    assert not [k for k in skills_dirs if "/plugins/marketplaces/" in k]
+    assert any("/plugins/cache/" in k for k in skills_dirs)
 
 
 def test_claude_code_honors_plugin_cache_dir_env_on_own_home_scan(tmp_path, monkeypatch):
     """CLAUDE_CODE_PLUGIN_CACHE_DIR relocates the plugins ROOT (cache/ and
-    marketplaces/ live beneath it). Honored only on an own-home scan."""
+    repos/ live beneath it). Honored only on an own-home scan."""
     from pathlib import Path
 
     from agent_scan.agents import ClaudeCodeDiscoverer
@@ -1041,14 +1054,14 @@ def test_claude_code_honors_plugin_cache_dir_env_on_own_home_scan(tmp_path, monk
     monkeypatch.setattr(Path, "home", lambda: home)
 
     plugin_root = tmp_path / "relocated-plugins"
-    plugin = plugin_root / "marketplaces" / "official" / "p"
+    plugin = plugin_root / "cache" / "official" / "p"
     plugin.mkdir(parents=True)
     (plugin / ".mcp.json").write_text('{"relocated-plugin": {"command": "p"}}')
     monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugin_root))
 
     mcp_configs = ClaudeCodeDiscoverer(home)._discover_plugin_mcp_servers()
 
-    keys = [k for k in mcp_configs if "/relocated-plugins/marketplaces/" in k]
+    keys = [k for k in mcp_configs if "/relocated-plugins/cache/" in k]
     assert len(keys) == 1, f"CLAUDE_CODE_PLUGIN_CACHE_DIR root must be scanned; got: {list(mcp_configs)}"
     assert mcp_configs[keys[0]][0][0] == "relocated-plugin"
 
@@ -1069,8 +1082,10 @@ def test_claude_code_honors_plugin_seed_dir_env_on_own_home_scan(tmp_path, monke
     seed_b = tmp_path / "seed-b"
     (seed_a / "cache" / "mp" / "p").mkdir(parents=True)
     (seed_a / "cache" / "mp" / "p" / ".mcp.json").write_text('{"seed-a-srv": {"command": "a"}}')
-    (seed_b / "marketplaces" / "mp" / "p").mkdir(parents=True)
-    (seed_b / "marketplaces" / "mp" / "p" / ".mcp.json").write_text('{"seed-b-srv": {"command": "b"}}')
+    # Seed roots mirror the plugins layout; the legacy ``repos/`` install dir is
+    # still scanned alongside ``cache/`` (only the ``marketplaces/`` catalog is skipped).
+    (seed_b / "repos" / "mp" / "p").mkdir(parents=True)
+    (seed_b / "repos" / "mp" / "p" / ".mcp.json").write_text('{"seed-b-srv": {"command": "b"}}')
     monkeypatch.setenv("CLAUDE_CODE_PLUGIN_SEED_DIR", os.pathsep.join([str(seed_a), str(seed_b)]))
 
     mcp_configs = ClaudeCodeDiscoverer(home)._discover_plugin_mcp_servers()
@@ -1088,8 +1103,8 @@ def test_claude_code_ignores_plugin_env_dirs_under_multiuser_scan(tmp_path, monk
     from agent_scan.agents import ClaudeCodeDiscoverer
 
     rogue = tmp_path / "rogue-plugins"
-    (rogue / "marketplaces" / "mp" / "p").mkdir(parents=True)
-    (rogue / "marketplaces" / "mp" / "p" / ".mcp.json").write_text('{"should-not-appear": {"command": "x"}}')
+    (rogue / "cache" / "mp" / "p").mkdir(parents=True)
+    (rogue / "cache" / "mp" / "p" / ".mcp.json").write_text('{"should-not-appear": {"command": "x"}}')
     monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(rogue))
     monkeypatch.setenv("CLAUDE_CODE_PLUGIN_SEED_DIR", str(rogue) + os.pathsep)
 


### PR DESCRIPTION
## Problem

`ClaudeCodeDiscoverer` walked `~/.claude/plugins/marketplaces/` — the cloned marketplace **catalog** — when discovering plugin skills, MCP servers, and commands. A marketplace clone lists *every* plugin the marketplace offers (40+ on a default install), almost all of which the user has **not installed**. So the scan surfaced skills/MCP/commands for plugins that were never installed.

## Fix

Claude Code copies **installed** plugins (any `user`/`project`/`local` scope) into the plugin `cache/` — and legacy `repos/` — per the plugins-reference *"plugin cache"* note. So scanning only `cache/` + `repos/` is both:

- **complete** — every installed plugin, regardless of scope, lands in `cache/`; and
- **correct** — the not-yet-installed catalog lives only in `marketplaces/`, which is now excluded.

Change: `_plugin_subdirs`: `("cache", "marketplaces", "repos")` → `("cache", "repos")`, plus updated explanatory comments on `_plugin_subdirs` / `_plugin_root_dirs` documenting why the `marketplaces/` catalog is deliberately skipped.

## Scope: Claude Code only

I checked every agent and its docs. The VSCode-family discoverers (VSCode, Cursor, Windsurf, Kiro, Antigravity) only ever have **installed** extensions on disk (`~/.vscode/extensions`, etc.); extensions are downloaded only on install and there is no on-disk catalog of un-installed extensions (Kiro's Powers even live under `.../powers/installed`). No change needed there.

## Tests

- Inverted the two `..._scans_marketplaces_dir` tests → they now assert the catalog is **skipped** while a sibling `cache/` plugin in the same scan is still discovered (so the negative assertion can't pass trivially).
- Updated the env-var / seed-dir / multi-user fixtures (previously staged under `marketplaces/`) to use `cache/`/`repos/`.

Full `tests/unit/test_agent_discovery.py` + `test_inspect.py` suites pass (308). The 8 `test_verify_api.py` failures are pre-existing environment-only failures (confirmed identical on a clean `main` checkout), unrelated to this change.

## References
- https://code.claude.com/docs/en/plugins-reference (plugin cache)
- https://code.claude.com/docs/en/discover-plugins (adding a marketplace installs nothing)
