### PR TITLE
Docs/agent detection table

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Legend: **✓** detected · **✗** the agent supports this but Agent Scan does 
 | Claude Desktop | ✗ | N/A | ✗ | ✓ | N/A | N/A | N/A | ✗ |
 | Claude Code | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Gemini CLI | N/A | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
-| OpenClaw | N/A | N/A | ✓ | ✗ | ✓ | N/A | ✗ | N/A |
+| OpenClaw | N/A | N/A | ✓ | ✗ | ✓ † | N/A | ✗ | N/A |
 | Amp | N/A | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ |
 | Kiro | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | OpenCode | N/A | ✗ | ✗ | ✗ | ✗ | ✗ | N/A | N/A |
@@ -100,13 +100,7 @@ Legend: **✓** detected · **✗** the agent supports this but Agent Scan does 
 | Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Amazon Q | N/A | N/A | N/A | ✓ | N/A | ✗ | N/A | N/A |
 
-Notes:
-
-- **Claude Code** discovers slash commands at the user, project, and plugin scopes (scanned alongside skills). Its enterprise/managed skills tier has no documented directory, so system skills are not scanned (✗), while system servers (`managed-mcp.json`) are.
-- **Claude Desktop** supports skills (personal and org-wide) stored in the cloud and `.mcpb` Desktop Extensions installed on disk at an undocumented path; both are supported but not scanned yet (✗). Only its user-level `claude_desktop_config.json` MCP servers are scanned. It has no project/workspace scope, and skills are not extension-distributed (N/A).
-- **Codex** stores MCP servers in TOML (`config.toml`); the other agents use JSON.
-- **Gemini CLI, Amp, OpenCode, OpenClaw, and Amazon Q** expose servers and/or skills at scopes Agent Scan does not read yet (shown as ✗) — for example project-level and extension-bundled configuration.
-- Several agents gate MCP at the admin level with a server-side allowlist or registry rather than a local config file; those have no scannable system-server file (N/A).
+† OpenClaw has no opened-project enumeration: its project/workspace skills are found only at the fixed `~/.openclaw/workspace/skills`
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -89,18 +89,20 @@ Legend: **✓** detected · **✗** the agent supports this but Agent Scan does 
 | Windsurf | ✓ | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Cursor | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | VS Code | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Claude Desktop | ✗ | N/A | ✗ | ✓ | N/A | N/A | N/A | ✗ |
+| Claude Desktop | N/A | N/A | ✗ | ✓ | N/A | N/A | N/A | ✗ |
 | Claude Code | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Gemini CLI | N/A | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
-| OpenClaw | N/A | N/A | ✓ | ✗ | ✓ † | N/A | ✗ | N/A |
-| Amp | N/A | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ |
+| OpenClaw | N/A | N/A | ✓ | ✗ | ✓ † | N/A | ✗ | ✗ |
+| Amp | N/A | ✗ | ✓ | ✗ | ✗ ‡ | ✗ | ✗ | ✗ |
 | Kiro | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | OpenCode | N/A | ✗ | ✗ | ✗ | ✗ | ✗ | N/A | N/A |
-| Antigravity | N/A | N/A | ✓ | ✓ | ✓ | N/A | ✓ | ✓ |
+| Antigravity | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Amazon Q | N/A | N/A | N/A | ✓ | N/A | ✗ | N/A | N/A |
 
 † OpenClaw has no opened-project enumeration: its project/workspace skills are found only at the fixed `~/.openclaw/workspace/skills`
+
+‡ Amp stores project/workspace skills at `.agents/skills` (and the `.claude/skills` compatibility path); only the user-scope `~/.config/agents/skills` is detected today, so project-scope skills are supported but not yet scanned.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Agent Scan helps you keep an inventory of all your installed agent components (h
 
 ## Supported agents and capabilities
 
-Agent Scan auto-discovers agents and their capabilities (MCP servers or skills) when their install paths exist. The table reflects [well-known agent definitions](src/agent_scan/well_known_clients.py).
+Agent Scan auto-discovers agents and their capabilities (MCP servers or skills) when their install paths exist. The table below shows on which operating systems each agent is scanned.
 
 - **✓**: at least one path is defined for that capability.
 - **✗**: the agent is listed for that OS but has no paths for that capability.
@@ -65,11 +65,48 @@ Agent Scan auto-discovers agents and their capabilities (MCP servers or skills) 
 | Gemini CLI | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | OpenClaw | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
 | Amp | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
-| Kiro | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ |
+| Kiro | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | OpenCode | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Antigravity | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ |
-| Codex | ✗ | ✓ | ✗ | ✓ | — | — |
+| Antigravity | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Codex | ✓ | ✓ | ✓ | ✓ | — | — |
 | Amazon Q | ✓ | ✗ | ✓ | ✗ | ✓ (WSL) | ✗ |
+
+### Detection coverage by scope
+
+The matrix above shows on which operating systems each agent is scanned. This one breaks detection down by **configuration scope** and **component type** (skills vs MCP servers), combined across operating systems. "Servers" means MCP servers.
+
+The four scopes:
+
+- **System** — machine-wide / admin-managed / enterprise config that applies to all users (e.g. `managed-mcp.json`, files under `/etc`, `/Library/Application Support`, or `ProgramData`).
+- **User** — the user's home-directory config (applies across all their projects).
+- **Project / workspace** — config scoped to an opened project or workspace.
+- **Extension / plugin** — components bundled inside installed extensions or plugins.
+
+Legend: **✓** detected · **✗** the agent supports this but Agent Scan does not scan it yet · **N/A** the agent has no such component at this scope.
+
+| Agent | System<br>skills | System<br>servers | User<br>skills | User<br>servers | Project / WS<br>skills | Project / WS<br>servers | Ext / plugin<br>skills | Ext / plugin<br>servers |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| Windsurf | ✓ | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Cursor | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| VS Code | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Claude Desktop | ✗ | N/A | ✗ | ✓ | N/A | N/A | N/A | ✗ |
+| Claude Code | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Gemini CLI | N/A | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| OpenClaw | N/A | N/A | ✓ | ✗ | ✓ | N/A | ✗ | N/A |
+| Amp | N/A | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ |
+| Kiro | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| OpenCode | N/A | ✗ | ✗ | ✗ | ✗ | ✗ | N/A | N/A |
+| Antigravity | N/A | N/A | ✓ | ✓ | ✓ | N/A | ✓ | ✓ |
+| Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Amazon Q | N/A | N/A | N/A | ✓ | N/A | ✗ | N/A | N/A |
+
+Notes:
+
+- **Claude Code** discovers slash commands at the user, project, and plugin scopes (scanned alongside skills). Its enterprise/managed skills tier has no documented directory, so system skills are not scanned (✗), while system servers (`managed-mcp.json`) are.
+- **Claude Desktop** supports skills (personal and org-wide) stored in the cloud and `.mcpb` Desktop Extensions installed on disk at an undocumented path; both are supported but not scanned yet (✗). Only its user-level `claude_desktop_config.json` MCP servers are scanned. It has no project/workspace scope, and skills are not extension-distributed (N/A).
+- **Codex** stores MCP servers in TOML (`config.toml`); the other agents use JSON.
+- **Gemini CLI, Amp, OpenCode, OpenClaw, and Amazon Q** expose servers and/or skills at scopes Agent Scan does not read yet (shown as ✗) — for example project-level and extension-bundled configuration.
+- Several agents gate MCP at the admin level with a server-side allowlist or registry rather than a local config file; those have no scannable system-server file (N/A).
 
 ## Quick Start
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add per-agent detection coverage table to README
<code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Add a scope-by-component detection coverage matrix (skills vs MCP servers) per agent.
• Correct OS capability table cells for Kiro, Antigravity, and Codex.
• Clarify table wording and add footnotes for known scan/support gaps.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Agent Scan scanner"] --> B["Agent discoverers"] --> C["README tables"]
  B --> F["Agent official docs"]
  C --> D["OS capability matrix"]
  C --> E["Scope x component matrix"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Auto-generate README tables from discoverer definitions</b></summary>

- ➕ Eliminates drift between docs and actual scanned paths
- ➕ Makes updates to discoverers automatically reflected in docs
- ➖ More build/CI complexity (generation step + formatting stability)
- ➖ Harder to include nuanced footnotes tied to non-scannable supported features

</details>

<details>
<summary><b>2. Split into two sections: &#x27;Supported by agent&#x27; vs &#x27;Scanned by Agent Scan&#x27;</b></summary>

- ➕ Reduces ambiguity between &#x27;supported&#x27; and &#x27;detected&#x27;
- ➕ Makes ✗ cells easier to interpret without footnotes
- ➖ Adds more documentation surface area and maintenance burden
- ➖ May duplicate information already implied by the matrix legend

</details>

<details>
<summary><b>3. Add a CI lint/check that validates selected cells against code</b></summary>

- ➕ Keeps human-authored narrative but catches obvious table drift
- ➕ Can focus on a subset of agents/scopes most likely to change
- ➖ Requires defining a machine-readable mapping for the table
- ➖ Still won’t validate claims that come from external agent documentation

</details>

**Recommendation:** The PR’s approach (explicit documentation plus footnotes for gray areas) is reasonable for a docs-only change and immediately improves user clarity. If table drift becomes a recurring issue, consider auto-generating the ‘scanned’ portions from discoverer definitions and layering human-written footnotes on top.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>README.md</strong> <code>Add scope-by-component detection matrix and correct OS capability cells</code> <code>+37/-4</code></summary>

<br/>

>Add scope-by-component detection matrix and correct OS capability cells
>
><pre>
>• Updates the supported-agents section to clarify that the first table is OS-level scanning coverage. Corrects several agent capability cells (Kiro, Antigravity, Codex) and introduces a new detection-coverage matrix broken down by scope (system/user/project/ext) and component type (skills vs MCP servers), including explanatory footnotes for exceptions.
></pre>
>
><a href='https://github.com/snyk/agent-scan/pull/360/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5'>README.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>