### PR TITLE
fix(vscode-family): don't scan not-installed extensions

### DIFF
--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -133,33 +133,28 @@ class AgentDiscoverer(ABC):
     ``__init_subclass__``.
 
     A discoverer is bound to a single user's ``home_directory`` at construction;
-    the multi-user (`--scan-all-users`) loop in ``pipelines`` constructs one
+    the multi-user (``--scan-all-users``) loop in ``pipelines`` constructs one
     discoverer per home directory.
 
-    Note: this abstraction intentionally does NOT consult the corresponding
-    ``CandidateClient`` row's ``mcp_config_globs`` / ``skills_dir_globs``
-    fields. Subclasses encode their layout directly. If a future agent
-    genuinely needs glob-based discovery, override ``discover_mcp_servers`` /
+    Unlike the legacy ``inspect.py`` pipeline, this abstraction does NOT consult
+    the ``CandidateClient`` row's ``mcp_config_globs`` / ``skills_dir_globs``;
+    subclasses encode their layout directly. An agent that genuinely needs
+    glob-based discovery should override ``discover_mcp_servers`` /
     ``discover_skills`` to handle it explicitly.
     """
 
     name: str = ""
 
     def __init__(self, home_directory: Path | None) -> None:
-        # ``None`` is the own-home sentinel; normalize it to ``Path.home()`` here so
-        # the stored home is always a concrete path. This keeps ``_scans_own_home``
-        # and every ``expand_path(..., self.home_directory)`` call site in agreement:
-        # ``expand_path`` treats ``None`` as "unknown home — don't expand" and would
-        # otherwise leave a ``~``-prefixed template literal (e.g. ``~/.claude``) on an
-        # own-home scan whose relocating env var is unset. Resolved at construction
-        # time, which is sound because the pipeline builds one discoverer per home
-        # immediately before scanning it.
+        # ``None`` is the own-home sentinel; normalize to ``Path.home()`` so the
+        # stored home is always concrete. ``expand_path`` treats ``None`` as
+        # "unknown home — don't expand", which would leave a ``~``-prefixed literal
+        # (e.g. ``~/.claude``) on an own-home scan whose relocating env var is unset.
         self.home_directory = home_directory if home_directory is not None else Path.home()
         # Lazily-populated cache for _project_paths_with_ancestors. A discoverer
-        # is constructed once per home and used for a single scan (see
-        # find_discoverers), so the project list is stable for its lifetime and
-        # the several discovery methods that consult it need not re-walk the
-        # workspaceStorage tree / re-read ~/.claude.json each time.
+        # serves a single scan (see find_discoverers), so the project list is
+        # stable for its lifetime and the discovery methods that consult it need
+        # not re-walk workspaceStorage / re-read ~/.claude.json each time.
         self._project_paths_cache: list[Path] | None = None
 
     def _scans_own_home(self) -> bool:
@@ -168,21 +163,15 @@ class AgentDiscoverer(ABC):
         Env-var-relocated config paths (``CLAUDE_CONFIG_DIR``, ``VSCODE_PORTABLE``)
         reflect the *scanning process's* environment, so they may only be honored
         when the home being scanned is that same user's. Other users' homes under
-        ``--scan-all-users`` must compare unequal (the scanner can't know their env).
+        ``--scan-all-users`` must compare unequal — the scanner can't know their env.
 
-        The scanning user's own home is spelled two ways depending on mode, so we
-        accept either:
-
-        * Single-user mode builds the discoverer with ``Path.home()`` (``$HOME``).
-        * ``--scan-all-users`` sources every home — including the current user's
-          own entry — from ``pwd.getpwall()`` (``Path(pw_dir)``), which can differ
-          from ``$HOME`` (a sudo-rewritten ``$HOME``, a symlinked / relocated /
-          container home). Comparing only against ``Path.home()`` there would drop
-          env-relocated config for the scanning user's own home. So we also accept
-          this uid's passwd ``pw_dir`` and resolve both sides to absorb symlinks.
-
-        ``pwd``/``os.getuid`` are POSIX-only; the guarded import simply skips that
-        extra candidate on Windows.
+        The scanning user's own home is spelled two ways, so we accept either and
+        resolve both sides to absorb symlinks: ``Path.home()`` (``$HOME``, used in
+        single-user mode) and this uid's passwd ``pw_dir`` (used by
+        ``--scan-all-users``, which sources homes from ``pwd.getpwall()`` and can
+        differ from ``$HOME`` for a sudo-rewritten / symlinked / container home).
+        ``pwd``/``os.getuid`` are POSIX-only; the guarded import skips the extra
+        candidate on Windows.
         """
         candidates = {Path.home()}
         try:
@@ -242,9 +231,9 @@ class AgentDiscoverer(ABC):
     # --- shared helpers (inherited by every concrete subclass) ---
 
     def _load_json_file(self, path: Path) -> dict | CouldNotParseMCPConfig | None:
-        """JSON-decode an arbitrary file. ``None`` if missing or unreadable due to
-        permissions, parsed dict on success, ``CouldNotParseMCPConfig`` on
-        malformed JSON.
+        """JSON-decode an arbitrary file. ``None`` if missing, unreadable (denied
+        permissions), or over the ``_MAX_CONFIG_FILE_BYTES`` cap; parsed dict on
+        success; ``CouldNotParseMCPConfig`` on malformed JSON.
 
         Uses ``pyjson5`` to match the legacy ``mcp_client.scan_mcp_config_file``
         path, which tolerates ``//`` comments and trailing commas. An empty or
@@ -343,12 +332,11 @@ class AgentDiscoverer(ABC):
         ``skip_unrecognized`` is an opt-in for *opportunistic* walks that match
         every file merely *named* ``mcp.json`` (the extension walk). When set, a
         valid-JSON file with no recognizable MCP shape (see
-        :func:`_looks_like_mcp_payload`) returns ``None`` (skip) instead of a
-        ``CouldNotParseMCPConfig`` — so an unrelated extension file isn't reported
-        as a malformed config. A wrapper-keyed file that then fails to validate is
-        still surfaced as malformed. Callers parsing an explicitly-named config
-        file (e.g. ``~/.vscode/mcp.json``) leave this off so genuine malformations
-        there are still reported.
+        :func:`_looks_like_mcp_payload`) returns ``None`` instead of
+        ``CouldNotParseMCPConfig``, so an unrelated extension file isn't reported as
+        malformed; a wrapper-keyed file that then fails to validate is still
+        surfaced. Callers parsing an explicitly-named config (e.g.
+        ``~/.vscode/mcp.json``) leave it off so genuine malformations are reported.
         """
         data = self._load_json_file(path)
         if data is None:
@@ -356,17 +344,16 @@ class AgentDiscoverer(ABC):
         if isinstance(data, CouldNotParseMCPConfig):
             return data
         if not isinstance(data, dict):
-            # A non-object root (JSON array/scalar) is not any known MCP shape.
-            # An opportunistic walk merely matched the filename, so skip it; an
-            # explicitly-named config file is unsupported/malformed and must
-            # surface as CouldNotParseMCPConfig (legacy ``scan_mcp_config_file``
-            # parity — there every model fails on a non-dict). It falls through to
-            # the format loop below, where each ``model_validate`` rejects the
-            # non-dict and the last error is reported.
+            # A non-object root (JSON array/scalar) is no known MCP shape. An
+            # opportunistic walk merely matched the filename, so skip it. An
+            # explicitly-named config falls through to the format loop below, where
+            # every ``model_validate`` rejects the non-dict and the last error
+            # surfaces as CouldNotParseMCPConfig (legacy ``scan_mcp_config_file``
+            # parity).
             if skip_unrecognized:
                 return None
         elif not data:
-            # Empty object: no servers to scan, and not malformed — skip quietly
+            # Empty object: no servers and not malformed — skip quietly
             # (legacy returns a zero-server ``ConfigWithoutMCP`` for ``{}``).
             return None
         elif skip_unrecognized and not _looks_like_mcp_payload(data):
@@ -446,7 +433,7 @@ class AgentDiscoverer(ABC):
         living in any parent folder of an opened project (e.g. a monorepo root
         that contains many project subdirectories).
 
-        The result is cached for the discoverer's lifetime
+        The result is cached for the discoverer's lifetime.
         """
         if self._project_paths_cache is not None:
             return self._project_paths_cache

--- a/src/agent_scan/agents/vscode/antigravity.py
+++ b/src/agent_scan/agents/vscode/antigravity.py
@@ -82,9 +82,11 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
     # Installed extensions live under ``~/.gemini/extensions/`` (shared with
     # the Gemini CLI; not under the ``antigravity/`` subdir). The Gemini CLI
     # manages this tree with its own per-extension layout — there is NO central
-    # ``extensions.json`` install manifest — so it is scanned wholesale rather
-    # than manifest-gated (see the ``_installed_extension_dirs`` override below).
+    # ``extensions.json`` install manifest — so it is scanned wholesale via
+    # ``_unmanaged_extension_paths`` (see ``_installed_extension_dirs`` below).
     _extension_paths = ("~/.gemini/extensions",)
+    # Subset of ``_extension_paths`` with no ``extensions.json`` install manifest.
+    _unmanaged_extension_paths: ClassVar[tuple[str, ...]] = ("~/.gemini/extensions",)
     # Built-in (bundled) extensions shipped inside the Antigravity application.
     # ENTIRELY INFERRED — verify: Antigravity was not available to verify on
     # disk, and Google has not published install paths. The macOS bundle name is
@@ -108,11 +110,15 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
     }
 
     def _installed_extension_dirs(self, base: Path) -> list[Path]:
-        """``~/.gemini/extensions`` is the Gemini-CLI-shared tree with no
-        ``extensions.json`` manifest, so it returns its immediate subdirs (every
-        present extension is scanned). Any other root (the built-in/bundled dirs)
-        falls through to the manifest-gated base logic."""
-        if base == expand_path(Path("~/.gemini/extensions"), self.home_directory):
+        """Roots in ``_unmanaged_extension_paths`` ship no ``extensions.json``
+        manifest, so those roots return their immediate subdirs (every present
+        extension is scanned). All other roots (e.g. built-in/bundled dirs) stay
+        manifest-gated via ``super()``."""
+        unmanaged = {
+            expand_path(Path(raw), self.home_directory)
+            for raw in self._unmanaged_extension_paths
+        }
+        if base in unmanaged:
             return self._immediate_subdirs(base)
         return super()._installed_extension_dirs(base)
 

--- a/src/agent_scan/agents/vscode/antigravity.py
+++ b/src/agent_scan/agents/vscode/antigravity.py
@@ -84,7 +84,7 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
     # manifest and an optional ``skills/`` tree. VERIFIED on a real macOS install
     # (``chrome-devtools-plugin``). There is NO central ``extensions.json`` (each
     # plugin subdir is itself the install marker), so the tree is scanned wholesale
-    # via ``_unmanaged_extension_paths`` (see ``_installed_extension_dirs`` below).
+    # (see ``_installed_extension_dirs`` below).
     # Plugin MCP is registered centrally in ``~/.gemini/config/mcp_config.json``
     # (already in ``_user_mcp_file_paths``), not a per-plugin ``mcp.json`` — but the
     # mcp.json walk is kept as a harmless catch in case a plugin ships one.
@@ -92,11 +92,6 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
     # no central manifest); kept as a shared-``~/.gemini`` best-effort catch that is
     # a no-op when absent.
     _extension_paths = ("~/.gemini/config/plugins", "~/.gemini/extensions")
-    # Subset of ``_extension_paths`` with no ``extensions.json`` install manifest.
-    _unmanaged_extension_paths: ClassVar[tuple[str, ...]] = (
-        "~/.gemini/config/plugins",
-        "~/.gemini/extensions",
-    )
     # Built-in (bundled) extensions shipped inside the Antigravity application.
     # KNOWN COVERAGE GAP on macOS: VERIFIED on disk that the bundle ships an
     # Electron ``app.asar`` (``…/Antigravity.app/Contents/Resources/app.asar``) and
@@ -123,12 +118,12 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
     }
 
     def _installed_extension_dirs(self, base: Path) -> list[Path]:
-        """Roots in ``_unmanaged_extension_paths`` ship no ``extensions.json``
-        manifest, so those roots return their immediate subdirs (every present
-        extension is scanned). All other roots (e.g. built-in/bundled dirs) stay
-        manifest-gated via ``super()``."""
-        unmanaged = {expand_path(Path(raw), self.home_directory) for raw in self._unmanaged_extension_paths}
-        if base in unmanaged:
+        """Every Antigravity extension root ships no ``extensions.json`` manifest,
+        so ``_extension_paths`` roots return their immediate subdirs (every present
+        extension is scanned). Built-in/bundled dirs stay manifest-gated via
+        ``super()``."""
+        extension_roots = {expand_path(Path(raw), self.home_directory) for raw in self._extension_paths}
+        if base in extension_roots:
             return self._immediate_subdirs(base)
         return super()._installed_extension_dirs(base)
 

--- a/src/agent_scan/agents/vscode/antigravity.py
+++ b/src/agent_scan/agents/vscode/antigravity.py
@@ -80,7 +80,10 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
         ".gemini/mcp_config.json",  # inferred — verify (undocumented for Antigravity)
     )
     # Installed extensions live under ``~/.gemini/extensions/`` (shared with
-    # the Gemini CLI; not under the ``antigravity/`` subdir).
+    # the Gemini CLI; not under the ``antigravity/`` subdir). The Gemini CLI
+    # manages this tree with its own per-extension layout — there is NO central
+    # ``extensions.json`` install manifest — so it is scanned wholesale rather
+    # than manifest-gated (see the ``_installed_extension_dirs`` override below).
     _extension_paths = ("~/.gemini/extensions",)
     # Built-in (bundled) extensions shipped inside the Antigravity application.
     # ENTIRELY INFERRED — verify: Antigravity was not available to verify on
@@ -103,6 +106,16 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
             "/opt/antigravity/resources/app/extensions",  # inferred — verify (may be packed in app.asar)
         ),
     }
+
+    def _installed_extension_dirs(self, base: Path) -> list[Path] | None:
+        """``~/.gemini/extensions`` is the Gemini-CLI-shared tree with no
+        ``extensions.json`` manifest, so it is scanned wholesale (returning
+        ``None`` tells the base walk to scan every subdir). Any other root (the
+        built-in/bundled dirs) falls through to the manifest-gated base logic."""
+        if base == expand_path(Path("~/.gemini/extensions"), self.home_directory):
+            return None
+        return super()._installed_extension_dirs(base)
+
     # Antigravity's own opened-workspace registry. Each opened folder is recorded
     # as a ``<id>.json`` file here, with the root under
     # ``projectResources.resources[].folderUri`` (a ``file://`` URI). Shared by the

--- a/src/agent_scan/agents/vscode/antigravity.py
+++ b/src/agent_scan/agents/vscode/antigravity.py
@@ -107,13 +107,13 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
         ),
     }
 
-    def _installed_extension_dirs(self, base: Path) -> list[Path] | None:
+    def _installed_extension_dirs(self, base: Path) -> list[Path]:
         """``~/.gemini/extensions`` is the Gemini-CLI-shared tree with no
-        ``extensions.json`` manifest, so it is scanned wholesale (returning
-        ``None`` tells the base walk to scan every subdir). Any other root (the
-        built-in/bundled dirs) falls through to the manifest-gated base logic."""
+        ``extensions.json`` manifest, so it returns its immediate subdirs (every
+        present extension is scanned). Any other root (the built-in/bundled dirs)
+        falls through to the manifest-gated base logic."""
         if base == expand_path(Path("~/.gemini/extensions"), self.home_directory):
-            return None
+            return self._immediate_subdirs(base)
         return super()._installed_extension_dirs(base)
 
     # Antigravity's own opened-workspace registry. Each opened folder is recorded

--- a/src/agent_scan/agents/vscode/antigravity.py
+++ b/src/agent_scan/agents/vscode/antigravity.py
@@ -1,7 +1,6 @@
 """Antigravity discoverer."""
 
 from pathlib import Path
-from typing import ClassVar
 
 from agent_scan.agents.vscode.base import (
     VSCodeFamilyDiscoverer,
@@ -92,30 +91,6 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
     # no central manifest); kept as a shared-``~/.gemini`` best-effort catch that is
     # a no-op when absent.
     _extension_paths = ("~/.gemini/config/plugins", "~/.gemini/extensions")
-    # Built-in (bundled) extensions shipped inside the Antigravity application.
-    # KNOWN COVERAGE GAP on macOS: VERIFIED on disk that the bundle ships an
-    # Electron ``app.asar`` (``…/Antigravity.app/Contents/Resources/app.asar``) and
-    # has NO ``Contents/Resources/app/extensions`` dir — built-ins are packed inside
-    # the archive and cannot be reached by a plain directory walk. The macOS entries
-    # below are retained as harmless no-ops (and in case a future build unpacks
-    # them); they do not currently match. Windows/Linux remain INFERRED — Google has
-    # not published install paths: Windows is user-level (%LOCALAPPDATA%, exact
-    # folder unconfirmed); Linux extracts to /opt/antigravity (community-reported,
-    # version-dependent) and likely also packs into app.asar. Re-check on a real
-    # install per platform.
-    _builtin_extension_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {
-        "darwin": (
-            "/Applications/Antigravity.app/Contents/Resources/app/extensions",  # packed in app.asar — no-op
-            "~/Applications/Antigravity.app/Contents/Resources/app/extensions",  # packed in app.asar — no-op
-        ),
-        "win32": (
-            # inferred — verify: user-level install confirmed by Google, exact folder name NOT.
-            "~/AppData/Local/Programs/Antigravity/resources/app/extensions",
-        ),
-        "linux": (
-            "/opt/antigravity/resources/app/extensions",  # inferred — verify (may be packed in app.asar)
-        ),
-    }
 
     def _installed_extension_dirs(self, base: Path) -> list[Path]:
         """Every Antigravity extension root ships no ``extensions.json`` manifest,

--- a/src/agent_scan/agents/vscode/antigravity.py
+++ b/src/agent_scan/agents/vscode/antigravity.py
@@ -79,26 +79,39 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
         # Workspace mirror of the user-global ``~/.gemini/config/mcp_config.json``.
         ".gemini/mcp_config.json",  # inferred — verify (undocumented for Antigravity)
     )
-    # Installed extensions live under ``~/.gemini/extensions/`` (shared with
-    # the Gemini CLI; not under the ``antigravity/`` subdir). The Gemini CLI
-    # manages this tree with its own per-extension layout — there is NO central
-    # ``extensions.json`` install manifest — so it is scanned wholesale via
-    # ``_unmanaged_extension_paths`` (see ``_installed_extension_dirs`` below).
-    _extension_paths = ("~/.gemini/extensions",)
+    # Antigravity installs *plugins* (its extension equivalent) under
+    # ``~/.gemini/config/plugins/<name>/`` — each a dir with a ``plugin.json``
+    # manifest and an optional ``skills/`` tree. VERIFIED on a real macOS install
+    # (``chrome-devtools-plugin``). There is NO central ``extensions.json`` (each
+    # plugin subdir is itself the install marker), so the tree is scanned wholesale
+    # via ``_unmanaged_extension_paths`` (see ``_installed_extension_dirs`` below).
+    # Plugin MCP is registered centrally in ``~/.gemini/config/mcp_config.json``
+    # (already in ``_user_mcp_file_paths``), not a per-plugin ``mcp.json`` — but the
+    # mcp.json walk is kept as a harmless catch in case a plugin ships one.
+    # ``~/.gemini/extensions`` is the Gemini *CLI's* tree (per-extension dirs, also
+    # no central manifest); kept as a shared-``~/.gemini`` best-effort catch that is
+    # a no-op when absent.
+    _extension_paths = ("~/.gemini/config/plugins", "~/.gemini/extensions")
     # Subset of ``_extension_paths`` with no ``extensions.json`` install manifest.
-    _unmanaged_extension_paths: ClassVar[tuple[str, ...]] = ("~/.gemini/extensions",)
+    _unmanaged_extension_paths: ClassVar[tuple[str, ...]] = (
+        "~/.gemini/config/plugins",
+        "~/.gemini/extensions",
+    )
     # Built-in (bundled) extensions shipped inside the Antigravity application.
-    # ENTIRELY INFERRED — verify: Antigravity was not available to verify on
-    # disk, and Google has not published install paths. The macOS bundle name is
-    # assumed to follow the product name; Google states the Windows installer is
-    # user-level (%LOCALAPPDATA%) but not the exact folder; the Linux installer
-    # currently extracts to /opt/antigravity (community-reported, version-
-    # dependent) and may pack extensions inside app.asar, in which case the dir
-    # below is absent. Re-check each entry against a real install.
+    # KNOWN COVERAGE GAP on macOS: VERIFIED on disk that the bundle ships an
+    # Electron ``app.asar`` (``…/Antigravity.app/Contents/Resources/app.asar``) and
+    # has NO ``Contents/Resources/app/extensions`` dir — built-ins are packed inside
+    # the archive and cannot be reached by a plain directory walk. The macOS entries
+    # below are retained as harmless no-ops (and in case a future build unpacks
+    # them); they do not currently match. Windows/Linux remain INFERRED — Google has
+    # not published install paths: Windows is user-level (%LOCALAPPDATA%, exact
+    # folder unconfirmed); Linux extracts to /opt/antigravity (community-reported,
+    # version-dependent) and likely also packs into app.asar. Re-check on a real
+    # install per platform.
     _builtin_extension_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {
         "darwin": (
-            "/Applications/Antigravity.app/Contents/Resources/app/extensions",  # inferred — verify
-            "~/Applications/Antigravity.app/Contents/Resources/app/extensions",  # inferred — verify
+            "/Applications/Antigravity.app/Contents/Resources/app/extensions",  # packed in app.asar — no-op
+            "~/Applications/Antigravity.app/Contents/Resources/app/extensions",  # packed in app.asar — no-op
         ),
         "win32": (
             # inferred — verify: user-level install confirmed by Google, exact folder name NOT.
@@ -114,10 +127,7 @@ class AntigravityDiscoverer(VSCodeFamilyDiscoverer):
         manifest, so those roots return their immediate subdirs (every present
         extension is scanned). All other roots (e.g. built-in/bundled dirs) stay
         manifest-gated via ``super()``."""
-        unmanaged = {
-            expand_path(Path(raw), self.home_directory)
-            for raw in self._unmanaged_extension_paths
-        }
+        unmanaged = {expand_path(Path(raw), self.home_directory) for raw in self._unmanaged_extension_paths}
         if base in unmanaged:
             return self._immediate_subdirs(base)
         return super()._installed_extension_dirs(base)

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -730,79 +730,77 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
 
     # --- private: install-manifest gating (don't scan uninstalled extensions) ---
 
-    def _installed_extension_names(self, base: Path) -> set[str] | None:
-        """Names of the extension dirs VSCode records as *installed* in
+    def _installed_extension_dirs(self, base: Path) -> list[Path] | None:
+        """The extension dirs VSCode records as *installed* in
         ``<base>/extensions.json`` — its authoritative install manifest. Each
         entry's ``relativeLocation`` is the on-disk dir name; some manifest shapes
-        omit it, so fall back to the basename of ``location.path``.
+        omit it, so fall back to the basename of ``location.path``. The name is
+        resolved against ``base`` and confined to it (see :meth:`_confine_to_base`)
+        so an attacker-influenceable manifest (under ``--scan-all-users``) cannot
+        redirect the scan outside the extension root.
 
         Returns ``None`` when no parseable ``extensions.json`` is present, which
         the caller treats as "no manifest, scan every subdir" — the *built-in*
         (bundled) extension roots ship none. A present-but-empty manifest (``[]``)
-        returns an empty set: nothing is installed, so nothing is scanned.
+        returns an empty list: nothing is installed, so nothing is scanned.
+        Uninstalled leftovers and upgraded-away versions linger on disk but are
+        absent from the manifest, so they are never reached — no separate
+        ``.obsolete`` denylist is needed (an obsolete dir is never in the manifest).
         """
         data = self._load_json_file(base / "extensions.json")
         if not isinstance(data, list):
             return None
-        names: set[str] = set()
+        dirs: list[Path] = []
+        seen: set[str] = set()
         for entry in data:
             if not isinstance(entry, dict):
                 continue
             rel = entry.get("relativeLocation")
-            if isinstance(rel, str) and rel:
-                names.add(rel)
+            if not (isinstance(rel, str) and rel):
+                location = entry.get("location")
+                path = location.get("path") if isinstance(location, dict) else None
+                rel = Path(path).name if isinstance(path, str) and path else None
+            if not rel or rel in seen:
                 continue
-            location = entry.get("location")
-            path = location.get("path") if isinstance(location, dict) else None
-            if isinstance(path, str) and path:
-                names.add(Path(path).name)
-        return names
-
-    def _obsolete_extension_names(self, base: Path) -> set[str]:
-        """Names of extension dirs VSCode marked uninstalled-but-not-yet-deleted in
-        ``<base>/.obsolete`` (a ``{dirname: true}`` map). These linger on disk
-        after an uninstall/upgrade until a later cleanup, so they must be skipped.
-        Empty when ``.obsolete`` is absent or not an object.
-        """
-        data = self._load_json_file(base / ".obsolete")
-        if not isinstance(data, dict):
-            return set()
-        return {name for name, flagged in data.items() if flagged and isinstance(name, str)}
+            seen.add(rel)
+            confined = self._confine_to_base(base, rel)
+            if confined is not None:
+                dirs.append(confined)
+        return dirs
 
     @staticmethod
-    def _top_level_extension_name(base: Path, found: Path) -> str | None:
-        """The extension's own directory name: the first path component of ``found``
-        relative to ``base``. ``None`` when ``found`` is not under ``base`` or sits
-        directly at the root (a hit needs ``<ext>/…/<name>``, so the root manifest
-        files ``extensions.json`` / ``.obsolete`` are never treated as extensions).
+    def _confine_to_base(base: Path, relative_location: str) -> Path | None:
+        """Resolve a manifest dir name against ``base``, confined to it.
+
+        ``relativeLocation`` is normally a single dir name (e.g.
+        ``pub.ext-1.0.0``), but the manifest is attacker-influenceable under
+        ``--scan-all-users``; a value carrying ``..`` or an absolute path must not
+        redirect the walk outside the extension root. Returns the resolved dir, or
+        ``None`` for anything that escapes (or equals) ``base``. Normalized
+        lexically — no filesystem access, so it cannot be defeated by symlinks
+        planted between this check and the walk.
         """
-        try:
-            parts = found.relative_to(base).parts
-        except ValueError:
-            return None
-        return parts[0] if len(parts) >= 2 else None
+        candidate = Path(os.path.normpath(base / relative_location))
+        if candidate != base and candidate.is_relative_to(base):
+            return candidate
+        return None
 
     def _iter_installed_extension_hits(self, name: str, *, want_file: bool) -> list[Path]:
-        """Walk each extension root for ``name`` (file or dir), restricted to the
-        user's *installed* extensions.
+        """Walk for ``name`` (file or dir) under the user's *installed* extensions.
 
-        Per root, ``extensions.json`` is the install allowlist and ``.obsolete``
-        the uninstalled denylist (see :meth:`_installed_extension_names` /
-        :meth:`_obsolete_extension_names`). A hit is kept only when its top-level
-        extension dir is not obsolete and — when the root has a manifest — is
-        listed there. Roots without a manifest (built-in/bundled) fall back to
-        scanning every subdir. The walk stays rooted at ``base`` so the
-        ``_MAX_PLUGIN_RGLOB_DEPTH`` depth cap keeps its current meaning.
+        ``extensions.json`` is VSCode's authoritative install manifest, so each
+        root is scanned at exactly the dirs it lists (see
+        :meth:`_installed_extension_dirs`). A root with no manifest — the built-in
+        / bundled extension dirs ship none — falls back to scanning every subdir,
+        so built-in coverage is unchanged. Each scanned dir is walked with the
+        ``_MAX_PLUGIN_RGLOB_DEPTH`` depth cap.
         """
         hits: list[Path] = []
         for base in self._extension_base_dirs():
-            allowed = self._installed_extension_names(base)
-            obsolete = self._obsolete_extension_names(base)
-            for found in _walk_under_depth(base, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=want_file):
-                ext = self._top_level_extension_name(base, found)
-                if ext is None or ext in obsolete or (allowed is not None and ext not in allowed):
-                    continue
-                hits.append(found)
+            installed = self._installed_extension_dirs(base)
+            roots = [base] if installed is None else installed
+            for root in roots:
+                hits.extend(_walk_under_depth(root, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=want_file))
         return hits
 
     def _discover_extension_mcp_servers(self) -> McpConfigsResult:

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -730,36 +730,53 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
 
     # --- private: install-manifest gating (don't scan uninstalled extensions) ---
 
-    def _installed_extension_dirs(self, base: Path) -> list[Path] | None:
-        """The extension dirs VSCode records as *installed* in
-        ``<base>/extensions.json`` — its authoritative install manifest. Each
-        entry's ``relativeLocation`` is the on-disk dir name; some manifest shapes
-        omit it, so fall back to the basename of ``location.path``. The name is
-        resolved against ``base`` and confined to it (see :meth:`_confine_to_base`)
-        so an attacker-influenceable manifest (under ``--scan-all-users``) cannot
-        redirect the scan outside the extension root.
+    @staticmethod
+    def _immediate_subdirs(base: Path) -> list[Path]:
+        """Immediate subdirectories of ``base`` (empty if absent/unreadable).
 
-        Return contract (consumed by :meth:`_extension_scan_roots`):
+        Used for *unmanaged* extension roots that ship no ``extensions.json`` —
+        every present subdir is an installed extension, so they are the dirs to
+        scan. Errors fail soft (empty list) so one unreadable root cannot drop the
+        whole discoverer; mirrors the tolerance in :func:`_walk_under_depth`.
+        """
+        try:
+            return [p for p in base.iterdir() if p.is_dir()]
+        except (PermissionError, OSError):
+            return []
 
-        * ``None`` — *not* manifest-managed; scan every subdir. Reserved for roots
-          that ship no ``extensions.json`` *by design*: the built-in (bundled)
-          extension roots, detected here, and the fork-declared unmanaged trees
-          (Kiro Powers, Antigravity's Gemini dir) whose subclasses override this.
-        * ``[]`` — manifest-managed, nothing to scan. A managed root whose
-          ``extensions.json`` is missing, unreadable, or unparseable **fails
+    def _installed_extension_dirs(self, base: Path) -> list[Path]:
+        """The dirs of the extensions *installed* under ``base`` — always a list,
+        the directories to walk for bundled ``mcp.json`` / ``skills/``.
+
+        Two kinds of root, both resolved here to a concrete list of dirs:
+
+        * *Manifest-managed* — gated by ``<base>/extensions.json``, VSCode's
+          authoritative install manifest. Each entry's ``relativeLocation`` is the
+          on-disk dir name; some manifest shapes omit it, so fall back to the
+          basename of ``location.path``. The name is resolved against ``base`` and
+          confined to it (see :meth:`_confine_to_base`) so an attacker-influenceable
+          manifest (under ``--scan-all-users``) cannot redirect the scan outside the
+          extension root. Returns exactly the dirs the manifest names, or ``[]``
+          when it is missing, unreadable, or unparseable — a managed root **fails
           closed**: an extension is installed iff the manifest lists it, and the
           editor itself loads nothing from such a dir, so there is nothing live to
-          scan. A present-but-empty manifest (``[]``) is the same: nothing installed.
-        * a non-empty list — exactly the installed dirs the manifest names.
+          scan (a present-but-empty manifest ``[]`` is the same: nothing installed).
+        * *Unmanaged* — roots that ship no ``extensions.json`` *by design*: the
+          built-in (bundled) extension roots, detected here, and the fork-declared
+          unmanaged trees (Kiro Powers, Antigravity's Gemini dir) whose subclasses
+          override this. Every present subdir is an installed extension, so this
+          returns all of them via :meth:`_immediate_subdirs`.
 
         Uninstalled leftovers and upgraded-away versions linger on disk but are
-        absent from the manifest, so they are never reached — no separate
-        ``.obsolete`` denylist is needed (an obsolete dir is never in the manifest).
+        absent from a managed root's manifest, so they are never reached — no
+        separate ``.obsolete`` denylist is needed (an obsolete dir is never in the
+        manifest).
         """
         # Built-in/bundled roots ship no manifest by design — they are not
-        # manifest-managed, so scan them wholesale rather than failing closed.
+        # manifest-managed, so scan every installed (present) subdir rather than
+        # failing closed.
         if base in set(self._builtin_extension_dirs()):
-            return None
+            return self._immediate_subdirs(base)
         data = self._load_json_file(base / "extensions.json")
         if not isinstance(data, list):
             return []
@@ -800,18 +817,12 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
 
     def _extension_scan_roots(self) -> list[Path]:
         """The directories to walk for bundled ``mcp.json`` / ``skills/``: each
-        extension root from :meth:`_extension_base_dirs`, gated through its install
-        manifest (see :meth:`_installed_extension_dirs` for the return contract).
-
-        An *unmanaged* root (``None``) — the built-in/bundled dirs and the fork
-        trees a subclass marks unmanaged — is scanned in full; a *manifest-managed*
-        root contributes exactly the dirs its ``extensions.json`` lists, which is
-        empty (scan nothing, fail closed) when that manifest is missing or
-        unparseable. The actual walking is the shared :func:`_walk_under_depth`."""
+        extension root from :meth:`_extension_base_dirs` contributes its installed
+        extension dirs (see :meth:`_installed_extension_dirs`). The actual walking
+        is the shared :func:`_walk_under_depth`."""
         roots: list[Path] = []
         for base in self._extension_base_dirs():
-            installed = self._installed_extension_dirs(base)
-            roots.extend([base] if installed is None else installed)
+            roots.extend(self._installed_extension_dirs(base))
         return roots
 
     def _discover_extension_mcp_servers(self) -> McpConfigsResult:

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -739,17 +739,30 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         so an attacker-influenceable manifest (under ``--scan-all-users``) cannot
         redirect the scan outside the extension root.
 
-        Returns ``None`` when no parseable ``extensions.json`` is present, which
-        the caller treats as "no manifest, scan every subdir" — the *built-in*
-        (bundled) extension roots ship none. A present-but-empty manifest (``[]``)
-        returns an empty list: nothing is installed, so nothing is scanned.
+        Return contract (consumed by :meth:`_extension_scan_roots`):
+
+        * ``None`` — *not* manifest-managed; scan every subdir. Reserved for roots
+          that ship no ``extensions.json`` *by design*: the built-in (bundled)
+          extension roots, detected here, and the fork-declared unmanaged trees
+          (Kiro Powers, Antigravity's Gemini dir) whose subclasses override this.
+        * ``[]`` — manifest-managed, nothing to scan. A managed root whose
+          ``extensions.json`` is missing, unreadable, or unparseable **fails
+          closed**: an extension is installed iff the manifest lists it, and the
+          editor itself loads nothing from such a dir, so there is nothing live to
+          scan. A present-but-empty manifest (``[]``) is the same: nothing installed.
+        * a non-empty list — exactly the installed dirs the manifest names.
+
         Uninstalled leftovers and upgraded-away versions linger on disk but are
         absent from the manifest, so they are never reached — no separate
         ``.obsolete`` denylist is needed (an obsolete dir is never in the manifest).
         """
+        # Built-in/bundled roots ship no manifest by design — they are not
+        # manifest-managed, so scan them wholesale rather than failing closed.
+        if base in set(self._builtin_extension_dirs()):
+            return None
         data = self._load_json_file(base / "extensions.json")
         if not isinstance(data, list):
-            return None
+            return []
         dirs: list[Path] = []
         seen: set[str] = set()
         for entry in data:
@@ -788,11 +801,13 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
     def _extension_scan_roots(self) -> list[Path]:
         """The directories to walk for bundled ``mcp.json`` / ``skills/``: each
         extension root from :meth:`_extension_base_dirs`, gated through its install
-        manifest. ``extensions.json`` is VSCode's authoritative install manifest,
-        so a managed root contributes exactly the dirs it lists (see
-        :meth:`_installed_extension_dirs`); a root with no manifest — the built-in
-        / bundled dirs, and the fork trees a subclass marks unmanaged — is scanned
-        in full. The actual walking is the shared :func:`_walk_under_depth`."""
+        manifest (see :meth:`_installed_extension_dirs` for the return contract).
+
+        An *unmanaged* root (``None``) — the built-in/bundled dirs and the fork
+        trees a subclass marks unmanaged — is scanned in full; a *manifest-managed*
+        root contributes exactly the dirs its ``extensions.json`` lists, which is
+        empty (scan nothing, fail closed) when that manifest is missing or
+        unparseable. The actual walking is the shared :func:`_walk_under_depth`."""
         roots: list[Path] = []
         for base in self._extension_base_dirs():
             installed = self._installed_extension_dirs(base)

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -785,32 +785,28 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
             return candidate
         return None
 
-    def _iter_installed_extension_hits(self, name: str, *, want_file: bool) -> list[Path]:
-        """Walk for ``name`` (file or dir) under the user's *installed* extensions.
-
-        ``extensions.json`` is VSCode's authoritative install manifest, so each
-        root is scanned at exactly the dirs it lists (see
-        :meth:`_installed_extension_dirs`). A root with no manifest — the built-in
-        / bundled extension dirs ship none — falls back to scanning every subdir,
-        so built-in coverage is unchanged. Each scanned dir is walked with the
-        ``_MAX_PLUGIN_RGLOB_DEPTH`` depth cap.
-        """
-        hits: list[Path] = []
+    def _extension_scan_roots(self) -> list[Path]:
+        """The directories to walk for bundled ``mcp.json`` / ``skills/``: each
+        extension root from :meth:`_extension_base_dirs`, gated through its install
+        manifest. ``extensions.json`` is VSCode's authoritative install manifest,
+        so a managed root contributes exactly the dirs it lists (see
+        :meth:`_installed_extension_dirs`); a root with no manifest — the built-in
+        / bundled dirs, and the fork trees a subclass marks unmanaged — is scanned
+        in full. The actual walking is the shared :func:`_walk_under_depth`."""
+        roots: list[Path] = []
         for base in self._extension_base_dirs():
             installed = self._installed_extension_dirs(base)
-            roots = [base] if installed is None else installed
-            for root in roots:
-                hits.extend(_walk_under_depth(root, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=want_file))
-        return hits
+            roots.extend([base] if installed is None else installed)
+        return roots
 
     def _discover_extension_mcp_servers(self) -> McpConfigsResult:
         """Scan ``mcp.json`` under each *installed* extension (no leading dot — the
         VSCode-family file-name convention). Mirrors
         :meth:`ClaudeCodeDiscoverer._discover_plugin_mcp_servers` but uses
         :attr:`_VSCODE_FAMILY_FORMATS` so wrapped, VSCode-flat ``servers``, and
-        fully flat shapes all parse. The walk is install-manifest gated (see
-        :meth:`_iter_installed_extension_hits`) so uninstalled extensions left on
-        disk are not scanned.
+        fully flat shapes all parse. Roots are install-manifest gated (see
+        :meth:`_extension_scan_roots`) so uninstalled extensions left on disk are
+        not scanned.
 
         ``skip_unrecognized=True``: this walk matches every file merely *named*
         ``mcp.json``, and extensions ship unrelated files under that name (JSON
@@ -819,22 +815,24 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         that fails to validate is still reported as malformed.
         """
         result: McpConfigsResult = {}
-        for mcp_file in self._iter_installed_extension_hits("mcp.json", want_file=True):
-            if not mcp_file.is_file():
-                continue
-            parsed = self._parse_mcp_file(mcp_file, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True)
-            if parsed is None:
-                continue
-            result[mcp_file.as_posix()] = parsed
+        for root in self._extension_scan_roots():
+            for mcp_file in _walk_under_depth(root, "mcp.json", _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
+                if not mcp_file.is_file():
+                    continue
+                parsed = self._parse_mcp_file(mcp_file, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True)
+                if parsed is None:
+                    continue
+                result[mcp_file.as_posix()] = parsed
         return result
 
     def _discover_extension_skills(self) -> SkillsDirsResult:
-        """Scan ``skills/`` subdirs under each *installed* extension (install-
-        manifest gated, see :meth:`_iter_installed_extension_hits`)."""
+        """Scan ``skills/`` subdirs under each *installed* extension (roots are
+        install-manifest gated, see :meth:`_extension_scan_roots`)."""
         result: SkillsDirsResult = {}
-        for skills_dir in self._iter_installed_extension_hits("skills", want_file=False):
-            if skills_dir.is_dir():
-                result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
+        for root in self._extension_scan_roots():
+            for skills_dir in _walk_under_depth(root, "skills", _MAX_PLUGIN_RGLOB_DEPTH, want_file=False):
+                if skills_dir.is_dir():
+                    result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
         return result
 
     # --- private: chat.agentSkillsLocations ---

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -728,12 +728,91 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
             expand_path(Path(raw), self.home_directory) for raw in self._builtin_extension_dir_templates.get(key, ())
         ]
 
+    # --- private: install-manifest gating (don't scan uninstalled extensions) ---
+
+    def _installed_extension_names(self, base: Path) -> set[str] | None:
+        """Names of the extension dirs VSCode records as *installed* in
+        ``<base>/extensions.json`` — its authoritative install manifest. Each
+        entry's ``relativeLocation`` is the on-disk dir name; some manifest shapes
+        omit it, so fall back to the basename of ``location.path``.
+
+        Returns ``None`` when no parseable ``extensions.json`` is present, which
+        the caller treats as "no manifest, scan every subdir" — the *built-in*
+        (bundled) extension roots ship none. A present-but-empty manifest (``[]``)
+        returns an empty set: nothing is installed, so nothing is scanned.
+        """
+        data = self._load_json_file(base / "extensions.json")
+        if not isinstance(data, list):
+            return None
+        names: set[str] = set()
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            rel = entry.get("relativeLocation")
+            if isinstance(rel, str) and rel:
+                names.add(rel)
+                continue
+            location = entry.get("location")
+            path = location.get("path") if isinstance(location, dict) else None
+            if isinstance(path, str) and path:
+                names.add(Path(path).name)
+        return names
+
+    def _obsolete_extension_names(self, base: Path) -> set[str]:
+        """Names of extension dirs VSCode marked uninstalled-but-not-yet-deleted in
+        ``<base>/.obsolete`` (a ``{dirname: true}`` map). These linger on disk
+        after an uninstall/upgrade until a later cleanup, so they must be skipped.
+        Empty when ``.obsolete`` is absent or not an object.
+        """
+        data = self._load_json_file(base / ".obsolete")
+        if not isinstance(data, dict):
+            return set()
+        return {name for name, flagged in data.items() if flagged and isinstance(name, str)}
+
+    @staticmethod
+    def _top_level_extension_name(base: Path, found: Path) -> str | None:
+        """The extension's own directory name: the first path component of ``found``
+        relative to ``base``. ``None`` when ``found`` is not under ``base`` or sits
+        directly at the root (a hit needs ``<ext>/…/<name>``, so the root manifest
+        files ``extensions.json`` / ``.obsolete`` are never treated as extensions).
+        """
+        try:
+            parts = found.relative_to(base).parts
+        except ValueError:
+            return None
+        return parts[0] if len(parts) >= 2 else None
+
+    def _iter_installed_extension_hits(self, name: str, *, want_file: bool) -> list[Path]:
+        """Walk each extension root for ``name`` (file or dir), restricted to the
+        user's *installed* extensions.
+
+        Per root, ``extensions.json`` is the install allowlist and ``.obsolete``
+        the uninstalled denylist (see :meth:`_installed_extension_names` /
+        :meth:`_obsolete_extension_names`). A hit is kept only when its top-level
+        extension dir is not obsolete and — when the root has a manifest — is
+        listed there. Roots without a manifest (built-in/bundled) fall back to
+        scanning every subdir. The walk stays rooted at ``base`` so the
+        ``_MAX_PLUGIN_RGLOB_DEPTH`` depth cap keeps its current meaning.
+        """
+        hits: list[Path] = []
+        for base in self._extension_base_dirs():
+            allowed = self._installed_extension_names(base)
+            obsolete = self._obsolete_extension_names(base)
+            for found in _walk_under_depth(base, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=want_file):
+                ext = self._top_level_extension_name(base, found)
+                if ext is None or ext in obsolete or (allowed is not None and ext not in allowed):
+                    continue
+                hits.append(found)
+        return hits
+
     def _discover_extension_mcp_servers(self) -> McpConfigsResult:
-        """Walk each extension root for ``mcp.json`` (no leading dot — matches the
+        """Scan ``mcp.json`` under each *installed* extension (no leading dot — the
         VSCode-family file-name convention). Mirrors
         :meth:`ClaudeCodeDiscoverer._discover_plugin_mcp_servers` but uses
         :attr:`_VSCODE_FAMILY_FORMATS` so wrapped, VSCode-flat ``servers``, and
-        fully flat shapes all parse.
+        fully flat shapes all parse. The walk is install-manifest gated (see
+        :meth:`_iter_installed_extension_hits`) so uninstalled extensions left on
+        disk are not scanned.
 
         ``skip_unrecognized=True``: this walk matches every file merely *named*
         ``mcp.json``, and extensions ship unrelated files under that name (JSON
@@ -742,19 +821,23 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         that fails to validate is still reported as malformed.
         """
         result: McpConfigsResult = {}
-        for base in self._extension_base_dirs():
-            for mcp_file in _walk_under_depth(base, "mcp.json", _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
-                if not mcp_file.is_file():
-                    continue
-                parsed = self._parse_mcp_file(mcp_file, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True)
-                if parsed is None:
-                    continue
-                result[mcp_file.as_posix()] = parsed
+        for mcp_file in self._iter_installed_extension_hits("mcp.json", want_file=True):
+            if not mcp_file.is_file():
+                continue
+            parsed = self._parse_mcp_file(mcp_file, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True)
+            if parsed is None:
+                continue
+            result[mcp_file.as_posix()] = parsed
         return result
 
     def _discover_extension_skills(self) -> SkillsDirsResult:
-        """Walk each extension root for ``skills/`` subdirectories."""
-        return self._discover_skill_and_command_dirs(self._extension_base_dirs(), "skills", inspect_skills_dir)
+        """Scan ``skills/`` subdirs under each *installed* extension (install-
+        manifest gated, see :meth:`_iter_installed_extension_hits`)."""
+        result: SkillsDirsResult = {}
+        for skills_dir in self._iter_installed_extension_hits("skills", want_file=False):
+            if skills_dir.is_dir():
+                result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
+        return result
 
     # --- private: chat.agentSkillsLocations ---
 

--- a/src/agent_scan/agents/vscode/kiro.py
+++ b/src/agent_scan/agents/vscode/kiro.py
@@ -63,12 +63,15 @@ class KiroDiscoverer(VSCodeFamilyDiscoverer):
     # each shipping its as-authored ``mcp.json`` + ``steering/`` (the official
     # kirodotdev/powers repo documents this layout, e.g. databricks/POWER.md).
     # Powers use NO ``extensions.json`` manifest — the ``installed/`` segment is
-    # itself the install marker — so that tree is scanned wholesale; see the
-    # ``_installed_extension_dirs`` override below. Powers are user-global only.
+    # itself the install marker — so that tree is scanned wholesale via
+    # ``_unmanaged_extension_paths`` (see ``_installed_extension_dirs`` below).
+    # Powers are user-global only.
     _extension_paths = (
         "~/.kiro/extensions",
         "~/.kiro/powers/installed",
     )
+    # Subset of ``_extension_paths`` with no ``extensions.json`` install manifest.
+    _unmanaged_extension_paths: ClassVar[tuple[str, ...]] = ("~/.kiro/powers/installed",)
     # Built-in (bundled) extensions shipped inside the Kiro application.
     # ENTIRELY INFERRED — verify: Kiro was not available to verify on disk and
     # its docs only say "follow the installer". The macOS bundle name and the
@@ -86,10 +89,14 @@ class KiroDiscoverer(VSCodeFamilyDiscoverer):
     }
 
     def _installed_extension_dirs(self, base: Path) -> list[Path]:
-        """Kiro Powers (``~/.kiro/powers/installed``) ship no ``extensions.json``
-        manifest — each installed Power is just a present subdir — so that root
-        returns its immediate subdirs (every Power is scanned). ``~/.kiro/extensions``
-        is the standard OpenVSX tree and stays manifest-gated via ``super()``."""
-        if base == expand_path(Path("~/.kiro/powers/installed"), self.home_directory):
+        """Roots in ``_unmanaged_extension_paths`` ship no ``extensions.json``
+        manifest — each installed Power is just a present subdir — so those roots
+        return their immediate subdirs (every Power is scanned). All other roots
+        (e.g. ``~/.kiro/extensions``) stay manifest-gated via ``super()``."""
+        unmanaged = {
+            expand_path(Path(raw), self.home_directory)
+            for raw in self._unmanaged_extension_paths
+        }
+        if base in unmanaged:
             return self._immediate_subdirs(base)
         return super()._installed_extension_dirs(base)

--- a/src/agent_scan/agents/vscode/kiro.py
+++ b/src/agent_scan/agents/vscode/kiro.py
@@ -1,8 +1,10 @@
 """Kiro discoverer."""
 
+from pathlib import Path
 from typing import ClassVar
 
 from agent_scan.agents.vscode.base import VSCodeFamilyDiscoverer
+from agent_scan.well_known_clients import expand_path
 
 
 class KiroDiscoverer(VSCodeFamilyDiscoverer):
@@ -55,12 +57,14 @@ class KiroDiscoverer(VSCodeFamilyDiscoverer):
         ".agents/skills",  # inferred — verify (undocumented for Kiro)
     )
     # Kiro is a VSCode fork using OpenVSX — installed extensions live under
-    # ``~/.kiro/extensions/`` and can contribute ``mcp.json`` / ``skills/``.
-    # Installed Kiro Powers live under ``~/.kiro/powers/installed/<name>/``,
+    # ``~/.kiro/extensions/``, tracked by that dir's ``extensions.json`` install
+    # manifest, so it is scanned manifest-gated like any VSCode-family extensions
+    # dir. Installed Kiro Powers live under ``~/.kiro/powers/installed/<name>/``,
     # each shipping its as-authored ``mcp.json`` + ``steering/`` (the official
     # kirodotdev/powers repo documents this layout, e.g. databricks/POWER.md).
-    # Walking that tree the same way as extensions picks them up. Powers are
-    # user-global only — no documented project-scoped equivalent.
+    # Powers use NO ``extensions.json`` manifest — the ``installed/`` segment is
+    # itself the install marker — so that tree is scanned wholesale; see the
+    # ``_installed_extension_dirs`` override below. Powers are user-global only.
     _extension_paths = (
         "~/.kiro/extensions",
         "~/.kiro/powers/installed",
@@ -80,3 +84,13 @@ class KiroDiscoverer(VSCodeFamilyDiscoverer):
         # linux: NO STABLE PATH — Kiro distributes an AppImage/tarball with no
         # documented fixed install root, so Linux built-in discovery is omitted.
     }
+
+    def _installed_extension_dirs(self, base: Path) -> list[Path] | None:
+        """Kiro Powers (``~/.kiro/powers/installed``) ship no ``extensions.json``
+        manifest — each installed Power is just a present subdir — so that root is
+        scanned wholesale (returning ``None`` tells the base walk to scan every
+        subdir). ``~/.kiro/extensions`` is the standard OpenVSX tree and stays
+        manifest-gated via ``super()``."""
+        if base == expand_path(Path("~/.kiro/powers/installed"), self.home_directory):
+            return None
+        return super()._installed_extension_dirs(base)

--- a/src/agent_scan/agents/vscode/kiro.py
+++ b/src/agent_scan/agents/vscode/kiro.py
@@ -93,10 +93,7 @@ class KiroDiscoverer(VSCodeFamilyDiscoverer):
         manifest — each installed Power is just a present subdir — so those roots
         return their immediate subdirs (every Power is scanned). All other roots
         (e.g. ``~/.kiro/extensions``) stay manifest-gated via ``super()``."""
-        unmanaged = {
-            expand_path(Path(raw), self.home_directory)
-            for raw in self._unmanaged_extension_paths
-        }
+        unmanaged = {expand_path(Path(raw), self.home_directory) for raw in self._unmanaged_extension_paths}
         if base in unmanaged:
             return self._immediate_subdirs(base)
         return super()._installed_extension_dirs(base)

--- a/src/agent_scan/agents/vscode/kiro.py
+++ b/src/agent_scan/agents/vscode/kiro.py
@@ -85,12 +85,11 @@ class KiroDiscoverer(VSCodeFamilyDiscoverer):
         # documented fixed install root, so Linux built-in discovery is omitted.
     }
 
-    def _installed_extension_dirs(self, base: Path) -> list[Path] | None:
+    def _installed_extension_dirs(self, base: Path) -> list[Path]:
         """Kiro Powers (``~/.kiro/powers/installed``) ship no ``extensions.json``
-        manifest — each installed Power is just a present subdir — so that root is
-        scanned wholesale (returning ``None`` tells the base walk to scan every
-        subdir). ``~/.kiro/extensions`` is the standard OpenVSX tree and stays
-        manifest-gated via ``super()``."""
+        manifest — each installed Power is just a present subdir — so that root
+        returns its immediate subdirs (every Power is scanned). ``~/.kiro/extensions``
+        is the standard OpenVSX tree and stays manifest-gated via ``super()``."""
         if base == expand_path(Path("~/.kiro/powers/installed"), self.home_directory):
-            return None
+            return self._immediate_subdirs(base)
         return super()._installed_extension_dirs(base)

--- a/src/agent_scan/agents/vscode/windsurf.py
+++ b/src/agent_scan/agents/vscode/windsurf.py
@@ -45,7 +45,13 @@ class WindsurfDiscoverer(VSCodeFamilyDiscoverer):
         "~/.agents/skills",
         "~/.claude/skills",
     )
-    _extension_paths = ("~/.codeium/windsurf/extensions",)
+    # Windsurf keeps Codeium *engine* state under ``~/.codeium/windsurf`` (the
+    # MCP/skill paths above), but its VSCode-fork *user data* — extensions and
+    # ``argv.json`` — lives under ``~/.windsurf``. VERIFIED on disk:
+    # ``~/.windsurf/extensions/extensions.json`` plus the installed dirs are there,
+    # while ``~/.codeium/windsurf`` has no ``extensions`` subdir. Standard
+    # ``extensions.json`` tree, so it is manifest-gated like upstream VSCode.
+    _extension_paths = ("~/.windsurf/extensions",)
     # Built-in (bundled) extensions shipped inside the Windsurf application.
     _builtin_extension_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {
         "darwin": (

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -4231,6 +4231,74 @@ def test_antigravity_extension_skills_discovers_skills_dir(tmp_path):
     assert len(matching) == 1
 
 
+# --- Per-fork extension-root conventions (subclass overrides of the
+# manifest gate; see KiroDiscoverer / AntigravityDiscoverer
+# ``_installed_extension_dirs``). Standard VSCode/OpenVSX dirs are gated by
+# ``extensions.json``; fork trees that don't use that convention are scanned
+# wholesale. ---
+
+
+def test_kiro_powers_dir_scanned_wholesale_ignoring_manifest(tmp_path):
+    """Kiro Powers (``~/.kiro/powers/installed``) use no ``extensions.json`` — the
+    ``installed/`` segment is the install marker — so the whole tree is scanned.
+    A stray empty ``extensions.json`` must NOT gate (suppress) Powers discovery.
+    """
+    from agent_scan.agents import KiroDiscoverer
+
+    powers = tmp_path / ".kiro" / "powers" / "installed"
+    power = powers / "databricks"
+    power.mkdir(parents=True)
+    (power / "mcp.json").write_text('{"mcpServers": {"power-srv": {"command": "p"}}}')
+    # A stray manifest that lists nothing would suppress the Power if this root
+    # were treated as manifest-gated — the override must keep it wholesale.
+    (powers / "extensions.json").write_text("[]")
+
+    mcp_configs = KiroDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "power-srv" in names
+
+
+def test_kiro_extensions_dir_is_manifest_gated(tmp_path):
+    """``~/.kiro/extensions`` is the standard OpenVSX tree, so it IS gated by its
+    ``extensions.json`` — a leftover dir not listed there is skipped (the Powers
+    override must not relax gating for this sibling root)."""
+    from agent_scan.agents import KiroDiscoverer
+
+    exts = tmp_path / ".kiro" / "extensions"
+    installed = exts / "pub.kept-1.0.0"
+    leftover = exts / "pub.left-0.9.0"
+    installed.mkdir(parents=True)
+    leftover.mkdir(parents=True)
+    (installed / "mcp.json").write_text('{"mcpServers": {"kept-srv": {"command": "k"}}}')
+    (leftover / "mcp.json").write_text('{"mcpServers": {"left-srv": {"command": "l"}}}')
+    (exts / "extensions.json").write_text('[{"relativeLocation": "pub.kept-1.0.0"}]')
+
+    mcp_configs = KiroDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "kept-srv" in names
+    assert "left-srv" not in names
+
+
+def test_antigravity_gemini_extensions_scanned_wholesale_ignoring_manifest(tmp_path):
+    """Antigravity's ``~/.gemini/extensions`` is the Gemini-CLI-shared tree with
+    no ``extensions.json`` convention, so it is scanned wholesale — a stray empty
+    ``extensions.json`` must not suppress its extensions."""
+    from agent_scan.agents import AntigravityDiscoverer
+
+    exts = tmp_path / ".gemini" / "extensions"
+    ext = exts / "v.ag-1.0.0"
+    ext.mkdir(parents=True)
+    (ext / "mcp.json").write_text('{"mcpServers": {"ag-srv": {"command": "a"}}}')
+    (exts / "extensions.json").write_text("[]")
+
+    mcp_configs = AntigravityDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "ag-srv" in names
+
+
 # --- VSCode: profile-specific MCP discovery ---
 #
 # VSCode profiles live at ``<userdata>/User/profiles/<id>/`` and each profile

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3565,6 +3565,40 @@ def test_vscode_builtin_extension_dir_scanned_without_manifest(tmp_path, monkeyp
     assert "builtin-srv" in names
 
 
+def test_installed_extension_dirs_builtin_returns_subdirs_not_none(tmp_path, monkeypatch):
+    """An *unmanaged* (built-in/bundled) root has no ``extensions.json``; every
+    present subdir is an installed extension. ``_installed_extension_dirs`` returns
+    exactly those subdirs as a list — never ``None`` — and excludes stray files."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    builtin = tmp_path / "app" / "extensions"
+    (builtin / "vendor.a-1.0.0").mkdir(parents=True)
+    (builtin / "vendor.b-2.0.0").mkdir(parents=True)
+    (builtin / "extensions.json").write_text("[]")  # a stray file must be excluded
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [builtin])
+
+    result = VSCodeDiscoverer(tmp_path)._installed_extension_dirs(builtin)
+
+    assert result is not None
+    assert isinstance(result, list)
+    assert set(result) == {builtin / "vendor.a-1.0.0", builtin / "vendor.b-2.0.0"}
+
+
+def test_installed_extension_dirs_empty_unmanaged_root_returns_empty_list(tmp_path, monkeypatch):
+    """An unmanaged root with no subdirs (or absent on disk) returns ``[]``, not
+    ``None`` — the sentinel is gone, the contract is always ``list[Path]``."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    empty = tmp_path / "app" / "extensions"
+    empty.mkdir(parents=True)
+    absent = tmp_path / "app" / "missing"
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [empty, absent])
+
+    disc = VSCodeDiscoverer(tmp_path)
+    assert disc._installed_extension_dirs(empty) == []
+    assert disc._installed_extension_dirs(absent) == []
+
+
 def test_vscode_extension_skills_skips_upgraded_away_version(tmp_path, monkeypatch):
     """The same install-manifest gate applies to extension ``skills/`` discovery."""
     from agent_scan.agents import VSCodeDiscoverer

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3390,22 +3390,24 @@ def test_vscode_extension_walk_respects_max_depth_cap(tmp_path, monkeypatch):
     assert not any("/a/b/c/d/mcp.json" in k for k in mcp_configs)
 
 
-# --- Install-manifest gating: don't scan uninstalled extensions ---
+# --- Install-manifest gating: scan only what extensions.json lists ---
 #
 # A directory existing under an extension root does NOT mean the extension is
-# installed. VSCode records the authoritative install set in
-# ``<ext-root>/extensions.json`` and, on uninstall/upgrade, leaves the stale dir
-# on disk while recording it in ``<ext-root>/.obsolete`` until a later cleanup.
-# The extension walks must scan only installed extensions.
+# installed. ``<ext-root>/extensions.json`` is VSCode's authoritative install
+# manifest, so the extension walks scan only the dirs it lists. Uninstalled
+# leftovers and upgraded-away versions linger on disk (VSCode also records them
+# in ``<ext-root>/.obsolete`` pending cleanup) but are absent from the manifest,
+# so they are never reached — no separate ``.obsolete`` check is needed.
 
 
-def test_vscode_extension_mcp_skips_obsolete_extension(tmp_path, monkeypatch):
-    """An extension dir VSCode marked uninstalled in ``.obsolete`` (left on disk
-    after an upgrade) is NOT scanned, while its installed replacement is.
+def test_vscode_extension_mcp_skips_upgraded_away_version(tmp_path, monkeypatch):
+    """An extension version left on disk after an upgrade is NOT scanned, while
+    its installed replacement is.
 
     Mirrors real on-disk state: ``ext-1.0.0`` was upgraded to ``ext-2.0.0``;
-    VSCode rewrote ``extensions.json`` to list only ``ext-2.0.0`` and recorded
-    ``ext-1.0.0`` in ``.obsolete`` pending deletion. Both dirs still exist.
+    VSCode rewrote ``extensions.json`` to list only ``ext-2.0.0`` and left the
+    ``ext-1.0.0`` dir on disk pending cleanup. Only the manifest-listed version
+    is scanned.
     """
     from agent_scan.agents import VSCodeDiscoverer
 
@@ -3418,7 +3420,6 @@ def test_vscode_extension_mcp_skips_obsolete_extension(tmp_path, monkeypatch):
     (old / "mcp.json").write_text('{"mcpServers": {"old-srv": {"command": "o"}}}')
     (new / "mcp.json").write_text('{"mcpServers": {"new-srv": {"command": "n"}}}')
     (exts / "extensions.json").write_text('[{"relativeLocation": "pub.ext-2.0.0"}]')
-    (exts / ".obsolete").write_text('{"pub.ext-1.0.0": true}')
 
     mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -3520,7 +3521,7 @@ def test_vscode_builtin_extension_dir_scanned_without_manifest(tmp_path, monkeyp
     assert "builtin-srv" in names
 
 
-def test_vscode_extension_skills_skips_obsolete_extension(tmp_path, monkeypatch):
+def test_vscode_extension_skills_skips_upgraded_away_version(tmp_path, monkeypatch):
     """The same install-manifest gate applies to extension ``skills/`` discovery."""
     from agent_scan.agents import VSCodeDiscoverer
 
@@ -3533,7 +3534,6 @@ def test_vscode_extension_skills_skips_obsolete_extension(tmp_path, monkeypatch)
     (old_skill / "SKILL.md").write_text("---\nname: old-skill\ndescription: o\n---\n\nbody.\n")
     (new_skill / "SKILL.md").write_text("---\nname: new-skill\ndescription: n\n---\n\nbody.\n")
     (exts / "extensions.json").write_text('[{"relativeLocation": "pub.sk-2.0.0"}]')
-    (exts / ".obsolete").write_text('{"pub.sk-1.0.0": true}')
 
     skills_dirs = VSCodeDiscoverer(tmp_path).discover_skills()
 
@@ -3541,9 +3541,9 @@ def test_vscode_extension_skills_skips_obsolete_extension(tmp_path, monkeypatch)
     assert not any("/pub.sk-1.0.0/" in k for k in skills_dirs)
 
 
-def test_cursor_extension_mcp_skips_obsolete_extension(tmp_path, monkeypatch):
+def test_cursor_extension_mcp_skips_upgraded_away_version(tmp_path, monkeypatch):
     """The install-manifest gate is inherited by forks — Cursor under
-    ``~/.cursor/extensions`` honors ``extensions.json`` / ``.obsolete`` too."""
+    ``~/.cursor/extensions`` scans only what its ``extensions.json`` lists."""
     from agent_scan.agents import CursorDiscoverer
 
     monkeypatch.setattr(CursorDiscoverer, "_builtin_extension_dirs", lambda self: [])
@@ -3555,13 +3555,44 @@ def test_cursor_extension_mcp_skips_obsolete_extension(tmp_path, monkeypatch):
     (old / "mcp.json").write_text('{"mcpServers": {"cur-old": {"command": "o"}}}')
     (new / "mcp.json").write_text('{"mcpServers": {"cur-new": {"command": "n"}}}')
     (exts / "extensions.json").write_text('[{"relativeLocation": "v.c-2.0.0"}]')
-    (exts / ".obsolete").write_text('{"v.c-1.0.0": true}')
 
     mcp_configs = CursorDiscoverer(tmp_path).discover_mcp_servers()
 
     names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
     assert "cur-new" in names
     assert "cur-old" not in names
+
+
+def test_vscode_extension_manifest_rejects_path_traversal(tmp_path, monkeypatch):
+    """A hostile ``extensions.json`` (e.g. another user's home under
+    ``--scan-all-users``) cannot redirect the walk outside the extension root via
+    a ``..`` or absolute ``relativeLocation``.
+
+    A normal entry alongside the malicious one is still scanned; the traversal
+    entry pointing at an ``mcp.json`` outside the root is not.
+    """
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".vscode" / "extensions"
+    good = exts / "pub.good-1.0.0"
+    good.mkdir(parents=True)
+    (good / "mcp.json").write_text('{"mcpServers": {"good-srv": {"command": "g"}}}')
+    # A real file outside the extension root that the traversal entry resolves to
+    # (``.vscode/extensions/../../outside`` -> ``<tmp>/outside``); confinement must
+    # reject it, so without the guard this mcp.json would otherwise be walked.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "mcp.json").write_text('{"mcpServers": {"evil-srv": {"command": "e"}}}')
+    (exts / "extensions.json").write_text(
+        '[{"relativeLocation": "pub.good-1.0.0"}, {"relativeLocation": "../../outside"}]'
+    )
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "good-srv" in names
+    assert "evil-srv" not in names
 
 
 def test_kiro_discoverer_walks_kiro_extensions_dir(tmp_path):

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3169,6 +3169,7 @@ def test_vscode_extension_mcp_discovers_wrapped_mcp_json(tmp_path):
     ext_dir = tmp_path / ".vscode" / "extensions" / "publisher.example-1.0.0"
     ext_dir.mkdir(parents=True)
     (ext_dir / "mcp.json").write_text('{"mcpServers": {"ext-srv": {"command": "e"}}}')
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "publisher.example-1.0.0"}]')
 
     mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -3188,6 +3189,7 @@ def test_vscode_extension_mcp_discovers_vscode_flat_servers_shape(tmp_path):
     ext_dir = tmp_path / ".vscode" / "extensions" / "x.flat-2.0.0"
     ext_dir.mkdir(parents=True)
     (ext_dir / "mcp.json").write_text('{"servers": {"flat-srv": {"command": "f"}}}')
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "x.flat-2.0.0"}]')
 
     mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -3222,6 +3224,7 @@ def test_vscode_extension_mcp_records_could_not_parse_for_invalid_json(tmp_path)
     ext_dir = tmp_path / ".vscode" / "extensions" / "x.bad-0.0.1"
     ext_dir.mkdir(parents=True)
     (ext_dir / "mcp.json").write_text("{ not valid json")
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "x.bad-0.0.1"}]')
 
     mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -3251,6 +3254,7 @@ def test_vscode_extension_mcp_skips_unrelated_json_named_mcp_json(tmp_path):
         '"title": "config schema", "type": "object", '
         '"properties": {"foo": {"type": "string"}}}'
     )
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "x.schema-1.0.0"}]')
 
     mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -3272,6 +3276,7 @@ def test_vscode_extension_mcp_still_flags_malformed_mcp_shaped_file(tmp_path):
     # Recognizably MCP (mcpServers wrapper), but the server has neither a
     # ``command`` (stdio) nor a ``url`` (remote), so no server model validates.
     (ext_dir / "mcp.json").write_text('{"mcpServers": {"bad": {"args": ["x"]}}}')
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "x.brokenmcp-1.0.0"}]')
 
     mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -3284,9 +3289,11 @@ def test_vscode_extension_skills_discovers_skills_dir(tmp_path):
     """An extension shipping a ``skills/`` directory is picked up."""
     from agent_scan.agents import VSCodeDiscoverer
 
-    ext_skill_dir = tmp_path / ".vscode" / "extensions" / "p.ext-1.0.0" / "skills" / "ext-skill"
+    exts = tmp_path / ".vscode" / "extensions"
+    ext_skill_dir = exts / "p.ext-1.0.0" / "skills" / "ext-skill"
     ext_skill_dir.mkdir(parents=True)
     (ext_skill_dir / "SKILL.md").write_text("---\nname: ext-skill\ndescription: e\n---\n\nbody.\n")
+    (exts / "extensions.json").write_text('[{"relativeLocation": "p.ext-1.0.0"}]')
 
     skills_dirs = VSCodeDiscoverer(tmp_path).discover_skills()
 
@@ -3323,6 +3330,7 @@ def test_cursor_extension_mcp_discovers_mcp_json(tmp_path):
     ext_dir = tmp_path / ".cursor" / "extensions" / "vendor.curext-3.1.4"
     ext_dir.mkdir(parents=True)
     (ext_dir / "mcp.json").write_text('{"mcpServers": {"cur-ext-srv": {"command": "c"}}}')
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "vendor.curext-3.1.4"}]')
 
     mcp_configs = CursorDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -3338,9 +3346,11 @@ def test_cursor_extension_skills_discovers_skills_dir(tmp_path):
     """Cursor extensions can ship a ``skills/`` directory just like VSCode."""
     from agent_scan.agents import CursorDiscoverer
 
-    ext_skill_dir = tmp_path / ".cursor" / "extensions" / "v.c-1.0.0" / "skills" / "cur-skill"
+    exts = tmp_path / ".cursor" / "extensions"
+    ext_skill_dir = exts / "v.c-1.0.0" / "skills" / "cur-skill"
     ext_skill_dir.mkdir(parents=True)
     (ext_skill_dir / "SKILL.md").write_text("---\nname: cur-skill\ndescription: c\n---\n\nbody.\n")
+    (exts / "extensions.json").write_text('[{"relativeLocation": "v.c-1.0.0"}]')
 
     skills_dirs = CursorDiscoverer(tmp_path).discover_skills()
 
@@ -3355,6 +3365,7 @@ def test_windsurf_extension_mcp_discovers_mcp_json(tmp_path):
     ext_dir = tmp_path / ".codeium" / "windsurf" / "extensions" / "v.ws-1.0.0"
     ext_dir.mkdir(parents=True)
     (ext_dir / "mcp.json").write_text('{"mcpServers": {"ws-ext-srv": {"command": "w"}}}')
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "v.ws-1.0.0"}]')
 
     mcp_configs = WindsurfDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -3379,9 +3390,15 @@ def test_vscode_extension_walk_respects_max_depth_cap(tmp_path, monkeypatch):
     # (agents.vscode.base), so patch the cap there.
     monkeypatch.setattr(vscode_base, "_MAX_PLUGIN_RGLOB_DEPTH", 3)
 
-    # Inside ``~/.vscode/extensions/`` the relative-parts depth of
-    # ``a/b/c/d/mcp.json`` is 4 — beyond cap 3, so it must NOT be discovered.
-    deep = tmp_path / ".vscode" / "extensions" / "a" / "b" / "c" / "d"
+    # Scan the tree as a built-in (manifest-less) root so it is walked wholesale
+    # and depth *pruning* — not manifest gating — is what's under test; depth is
+    # measured from the scanned root. A dedicated dir (not the user extensions
+    # path) keeps it a single, purely built-in scan root.
+    exts = tmp_path / "builtin-extensions"
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [exts])
+    # Relative to that root the depth of ``a/b/c/d/mcp.json`` is 4 — beyond cap 3,
+    # so it must NOT be discovered.
+    deep = exts / "a" / "b" / "c" / "d"
     deep.mkdir(parents=True)
     (deep / "mcp.json").write_text('{"mcpServers": {"deep": {"command": "x"}}}')
 
@@ -3468,10 +3485,16 @@ def test_vscode_extension_mcp_empty_manifest_scans_nothing(tmp_path, monkeypatch
     assert not any("/extensions/" in k for k in mcp_configs)
 
 
-def test_vscode_extension_mcp_no_manifest_scans_all(tmp_path, monkeypatch):
-    """With no ``extensions.json`` present the walk falls back to scanning every
-    subdir — the behavior built-in/bundled extension roots rely on (they ship no
-    manifest)."""
+def test_vscode_extension_mcp_no_manifest_scans_nothing(tmp_path, monkeypatch):
+    """A *managed* extension root with no ``extensions.json`` scans NOTHING (fail
+    closed): with no manifest there is no installed set, and VSCode itself loads
+    nothing from such a dir (an extension is installed iff the manifest lists it).
+
+    The scan-all exception is reserved for roots that ship no manifest *by design*
+    — built-in/bundled roots (see
+    ``test_vscode_builtin_extension_dir_scanned_without_manifest``) and the
+    fork-declared unmanaged trees (Kiro Powers, Antigravity's Gemini dir).
+    """
     from agent_scan.agents import VSCodeDiscoverer
 
     monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
@@ -3482,7 +3505,28 @@ def test_vscode_extension_mcp_no_manifest_scans_all(tmp_path, monkeypatch):
     mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
 
     names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
-    assert "nomani-srv" in names
+    assert "nomani-srv" not in names
+    assert not any("/extensions/" in k for k in mcp_configs)
+
+
+def test_vscode_extension_mcp_corrupt_manifest_scans_nothing(tmp_path, monkeypatch):
+    """A *managed* extension root whose ``extensions.json`` is corrupt (unparseable)
+    scans NOTHING (fail closed) — it does not fall back to scanning every on-disk
+    dir. An unreadable manifest yields no installed set, same as a missing one."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".vscode" / "extensions"
+    ext_dir = exts / "pub.corrupt-1.0.0"
+    ext_dir.mkdir(parents=True)
+    (ext_dir / "mcp.json").write_text('{"mcpServers": {"corrupt-srv": {"command": "c"}}}')
+    (exts / "extensions.json").write_text("{ not valid json")
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "corrupt-srv" not in names
+    assert not any("/extensions/" in k for k in mcp_configs)
 
 
 def test_vscode_extension_manifest_location_path_fallback(tmp_path, monkeypatch):
@@ -3607,6 +3651,7 @@ def test_kiro_discoverer_walks_kiro_extensions_dir(tmp_path):
     ext_dir = tmp_path / ".kiro" / "extensions" / "x.kr-1.0.0"
     ext_dir.mkdir(parents=True)
     (ext_dir / "mcp.json").write_text('{"mcpServers": {"kr-ext": {"command": "k"}}}')
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "x.kr-1.0.0"}]')
 
     mcp_configs = KiroDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -4117,6 +4162,7 @@ def test_kiro_extension_mcp_discovers_mcp_json(tmp_path):
     ext_dir = tmp_path / ".kiro" / "extensions" / "p.kr-ext-1.0.0"
     ext_dir.mkdir(parents=True)
     (ext_dir / "mcp.json").write_text('{"mcpServers": {"kr-ext-srv": {"command": "k"}}}')
+    (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "p.kr-ext-1.0.0"}]')
 
     mcp_configs = KiroDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -4133,9 +4179,11 @@ def test_kiro_extension_skills_discovers_skills_dir(tmp_path):
     """An extension shipping a ``skills/`` directory under ``~/.kiro/extensions/`` surfaces."""
     from agent_scan.agents import KiroDiscoverer
 
-    ext_skill_dir = tmp_path / ".kiro" / "extensions" / "p.kr-1.0.0" / "skills" / "kr-skill"
+    exts = tmp_path / ".kiro" / "extensions"
+    ext_skill_dir = exts / "p.kr-1.0.0" / "skills" / "kr-skill"
     ext_skill_dir.mkdir(parents=True)
     (ext_skill_dir / "SKILL.md").write_text("---\nname: kr-skill\ndescription: t\n---\n\nbody\n")
+    (exts / "extensions.json").write_text('[{"relativeLocation": "p.kr-1.0.0"}]')
 
     skills_dirs = KiroDiscoverer(tmp_path).discover_skills()
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3390,6 +3390,180 @@ def test_vscode_extension_walk_respects_max_depth_cap(tmp_path, monkeypatch):
     assert not any("/a/b/c/d/mcp.json" in k for k in mcp_configs)
 
 
+# --- Install-manifest gating: don't scan uninstalled extensions ---
+#
+# A directory existing under an extension root does NOT mean the extension is
+# installed. VSCode records the authoritative install set in
+# ``<ext-root>/extensions.json`` and, on uninstall/upgrade, leaves the stale dir
+# on disk while recording it in ``<ext-root>/.obsolete`` until a later cleanup.
+# The extension walks must scan only installed extensions.
+
+
+def test_vscode_extension_mcp_skips_obsolete_extension(tmp_path, monkeypatch):
+    """An extension dir VSCode marked uninstalled in ``.obsolete`` (left on disk
+    after an upgrade) is NOT scanned, while its installed replacement is.
+
+    Mirrors real on-disk state: ``ext-1.0.0`` was upgraded to ``ext-2.0.0``;
+    VSCode rewrote ``extensions.json`` to list only ``ext-2.0.0`` and recorded
+    ``ext-1.0.0`` in ``.obsolete`` pending deletion. Both dirs still exist.
+    """
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".vscode" / "extensions"
+    old = exts / "pub.ext-1.0.0"
+    new = exts / "pub.ext-2.0.0"
+    old.mkdir(parents=True)
+    new.mkdir(parents=True)
+    (old / "mcp.json").write_text('{"mcpServers": {"old-srv": {"command": "o"}}}')
+    (new / "mcp.json").write_text('{"mcpServers": {"new-srv": {"command": "n"}}}')
+    (exts / "extensions.json").write_text('[{"relativeLocation": "pub.ext-2.0.0"}]')
+    (exts / ".obsolete").write_text('{"pub.ext-1.0.0": true}')
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "new-srv" in names
+    assert "old-srv" not in names
+    assert not any("/pub.ext-1.0.0/" in k for k in mcp_configs)
+
+
+def test_vscode_extension_mcp_skips_unmanifested_orphan_dir(tmp_path, monkeypatch):
+    """A dir present under ``extensions/`` but absent from ``extensions.json`` (an
+    orphan/leftover, never a completed install) is not scanned."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".vscode" / "extensions"
+    installed = exts / "pub.installed-1.0.0"
+    orphan = exts / "pub.orphan-9.9.9"
+    installed.mkdir(parents=True)
+    orphan.mkdir(parents=True)
+    (installed / "mcp.json").write_text('{"mcpServers": {"installed-srv": {"command": "i"}}}')
+    (orphan / "mcp.json").write_text('{"mcpServers": {"orphan-srv": {"command": "x"}}}')
+    (exts / "extensions.json").write_text('[{"relativeLocation": "pub.installed-1.0.0"}]')
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "installed-srv" in names
+    assert "orphan-srv" not in names
+
+
+def test_vscode_extension_mcp_empty_manifest_scans_nothing(tmp_path, monkeypatch):
+    """An empty ``extensions.json`` (``[]``) means no installed extensions, so a
+    leftover extension dir on disk is not scanned."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".vscode" / "extensions"
+    leftover = exts / "pub.left-1.0.0"
+    leftover.mkdir(parents=True)
+    (leftover / "mcp.json").write_text('{"mcpServers": {"left-srv": {"command": "l"}}}')
+    (exts / "extensions.json").write_text("[]")
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert not any("/extensions/" in k for k in mcp_configs)
+
+
+def test_vscode_extension_mcp_no_manifest_scans_all(tmp_path, monkeypatch):
+    """With no ``extensions.json`` present the walk falls back to scanning every
+    subdir — the behavior built-in/bundled extension roots rely on (they ship no
+    manifest)."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    ext_dir = tmp_path / ".vscode" / "extensions" / "pub.nomanifest-1.0.0"
+    ext_dir.mkdir(parents=True)
+    (ext_dir / "mcp.json").write_text('{"mcpServers": {"nomani-srv": {"command": "n"}}}')
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "nomani-srv" in names
+
+
+def test_vscode_extension_manifest_location_path_fallback(tmp_path, monkeypatch):
+    """A manifest entry without ``relativeLocation`` is matched by the basename of
+    its ``location.path`` (manifest entry shapes vary across versions/forks)."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".vscode" / "extensions"
+    ext_dir = exts / "pub.viapath-1.0.0"
+    ext_dir.mkdir(parents=True)
+    (ext_dir / "mcp.json").write_text('{"mcpServers": {"viapath-srv": {"command": "p"}}}')
+    (exts / "extensions.json").write_text(f'[{{"location": {{"path": "{ext_dir.as_posix()}", "scheme": "file"}}}}]')
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "viapath-srv" in names
+
+
+def test_vscode_builtin_extension_dir_scanned_without_manifest(tmp_path, monkeypatch):
+    """Built-in (bundled) extension roots ship no ``extensions.json``; the gate
+    must still scan them (they hold e.g. Copilot Chat's MCP/skills)."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    builtin = tmp_path / "app" / "extensions"
+    ext_dir = builtin / "vendor.builtin-1.0.0"
+    ext_dir.mkdir(parents=True)
+    (ext_dir / "mcp.json").write_text('{"mcpServers": {"builtin-srv": {"command": "b"}}}')
+    # No user ``~/.vscode/extensions`` tree; only the bundled root is present.
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [builtin])
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "builtin-srv" in names
+
+
+def test_vscode_extension_skills_skips_obsolete_extension(tmp_path, monkeypatch):
+    """The same install-manifest gate applies to extension ``skills/`` discovery."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".vscode" / "extensions"
+    old_skill = exts / "pub.sk-1.0.0" / "skills" / "old-skill"
+    new_skill = exts / "pub.sk-2.0.0" / "skills" / "new-skill"
+    old_skill.mkdir(parents=True)
+    new_skill.mkdir(parents=True)
+    (old_skill / "SKILL.md").write_text("---\nname: old-skill\ndescription: o\n---\n\nbody.\n")
+    (new_skill / "SKILL.md").write_text("---\nname: new-skill\ndescription: n\n---\n\nbody.\n")
+    (exts / "extensions.json").write_text('[{"relativeLocation": "pub.sk-2.0.0"}]')
+    (exts / ".obsolete").write_text('{"pub.sk-1.0.0": true}')
+
+    skills_dirs = VSCodeDiscoverer(tmp_path).discover_skills()
+
+    assert any("/pub.sk-2.0.0/skills" in k for k in skills_dirs)
+    assert not any("/pub.sk-1.0.0/" in k for k in skills_dirs)
+
+
+def test_cursor_extension_mcp_skips_obsolete_extension(tmp_path, monkeypatch):
+    """The install-manifest gate is inherited by forks — Cursor under
+    ``~/.cursor/extensions`` honors ``extensions.json`` / ``.obsolete`` too."""
+    from agent_scan.agents import CursorDiscoverer
+
+    monkeypatch.setattr(CursorDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".cursor" / "extensions"
+    old = exts / "v.c-1.0.0"
+    new = exts / "v.c-2.0.0"
+    old.mkdir(parents=True)
+    new.mkdir(parents=True)
+    (old / "mcp.json").write_text('{"mcpServers": {"cur-old": {"command": "o"}}}')
+    (new / "mcp.json").write_text('{"mcpServers": {"cur-new": {"command": "n"}}}')
+    (exts / "extensions.json").write_text('[{"relativeLocation": "v.c-2.0.0"}]')
+    (exts / ".obsolete").write_text('{"v.c-1.0.0": true}')
+
+    mcp_configs = CursorDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "cur-new" in names
+    assert "cur-old" not in names
+
+
 def test_kiro_discoverer_walks_kiro_extensions_dir(tmp_path):
     """Kiro is a VSCode fork using the OpenVSX registry, so installed extensions
     live at ``~/.kiro/extensions/`` and can ship ``mcp.json`` like any VSCode-family ext.

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -5593,6 +5593,29 @@ def test_windsurf_builtin_extension_no_linux_path(tmp_path, monkeypatch, linux_p
     assert WindsurfDiscoverer(tmp_path)._builtin_extension_dirs() == []
 
 
+@pytest.mark.parametrize("platform", ["darwin", "linux", "linux2", "win32"])
+def test_antigravity_builtin_extension_no_path_any_platform(tmp_path, monkeypatch, platform):
+    """Antigravity ships NO on-disk built-in extension tree, so built-in
+    discovery is empty on every platform — not a guess, a verified finding.
+
+    Inspected on a real macOS install (v2.0.11): the bundle is a thin Electron
+    shell (``app.asar`` → ``dist/main.js``) driven by a ~127MB Go
+    ``language_server`` binary; it has NO ``Contents/Resources/app/extensions``
+    dir and NO ``extensions/`` packed inside ``app.asar`` (and no ``product.json``
+    / ``extensionsGallery``). It is not a Code-OSS bundle that ships built-in
+    VSIX extensions. The earlier per-OS ``resources/app/extensions`` templates
+    chased a layout this product does not use, so the override is dropped and the
+    family-base empty default applies. Re-add (with a real path) only if a future
+    build is verified to ship an on-disk built-in extensions dir."""
+    import agent_scan.agents.vscode.base as base
+    from agent_scan.agents import AntigravityDiscoverer
+
+    monkeypatch.setattr(base.sys, "platform", platform)
+
+    assert AntigravityDiscoverer._builtin_extension_dir_templates == {}
+    assert AntigravityDiscoverer(tmp_path)._builtin_extension_dirs() == []
+
+
 @pytest.mark.skipif(
     sys.platform not in ("darwin", "linux", "linux2", "win32"),
     reason="built-in paths only defined for macOS/Linux/Windows",

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3374,10 +3374,14 @@ def test_cursor_extension_skills_discovers_skills_dir(tmp_path):
 
 
 def test_windsurf_extension_mcp_discovers_mcp_json(tmp_path):
-    """Windsurf is a VSCode fork; ``~/.codeium/windsurf/extensions/`` follows the same convention."""
+    """Windsurf is a VSCode fork. Its Codeium *engine* state lives under
+    ``~/.codeium/windsurf`` (the MCP/skill paths), but its VSCode-fork *user data*
+    — extensions + ``argv.json`` — lives under ``~/.windsurf`` (VERIFIED on disk:
+    ``~/.windsurf/extensions/extensions.json`` is present; ``~/.codeium/windsurf``
+    has no ``extensions`` subdir). Standard ``extensions.json`` tree → manifest-gated."""
     from agent_scan.agents import WindsurfDiscoverer
 
-    ext_dir = tmp_path / ".codeium" / "windsurf" / "extensions" / "v.ws-1.0.0"
+    ext_dir = tmp_path / ".windsurf" / "extensions" / "v.ws-1.0.0"
     ext_dir.mkdir(parents=True)
     (ext_dir / "mcp.json").write_text('{"mcpServers": {"ws-ext-srv": {"command": "w"}}}')
     (ext_dir.parent / "extensions.json").write_text('[{"relativeLocation": "v.ws-1.0.0"}]')
@@ -4326,6 +4330,47 @@ def test_antigravity_extension_skills_discovers_skills_dir(tmp_path):
 
     matching = [k for k in skills_dirs if k.endswith("/extensions/p.ag-1.0.0/skills")]
     assert len(matching) == 1
+
+
+def test_antigravity_discovers_plugin_skills_under_config_plugins(tmp_path):
+    """Antigravity installs plugins (its extension equivalent) under
+    ``~/.gemini/config/plugins/<name>/`` — each a dir with a ``plugin.json``
+    manifest and an optional ``skills/`` tree, no central ``extensions.json``. The
+    bundled skills must surface. VERIFIED layout on a real macOS install
+    (``chrome-devtools-plugin`` shipping a ``skills/`` tree)."""
+    from agent_scan.agents import AntigravityDiscoverer
+
+    plugin = tmp_path / ".gemini" / "config" / "plugins" / "chrome-devtools-plugin"
+    skill_dir = plugin / "skills" / "chrome-devtools"
+    skill_dir.mkdir(parents=True)
+    (plugin / "plugin.json").write_text('{"name": "chrome-devtools-plugin", "version": "0.21.0"}')
+    (skill_dir / "SKILL.md").write_text("---\nname: chrome-devtools\ndescription: d\n---\n\nbody\n")
+    (tmp_path / ".gemini" / "antigravity").mkdir(parents=True)
+
+    skills_dirs = AntigravityDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/config/plugins/chrome-devtools-plugin/skills")]
+    assert len(matching) == 1
+
+
+def test_antigravity_config_plugins_scanned_wholesale_ignoring_manifest(tmp_path):
+    """The ``~/.gemini/config/plugins`` tree uses no ``extensions.json`` — each
+    plugin subdir is itself the install marker — so it is scanned wholesale: a
+    plugin shipping ``mcp.json`` surfaces, and a stray empty ``extensions.json``
+    must not suppress it."""
+    from agent_scan.agents import AntigravityDiscoverer
+
+    plugins = tmp_path / ".gemini" / "config" / "plugins"
+    plugin = plugins / "some-plugin"
+    plugin.mkdir(parents=True)
+    (plugin / "mcp.json").write_text('{"mcpServers": {"plugin-srv": {"command": "p"}}}')
+    (plugins / "extensions.json").write_text("[]")
+    (tmp_path / ".gemini" / "antigravity").mkdir(parents=True)
+
+    mcp_configs = AntigravityDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = {n for v in mcp_configs.values() if isinstance(v, list) for n, _ in v}
+    assert "plugin-srv" in names
 
 
 # --- Per-fork extension-root conventions (subclass overrides of the


### PR DESCRIPTION
## What

Stop the VSCode-family discoverers (VSCode, Cursor, Windsurf, Kiro, Antigravity) from scanning extensions that aren't actually installed, **and** correct two fork extension roots that pointed at directories which don't exist on real installs.

## Why

### 1. Uninstalled extensions were being scanned

The extension walks in `VSCodeFamilyDiscoverer` recursively globbed **every** subdirectory of each extension root for `mcp.json` / `skills/`. But a directory existing on disk does **not** mean the extension is installed: `<ext-root>/extensions.json` is VSCode's authoritative install manifest, and on uninstall/upgrade the stale dir is left on disk until a later cleanup. So uninstalled extensions were being scanned.

This **corrects the claim in 53dad15** that *"the VSCode-family discoverers … only ever have installed extensions on disk."* They don't (verified: upgraded-away versions sit on disk next to their installed replacements).

### 2. Two fork extension roots were wrong (verified on a real macOS install)

- **Windsurf** scanned `~/.codeium/windsurf/extensions`, which **does not exist** — that tree holds only Codeium *engine* state. Windsurf's VSCode-fork user data (extensions + `argv.json`, incl. the `extensions.json` manifest) lives under **`~/.windsurf/extensions`**. Every Windsurf extension was being missed.
- **Antigravity** scanned `~/.gemini/extensions` (the Gemini *CLI's* tree, absent for the IDE). Antigravity installs **plugins** under **`~/.gemini/config/plugins/<name>/`** (`plugin.json` + optional `skills/`). Its plugin MCP is registered centrally in `~/.gemini/config/mcp_config.json` (already covered), so the real-world gap was **plugin-bundled skills being silently dropped**.

## How

### Install-manifest gating (`src/agent_scan/agents/vscode/base.py`)

`_installed_extension_dirs(base)` resolves each extension root to the concrete list of dirs to walk (always a `list[Path]`):

- **Manifest-managed roots** (`~/.vscode/extensions`, `~/.cursor/...`, `~/.windsurf/extensions`, `~/.kiro/extensions`, portable dir) are gated by `<base>/extensions.json`. Each entry's `relativeLocation` (fallback: basename of `location.path`) is resolved against the root and **confined to it** (`_confine_to_base`, lexical normpath) so an attacker-influenceable manifest under `--scan-all-users` can't redirect the walk via `..`/absolute paths. A managed root **fails closed**: missing / unreadable / corrupt / empty `[]` manifest → scans nothing (an extension is installed iff the manifest lists it, and the editor loads nothing from an unlisted dir). No `.obsolete` denylist is needed — an obsolete dir is simply never in the manifest.
- **Unmanaged roots** ship no `extensions.json` *by design* — built-in/bundled roots, plus fork-declared trees (Kiro Powers `~/.kiro/powers/installed`, Antigravity `~/.gemini/config/plugins` + `~/.gemini/extensions`). Every present subdir is an installed extension, so all are scanned (`_immediate_subdirs`). Forks override `_installed_extension_dirs` to route their declared unmanaged roots here and defer the rest to `super()`.

`_extension_scan_roots()` feeds both `_discover_extension_mcp_servers` and `_discover_extension_skills`.

### Fork root corrections

- `WindsurfDiscoverer._extension_paths` → `~/.windsurf/extensions` (manifest-gated).
- `AntigravityDiscoverer._extension_paths` / `_unmanaged_extension_paths` → `("~/.gemini/config/plugins", "~/.gemini/extensions")` (wholesale; the Gemini-CLI path kept as a shared-`~/.gemini` no-op catch). Built-in extensions are packed in the app's Electron `app.asar` (no `Contents/Resources/app/extensions` dir) — a documented macOS coverage gap.

### Out of scope

Disabled-but-installed extensions are still scanned (a disabled extension *is* installed; enablement lives in `state.vscdb` SQLite, not a documented JSON path).
