### PR TITLE
fix: remote urls

### DIFF
--- a/src/agent_scan/mcp_client.py
+++ b/src/agent_scan/mcp_client.py
@@ -257,7 +257,10 @@ async def check_server(
     else:
         logger.debug(f"Remote server with url: {server_config.url}, type: {server_config.type or 'none'}")
         strategy: list[tuple[Literal["sse", "http"], str]] = []
-        base_url = server_config.url.rstrip("/")
+        original_url = server_config.url.rstrip("/")
+        original_type = server_config.type
+
+        base_url = original_url
         url_path = urlparse(base_url).path
         if url_path.endswith("/sse"):
             base_url = base_url[: -len("/sse")]
@@ -310,6 +313,12 @@ async def check_server(
                 logger.debug("Server check failed")
                 exceptions.append(e)
                 continue
+
+        # No strategy worked. Reset server_config to the URL the user originally
+        # configured (trailing slash stripped) and the original transport, so
+        # callers don't see it stuck on the last-tried mutated URL.
+        server_config.url = original_url
+        server_config.type = original_type
 
         # if python 3.11 or higher, use ExceptionGroup
         if sys.version_info >= (3, 11):

--- a/src/agent_scan/mcp_client.py
+++ b/src/agent_scan/mcp_client.py
@@ -257,19 +257,15 @@ async def check_server(
     else:
         logger.debug(f"Remote server with url: {server_config.url}, type: {server_config.type or 'none'}")
         strategy: list[tuple[Literal["sse", "http"], str]] = []
-        url_path = urlparse(server_config.url).path
+        base_url = server_config.url.rstrip("/")
+        url_path = urlparse(base_url).path
         if url_path.endswith("/sse"):
-            url_with_sse = server_config.url
-            url_without_end = server_config.url.replace("/sse", "")
-            url_with_mcp = server_config.url.replace("/sse", "/mcp")
+            base_url = base_url[: -len("/sse")]
         elif url_path.endswith("/mcp"):
-            url_with_mcp = server_config.url
-            url_without_end = server_config.url.replace("/mcp", "")
-            url_with_sse = server_config.url.replace("/mcp", "/sse")
-        else:
-            url_without_end = server_config.url
-            url_with_mcp = server_config.url + "/mcp"
-            url_with_sse = server_config.url + "/sse"
+            base_url = base_url[: -len("/mcp")]
+        url_without_end = base_url
+        url_with_mcp = base_url + "/mcp"
+        url_with_sse = base_url + "/sse"
 
         if server_config.type == "http" or server_config.type is None:
             strategy.append(("http", url_with_mcp))

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -145,6 +145,12 @@ async def test_remote_url_candidates_have_no_double_slash_and_include_clean(inpu
             break
     assert expected_clean in tried, f"clean URL {expected_clean!r} not tried; tried={tried}"
 
+    # After all strategies fail, server_config must be reset to the URL the
+    # user originally configured (trailing slash stripped) and the original
+    # type — not left on whatever the last attempt mutated it to.
+    assert server.url == input_url.rstrip("/"), f"server.url not reset to original: {server.url!r}"
+    assert server.type is None
+
 
 @pytest.mark.asyncio
 async def test_math_server():

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -18,7 +18,7 @@ from mcp.types import (
 from pytest_lazy_fixtures import lf
 
 from agent_scan.mcp_client import _check_server_pass, check_server, scan_mcp_config_file
-from agent_scan.models import StdioServer
+from agent_scan.models import RemoteServer, StdioServer
 from agent_scan.utils import resolve_command_and_args
 
 
@@ -99,6 +99,51 @@ async def test_check_server_mocked(mock_stdio_client):
     assert len(signature.prompts) == 2
     assert len(signature.resources) == 1
     assert len(signature.tools) == 3
+
+
+@pytest.mark.parametrize(
+    "input_url",
+    [
+        "https://example.com",
+        "https://example.com/",
+        "https://example.com/mcp",
+        "https://example.com/mcp/",
+        "https://example.com/sse",
+        "https://example.com/sse/",
+        "https://example.com/api/",
+        "https://example.com/api/mcp/",
+    ],
+)
+@pytest.mark.asyncio
+async def test_remote_url_candidates_have_no_double_slash_and_include_clean(input_url):
+    """Regression: trailing slashes or pre-existing /mcp,/sse suffixes used to
+    produce candidate URLs like //mcp or /mcp/mcp, and never fell back to a
+    clean URL stripped of the suffix."""
+    tried: list[str] = []
+
+    async def fake_check(server_config, *args, **kwargs):
+        tried.append(server_config.url)
+        raise RuntimeError("boom")
+
+    server = RemoteServer(url=input_url)
+    with patch("agent_scan.mcp_client._check_server_pass", side_effect=fake_check):
+        with pytest.raises(Exception, match="(?i)could not connect|boom"):
+            await check_server(server, 1, False)
+
+    assert tried, "expected the strategy to try at least one URL"
+    for url in tried:
+        scheme, _, rest = url.partition("://")
+        assert "//" not in rest, f"double slash leaked into candidate URL: {url}"
+        assert "/mcp/mcp" not in url, f"duplicated /mcp suffix in candidate URL: {url}"
+        assert "/sse/sse" not in url, f"duplicated /sse suffix in candidate URL: {url}"
+
+    # Clean fallback (no /mcp or /sse suffix) must be among the candidates.
+    expected_clean = input_url.rstrip("/")
+    for suffix in ("/mcp", "/sse"):
+        if expected_clean.endswith(suffix):
+            expected_clean = expected_clean[: -len(suffix)]
+            break
+    assert expected_clean in tried, f"clean URL {expected_clean!r} not tried; tried={tried}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix remote MCP/SSE URL normalization in MCP client
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Normalize remote base URLs to avoid double slashes and duplicated /mcp or /sse suffixes.
• Ensure URL probing strategy always includes a clean “base” fallback URL.
• Add regression tests covering trailing slashes and pre-suffixed remote URLs.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["check_server()"] --> B["Normalize base_url"] --> C["Build candidates: /mcp, /sse"] --> D["_check_server_pass()"]
  E["RemoteServer.url"] --> A
  T["test_mcp_client.py"] --> A
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Use a URL builder library (e.g., yarl.URL) for path joining</b></summary>

- ➕ Safer path manipulation (join/with_path) without manual string slicing
- ➕ Less error-prone across edge cases (query strings, fragments, repeated slashes)
- ➖ Adds/extends a dependency (or introduces it) for relatively small logic
- ➖ Requires refactoring surrounding code to use URL objects consistently

</details>

<details>
<summary><b>2. Centralize candidate generation into a dedicated helper (unit-tested)</b></summary>

- ➕ Improves readability of check_server() by isolating URL normalization
- ➕ Makes the strategy easier to test without patching internal calls
- ➖ Slight additional indirection and file churn for a small fix

</details>

**Recommendation:** The PR’s approach (normalize to a base URL, then append /mcp and /sse) is a good, minimal fix and the regression test meaningfully locks behavior. If URL handling grows (queries/fragments, more endpoints), consider adopting a URL builder (or at least extracting a helper) to avoid future string-slicing edge cases.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>mcp_client.py</strong> <code>Normalize remote base URL before generating /mcp and /sse candidates</code> <code>+7/-11</code></summary>

<br/>

>Normalize remote base URL before generating /mcp and /sse candidates
>
><pre>
>• Reworks candidate URL generation to first strip trailing slashes and remove an existing /mcp or /sse suffix. Ensures the probed URLs are consistently derived from a clean base, avoiding // and duplicated path segments.
></pre>
>
><a href='https://github.com/snyk/agent-scan/pull/357/files#diff-ee66bb74b876c1ace8d589122d08576c09a6f76a45f58f476e88fdead667afc0'>src/agent_scan/mcp_client.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_mcp_client.py</strong> <code>Add regression test for remote URL candidate cleanliness and fallback</code> <code>+46/-1</code></summary>

<br/>

>Add regression test for remote URL candidate cleanliness and fallback
>
><pre>
>• Adds a parametrized async test covering URLs with trailing slashes and pre-existing /mcp or /sse suffixes. The test asserts that candidate URLs never contain double slashes or duplicated suffixes and that a clean base URL is always tried.
></pre>
>
><a href='https://github.com/snyk/agent-scan/pull/357/files#diff-269924abef4a506fec848293b4d350e84064f491bcc757012787a9316f15fc0d'>tests/unit/test_mcp_client.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>