### PR TITLE
feat(inspect): attach config-file path to each MCP server in upload payload

### DIFF
--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -394,7 +394,7 @@ def inspected_client_to_scan_path_result(inspected_client: InspectedClient) -> S
     """
     servers: list[ServerScanResult] = []
     candidate_errors: list[ScanError] = []
-    for _, extensions_or_error in inspected_client.extensions.items():
+    for config_path, extensions_or_error in inspected_client.extensions.items():
         if isinstance(
             extensions_or_error, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig | SkillScannError
         ):
@@ -412,19 +412,30 @@ def inspected_client_to_scan_path_result(inspected_client: InspectedClient) -> S
             if isinstance(extension.signature_or_error, ServerSignature):
                 servers.append(
                     ServerScanResult(
-                        name=extension.name, server=extension.config, signature=extension.signature_or_error, error=None
+                        name=extension.name,
+                        config_path=config_path,
+                        server=extension.config,
+                        signature=extension.signature_or_error,
+                        error=None,
                     )
                 )
             elif extension.signature_or_error is None:
                 # Recorded but not inspected (e.g. stdio MCP server on the
                 # push-key path).
                 servers.append(
-                    ServerScanResult(name=extension.name, server=extension.config, signature=None, error=None)
+                    ServerScanResult(
+                        name=extension.name,
+                        config_path=config_path,
+                        server=extension.config,
+                        signature=None,
+                        error=None,
+                    )
                 )
             else:
                 servers.append(
                     ServerScanResult(
                         name=extension.name,
+                        config_path=config_path,
                         server=extension.config,
                         signature=None,
                         error=ScanError(

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -388,6 +388,12 @@ class ServerSignature(BaseModel):
 class ServerScanResult(BaseModel):
     model_config = ConfigDict()
     name: str | None = None
+    # Absolute path of the config file this server was discovered in (e.g. a
+    # project ``.mcp.json`` or ``~/.claude.json``). A single client can flatten
+    # servers from several config files into one ScanPathResult, so the
+    # provenance is tracked per server rather than at the ScanPathResult level.
+    # Sent absolute to both backends, matching SkillServer.path.
+    config_path: str | None = None
     server: StdioServer | RemoteServer | SkillServer
     signature: ServerSignature | None = None
     error: ScanError | None = None
@@ -410,6 +416,7 @@ class ServerScanResult(BaseModel):
         """
         output = ServerScanResult(
             name=self.name,
+            config_path=self.config_path,
             server=self.server.model_copy(deep=True),
             signature=self.signature.model_copy(deep=True) if self.signature else None,
             error=self.error.clone() if self.error else None,

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -808,3 +808,119 @@ async def test_inspect_client_explicit_do_stdio_handshake_runs_stdio_servers():
         await inspect_client(client, timeout=10, tokens=[], scan_skills=False, do_stdio_handshake=True)
 
     mock_inspect_extension.assert_awaited_once()
+
+
+# --- config_path propagation tests ---
+
+
+def _signature() -> "object":
+    from mcp.types import Implementation, InitializeResult
+
+    from agent_scan.models import ServerSignature
+
+    return ServerSignature(
+        metadata=InitializeResult(
+            protocolVersion="2024-11-05",
+            capabilities={},
+            serverInfo=Implementation(name="x", version="1"),
+        ),
+    )
+
+
+def test_inspected_client_to_scan_path_result_sets_config_path_per_server():
+    """Every ServerScanResult must carry the config-file path it was
+    discovered in. The config path is the key of ``InspectedClient.extensions``;
+    the converter must propagate it onto each server across all three branches
+    (inspected signature, recorded-but-not-inspected ``None``, and error)."""
+    from agent_scan.models import InspectedClient, InspectedExtensions, ServerStartupError
+
+    cfg_path = "/home/u/.config/agent/.mcp.json"
+    ok = InspectedExtensions(name="ok", config=StdioServer(command="echo"), signature_or_error=_signature())
+    not_inspected = InspectedExtensions(name="skip", config=StdioServer(command="echo"), signature_or_error=None)
+    errored = InspectedExtensions(
+        name="boom",
+        config=RemoteServer(url="https://example.com/mcp", type="http"),
+        signature_or_error=ServerStartupError(message="boom"),
+    )
+
+    client = InspectedClient(
+        name="test",
+        client_path="/install/path",
+        extensions={cfg_path: [ok, not_inspected, errored]},
+    )
+
+    result = inspected_client_to_scan_path_result(client)
+
+    by_name = {s.name: s for s in result.servers or []}
+    assert by_name["ok"].config_path == cfg_path
+    assert by_name["skip"].config_path == cfg_path
+    assert by_name["boom"].config_path == cfg_path
+    # The top-level ScanPathResult.path stays the client install path, not the config file.
+    assert result.path == "/install/path"
+
+
+def test_inspected_client_to_scan_path_result_config_path_multiple_files():
+    """A single client flattens multiple config files into one ScanPathResult;
+    each server must retain the config path of the file it came from."""
+    from agent_scan.models import InspectedClient, InspectedExtensions
+
+    cfg_a = "/home/u/.cursor/mcp.json"
+    cfg_b = "/home/u/project/.mcp.json"
+    ext_a = InspectedExtensions(name="srv-a", config=StdioServer(command="a"), signature_or_error=_signature())
+    ext_b = InspectedExtensions(name="srv-b", config=StdioServer(command="b"), signature_or_error=_signature())
+
+    client = InspectedClient(
+        name="test",
+        client_path="/install/path",
+        extensions={cfg_a: [ext_a], cfg_b: [ext_b]},
+    )
+
+    result = inspected_client_to_scan_path_result(client)
+
+    by_name = {s.name: s for s in result.servers or []}
+    assert by_name["srv-a"].config_path == cfg_a
+    assert by_name["srv-b"].config_path == cfg_b
+
+
+def test_server_scan_result_clone_preserves_config_path():
+    """clone() must propagate config_path so the analysis-payload copy
+    (built via ScanPathResult.clone()/ServerScanResult.clone()) carries it too."""
+    from agent_scan.models import ServerScanResult
+
+    original = ServerScanResult(
+        name="srv",
+        config_path="/home/u/.mcp.json",
+        server=StdioServer(command="echo"),
+    )
+    cloned = original.clone()
+    assert cloned.config_path == "/home/u/.mcp.json"
+
+
+def test_config_path_survives_serialization_round_trip():
+    """config_path must serialize into the upload payload and round-trip back."""
+    from agent_scan.models import (
+        ScanPathResult,
+        ScanPathResultsCreate,
+        ScanUserInfo,
+        ServerScanResult,
+    )
+
+    payload = ScanPathResultsCreate(
+        scan_path_results=[
+            ScanPathResult(
+                client="test",
+                path="/install/path",
+                servers=[
+                    ServerScanResult(
+                        name="srv",
+                        config_path="/home/u/.mcp.json",
+                        server=StdioServer(command="echo"),
+                    )
+                ],
+            )
+        ],
+        scan_user_info=ScanUserInfo(),
+    )
+
+    restored = ScanPathResultsCreate.model_validate_json(payload.model_dump_json())
+    assert restored.scan_path_results[0].servers[0].config_path == "/home/u/.mcp.json"


### PR DESCRIPTION
## What

Attach the **config-file path** of each discovered MCP server to the data sent to both backends (`invariant-platform` via the control server, and `invariant-mcp-scan-backend` via the analysis server).

A new optional field `config_path` is added to `ServerScanResult` and populated in `inspected_client_to_scan_path_result` from the `InspectedClient.extensions` dict key — the MCP config file (`~/.claude.json`, a project `.mcp.json`, a plugin `.mcp.json`, …) each server was discovered in.

## Why

The config-file path *was* available during inspection but got **dropped** during flattening — `inspected_client_to_scan_path_result` iterated `for _, extensions_or_error in inspected_client.extensions.items()`, discarding the key. The backends therefore couldn't attribute a server to its source config file (useful for attribution, dedup, and remediation guidance).

A single client flattens servers from **multiple** config files into **one** `ScanPathResult` (whose `path` is the *client install path*, not a config file), so provenance is tracked **per server** rather than at the path level.

## Design notes

- **Absolute path to both backends**, no anonymization — matching how the structurally analogous `SkillServer.path` is already handled (sent absolute to both, not run through `get_relative_path()`/`redact_server()`). As a result `verify_api.py` and `redact.py` need no changes; the field flows automatically via `model_dump_json()`.
- `ServerScanResult.clone()` propagates `config_path` so the analysis-payload copy (built via `clone()`) carries it too.
- Both legacy (`get_mcp_config_per_client`) and modern (`AgentDiscoverer`) discovery flows funnel through the single converter, so one change covers both.

## ⚠️ Backend coordination required

`ServerScanResult` is hand-duplicated in `invariant-platform` (`backend/models/base.py`) and `invariant-mcp-scan-backend`. The field is **optional**, so those backends safely ignore it (Pydantic `extra="ignore"`) until they add a matching `config_path: str | None = None` in coordinated PRs to actually consume it. **This PR only changes the agent-scan sending side.**

## Tests

- `inspected_client_to_scan_path_result` populates `config_path` per server across all three branches (signature / not-inspected `None` / error).
- Multiple config files in one client → each server keeps its own `config_path`.
- `ServerScanResult.clone()` preserves `config_path`.
- `config_path` survives `ScanPathResultsCreate` JSON round-trip.

`tests/unit/test_inspect.py` + `tests/unit/test_redact.py` + `tests/v4compatibility/test_inspect.py`: 97 passed. The 8 pre-existing env-only `test_verify_api.py` failures are present on `main` too (proxy/network), unrelated to this change.