### PR TITLE
refactor: strip tool-version probing and discarded home-dir enumeration from bootstrap

### DIFF
--- a/src/agent_scan/bootstrap.py
+++ b/src/agent_scan/bootstrap.py
@@ -27,7 +27,6 @@ from agent_scan.utils import (
     get_environment,
     get_hostname,
     get_readable_home_directories,
-    get_tool_versions,
     get_username,
 )
 from agent_scan.verify_api import setup_tcp_connector
@@ -165,19 +164,15 @@ async def _build_request(
     # Security review allowlist: this payload sends client metadata, host OS
     # details, hostname/current username, CI/WSL/container booleans, shell/term,
     # locale/timezone, cwd/home/executable paths, readable home directories capped
-    # at 1000 entries, redacted argv tokens, and a runtimes dict containing
-    # best-effort versions of python/node/npx/uvx/docker (each value is the
-    # verbatim first line of `<tool> --version`, or None when probing fails).
+    # at 1000 entries, and redacted argv tokens.
     # It intentionally excludes scanned_usernames and schema_version.
     # Home enumeration mirrors the scan's --scan-all-users opt-in: a single-user
     # scan only reports the current user's home, matching what discovery touches.
-    # Run the two slow signals (home enumeration + external tool probes)
-    # concurrently. Both are subprocess/IO bound and independent, so total
-    # wall time is bounded by whichever is slower rather than their sum.
-    home_dirs_raw, runtimes = await asyncio.gather(
-        asyncio.to_thread(get_readable_home_directories, all_users=scan_all_users),
-        get_tool_versions(),
-    )
+    # Home enumeration is subprocess/IO bound, so offload it to a thread to
+    # keep the event loop responsive. The result is not part of the payload
+    # (see "paths" exclusion below); the call is retained for its access-probe
+    # logging side effects.
+    await asyncio.to_thread(get_readable_home_directories, all_users=scan_all_users)
 
     return ClientBootstrapRequest(
         client=ClientInfo(
@@ -203,7 +198,6 @@ async def _build_request(
             term=os.environ.get("TERM"),
             locale=_get_locale(),
             timezone=_get_timezone(),
-            runtimes=runtimes,
         ),
     )
 

--- a/src/agent_scan/bootstrap.py
+++ b/src/agent_scan/bootstrap.py
@@ -26,7 +26,6 @@ from agent_scan.runtime_config import RuntimeConfig
 from agent_scan.utils import (
     get_environment,
     get_hostname,
-    get_readable_home_directories,
     get_username,
 )
 from agent_scan.verify_api import setup_tcp_connector
@@ -35,7 +34,6 @@ from agent_scan.version import version_info
 logger = logging.getLogger(__name__)
 
 _RETRY_STATUSES = {408, 429}
-_HOME_DIRECTORIES_LIMIT = 1000
 
 # Canonical control-server URL contract. The push endpoint is the surface
 # users configure via --control-server; the bootstrap endpoint is its
@@ -159,21 +157,12 @@ async def _build_request(
     subcommand: str | None,
     control_identifier: str | None,
     argv: list[str],
-    scan_all_users: bool = False,
 ) -> ClientBootstrapRequest:
-    # Security review allowlist: this payload sends client metadata, host OS
-    # details, hostname/current username, CI/WSL/container booleans, shell/term,
-    # locale/timezone, cwd/home/executable paths, readable home directories capped
-    # at 1000 entries, and redacted argv tokens.
-    # It intentionally excludes scanned_usernames and schema_version.
-    # Home enumeration mirrors the scan's --scan-all-users opt-in: a single-user
-    # scan only reports the current user's home, matching what discovery touches.
-    # Home enumeration is subprocess/IO bound, so offload it to a thread to
-    # keep the event loop responsive. The result is not part of the payload
-    # (see "paths" exclusion below); the call is retained for its access-probe
-    # logging side effects.
-    await asyncio.to_thread(get_readable_home_directories, all_users=scan_all_users)
-
+    # Security review allowlist: this payload sends client metadata (name,
+    # version, command/subcommand, control identifier, redacted argv tokens)
+    # and host info (OS details, hostname/current username, CI/WSL/container
+    # booleans, shell/term, locale/timezone). It intentionally excludes
+    # scanned_usernames, schema_version, and filesystem paths.
     return ClientBootstrapRequest(
         client=ClientInfo(
             name="agent-scan",
@@ -214,7 +203,6 @@ async def bootstrap_first_control_server(
     control_identifier: str | None,
     argv: list[str],
     no_bootstrap: bool,
-    scan_all_users: bool = False,
     skip_ssl_verify: bool = False,
     timeout_seconds: float = 3.0,
     max_attempts: int = 3,
@@ -237,7 +225,6 @@ async def bootstrap_first_control_server(
             control_identifier=control_identifier,
             argv=argv,
             no_bootstrap=no_bootstrap,
-            scan_all_users=scan_all_users,
             skip_ssl_verify=skip_ssl_verify,
             timeout_seconds=timeout_seconds,
             max_attempts=max_attempts,
@@ -255,7 +242,6 @@ async def _bootstrap_first_control_server_impl(
     control_identifier: str | None,
     argv: list[str],
     no_bootstrap: bool,
-    scan_all_users: bool,
     skip_ssl_verify: bool,
     timeout_seconds: float,
     max_attempts: int,
@@ -272,7 +258,7 @@ async def _bootstrap_first_control_server_impl(
         )
 
     try:
-        payload = await _build_request(command, subcommand, control_identifier, argv, scan_all_users)
+        payload = await _build_request(command, subcommand, control_identifier, argv)
     except Exception as exc:
         logger.warning("Client bootstrap failed; using defaults: %s", exc)
         return RuntimeConfig()

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -704,7 +704,6 @@ async def bootstrap_runtime_config(
             control_identifier=control_servers[0].identifier if control_servers else None,
             argv=sys.argv[1:],
             no_bootstrap=getattr(args, "no_bootstrap", False),
-            scan_all_users=getattr(args, "scan_all_users", False),
             skip_ssl_verify=getattr(args, "skip_ssl_verify", False),
         )
         set_runtime_config(runtime_config)

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -578,13 +578,6 @@ class HostInfo(BaseModel):
     term: str | None = None
     locale: str | None = None
     timezone: str | None = None
-    # Best-effort versions of language runtimes / tooling on the host
-    # (python, node, npx, uvx, docker, ...). Each value is a verbatim
-    # first line of `<tool> --version` output, or None when the tool
-    # isn't installed / probing failed. Open shape so a newer agent can
-    # report additional tools (pipx, bun, deno) without a schema change
-    # on the server side.
-    runtimes: dict[str, str | None] = Field(default_factory=dict)
 
 
 class PathsInfo(BaseModel):

--- a/src/agent_scan/utils.py
+++ b/src/agent_scan/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 import getpass
 import glob
@@ -9,7 +8,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -39,34 +37,6 @@ def get_username() -> str:
         return "unknown"
 
 
-# Per-tool wall-clock cap. The bootstrap handshake is best-effort and runs
-# before any HTTP retry, so a hung `docker --version` (e.g. Docker Desktop
-# starting on macOS) must not stall scan startup. Two seconds is enough for
-# every probe we care about on a healthy host; anything slower is treated
-# as "not installed."
-_TOOL_VERSION_PROBE_TIMEOUT = 2.0
-# Tools we expect to find on developer machines. Order is preserved in the
-# returned dict for stable serialization of the bootstrap payload. `python`
-# is probed via `python --version` like every other entry — note that this
-# may resolve to a different interpreter than the one running agent-scan
-# if multiple Pythons are on PATH; that's accepted in exchange for treating
-# every runtime uniformly.
-_DEFAULT_PROBED_TOOLS: tuple[str, ...] = (
-    "python",
-    "node",
-    "npx",
-    "uvx",
-    "docker",
-    # Shell-side dependencies of snyk_mcp_stdio_local_proxy.sh. The shim
-    # is bash-only (uses process substitution `>(...)`) and shells out to
-    # shasum/grep. Probing them here lets the server gate the
-    # stdio-local-proxy runtime flag on hosts that actually have the
-    # toolchain — and surface missing pieces in telemetry.
-    "bash",
-    "shasum",
-    "grep",
-)
-
 # Wall-clock cap for the `Get-CimInstance Win32_UserProfile` query that
 # enumerates Windows user profiles under --scan-all-users. WMI/CIM is known
 # to hang when the local repository is corrupted, the WinMgmt service is
@@ -74,54 +44,6 @@ _DEFAULT_PROBED_TOOLS: tuple[str, ...] = (
 # enough for healthy hosts (typical query is <500ms) while still preventing
 # scan startup and bootstrap payload build from blocking indefinitely.
 _WINDOWS_PROFILE_QUERY_TIMEOUT = 10.0
-
-
-def _probe_tool_version(command: str) -> str | None:
-    """Run `<command> --version` and return the first non-empty output line.
-
-    Returns None when the binary is missing, the call times out, exits
-    non-zero, or otherwise fails. Never raises — the caller folds the
-    result straight into telemetry, so any exception here would break
-    the bootstrap payload build and cascade into a failed handshake.
-
-    Output channel choice is intentionally lenient: `node --version`
-    writes to stdout, `docker --version` writes to stdout, but some
-    third-party tools (and old npm versions) write to stderr. We prefer
-    stdout and fall back to stderr so the most common case is correct
-    without specializing per tool.
-    """
-    try:
-        result = subprocess.run(
-            [command, "--version"],
-            capture_output=True,
-            text=True,
-            timeout=_TOOL_VERSION_PROBE_TIMEOUT,
-            check=False,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError, OSError):
-        return None
-    if result.returncode != 0:
-        return None
-    output = (result.stdout or result.stderr or "").strip()
-    if not output:
-        return None
-    return output.splitlines()[0].strip() or None
-
-
-async def get_tool_versions(
-    tools: Iterable[str] = _DEFAULT_PROBED_TOOLS,
-) -> dict[str, str | None]:
-    """Probe versions of external tools in parallel.
-
-    Always returns a dict with one entry per requested tool. Missing /
-    unprobeable tools map to None — distinct from absent keys, which
-    signal "we didn't ask about this tool at all." Probes are offloaded
-    to threads via asyncio.to_thread so the slowest one bounds total
-    wall-clock time, not the sum.
-    """
-    tool_list = list(tools)
-    results = await asyncio.gather(*(asyncio.to_thread(_probe_tool_version, t) for t in tool_list))
-    return dict(zip(tool_list, results, strict=True))
 
 
 def ensure_unicode_console() -> None:

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,8 +1,6 @@
 import asyncio
 import json
 import logging
-import time
-from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -64,15 +62,6 @@ def _control_server(url: str) -> ControlServer:
     if "/mcp-scan/push" not in url:
         url = f"{url.rstrip('/')}/mcp-scan/push"
     return ControlServer(url=url, headers={"x-client-id": str(uuid4())}, identifier="machine-1")
-
-
-@pytest.fixture(autouse=True)
-def _mock_home_dirs(monkeypatch):
-    monkeypatch.setattr(
-        bootstrap_module,
-        "get_readable_home_directories",
-        lambda all_users=False: [(Path("/home/alice"), "alice")],
-    )
 
 
 @pytest.mark.asyncio
@@ -380,74 +369,6 @@ async def test_response_missing_bootstrap_event_id_returns_default():
 
     assert cfg.source == "default"
     assert len(server.requests) == 1
-
-
-@pytest.mark.asyncio
-async def test_slow_home_enumeration_is_outside_http_timeout(monkeypatch):
-    def slow_home_dirs(all_users=False):
-        time.sleep(0.05)
-        return [(Path("/home/alice"), "alice")]
-
-    monkeypatch.setattr(bootstrap_module, "get_readable_home_directories", slow_home_dirs)
-    bootstrap_event_id = uuid4()
-    async with _BootstrapServer(
-        [(200, {"bootstrap_event_id": str(bootstrap_event_id), "runtime_config": {}}, 0)]
-    ) as server:
-        cfg = await bootstrap_first_control_server(
-            [_control_server(server.url)],
-            command="scan",
-            subcommand=None,
-            control_identifier="machine-1",
-            argv=[],
-            no_bootstrap=False,
-            timeout_seconds=0.5,
-        )
-
-    assert cfg.bootstrap_event_id == bootstrap_event_id
-
-
-@pytest.mark.asyncio
-async def test_home_enumeration_failure_returns_default(monkeypatch):
-    def fail_home_dirs(all_users=False):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(bootstrap_module, "get_readable_home_directories", fail_home_dirs)
-    async with _BootstrapServer() as server:
-        cfg = await bootstrap_first_control_server(
-            [_control_server(server.url)],
-            command="scan",
-            subcommand=None,
-            control_identifier="machine-1",
-            argv=[],
-            no_bootstrap=False,
-        )
-
-    assert cfg.source == "default"
-    assert server.requests == []
-
-
-@pytest.mark.asyncio
-async def test_home_directory_enumeration_uses_to_thread(monkeypatch):
-    called = False
-
-    async def fake_to_thread(func, *args, **kwargs):
-        nonlocal called
-        called = True
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(bootstrap_module.asyncio, "to_thread", fake_to_thread)
-    async with _BootstrapServer() as server:
-        cfg = await bootstrap_first_control_server(
-            [_control_server(server.url)],
-            command="scan",
-            subcommand=None,
-            control_identifier="machine-1",
-            argv=[],
-            no_bootstrap=False,
-        )
-
-    assert cfg.source == "bootstrap"
-    assert called is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bootstrap_payload.py
+++ b/tests/unit/test_bootstrap_payload.py
@@ -20,12 +20,6 @@ _posix_only = pytest.mark.skipif(
 
 @pytest.mark.asyncio
 async def test_payload_includes_required_fields(monkeypatch):
-    monkeypatch.setattr(
-        bootstrap_module,
-        "get_readable_home_directories",
-        lambda all_users=False: [(Path("/home/alice"), "alice")],
-    )
-
     payload = await bootstrap_module._build_request("scan", None, "machine-1", ["--ci"])
     data = payload.model_dump()
 
@@ -46,11 +40,6 @@ async def test_windows_payload_reflects_platform_and_wsl(monkeypatch):
     monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
     monkeypatch.setattr(bootstrap_module.platform, "system", lambda: "Windows")
     monkeypatch.setattr(bootstrap_module.platform, "release", lambda: "10")
-    monkeypatch.setattr(
-        bootstrap_module,
-        "get_readable_home_directories",
-        lambda all_users=False: [(Path("C:/Users/Alice"), "Alice")],
-    )
 
     payload = await bootstrap_module._build_request("scan", None, None, [])
     host = payload.model_dump()["host"]
@@ -61,11 +50,6 @@ async def test_windows_payload_reflects_platform_and_wsl(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_argv_flags_are_redacted(monkeypatch):
-    monkeypatch.setattr(
-        bootstrap_module,
-        "get_readable_home_directories",
-        lambda all_users=False: [(Path("/home/alice"), "alice")],
-    )
     # Mixed-case alphanumeric placeholders. Pure lowercase-hex literals
     # of this length match upstream secret-scanner heuristics for legacy
     # GitHub PATs and trigger false positives on the PR scan; mixing in
@@ -102,11 +86,6 @@ async def test_control_server_header_value_is_redacted_as_single_token(monkeypat
     # token must be replaced by exactly one redaction marker, with no
     # partial-leak of either the header name or the header value, and
     # the surrounding flag token must remain intact.
-    monkeypatch.setattr(
-        bootstrap_module,
-        "get_readable_home_directories",
-        lambda all_users=False: [(Path("/home/alice"), "alice")],
-    )
     # Mixed-case alphanumeric — same reasoning as test_argv_flags_are_redacted
     # above: lowercase-hex literals trigger upstream PAT scanners on PRs.
     client_id_value = "Vp3WbZxMrTcLqYn8XfJgAk5Bs7Hu"
@@ -132,11 +111,6 @@ async def test_control_server_header_value_is_redacted_as_single_token(monkeypat
 @pytest.mark.asyncio
 async def test_is_ci_flips_with_environment(monkeypatch):
     monkeypatch.setenv("AGENT_SCAN_ENVIRONMENT", "ci")
-    monkeypatch.setattr(
-        bootstrap_module,
-        "get_readable_home_directories",
-        lambda all_users=False: [(Path("/home/alice"), "alice")],
-    )
 
     payload = await bootstrap_module._build_request("scan", None, None, [])
 
@@ -283,13 +257,7 @@ def test_timezone_returns_a_value_when_all_iana_sources_fail(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_payload_excludes_schema_version_and_scanned_usernames(monkeypatch):
-    monkeypatch.setattr(
-        bootstrap_module,
-        "get_readable_home_directories",
-        lambda all_users=False: [(Path("/home/alice"), "alice")],
-    )
-
+async def test_payload_excludes_schema_version_and_scanned_usernames():
     payload = await bootstrap_module._build_request("scan", None, None, [])
     data = payload.model_dump()
 

--- a/tests/unit/test_bootstrap_payload.py
+++ b/tests/unit/test_bootstrap_payload.py
@@ -35,63 +35,10 @@ async def test_payload_includes_required_fields(monkeypatch):
     assert data["client"]["control_identifier"] == "machine-1"
     assert data["host"]["hostname"]
     assert data["host"]["current_username"]
-    # `runtimes` is an open dict populated by `_DEFAULT_PROBED_TOOLS`; "python"
-    # is one of those probes (`python --version`), so the key is always
-    # present in the request even when the binary is missing on PATH (in
-    # which case the value is None).
-    assert "python" in data["host"]["runtimes"]
-
-
-@pytest.mark.asyncio
-async def test_payload_runtimes_passes_through_probed_tools_verbatim(monkeypatch):
-    # `runtimes` is whatever `get_tool_versions` returns, no post-processing
-    # in `_build_request`. python is just another probed tool now.
-    monkeypatch.setattr(
-        bootstrap_module,
-        "get_readable_home_directories",
-        lambda all_users=False: [(Path("/home/alice"), "alice")],
-    )
-
-    async def fake_probes():
-        return {
-            "python": "Python 3.12.5",
-            "node": "v20.10.0",
-            "npx": "10.2.3",
-            "uvx": "0.4.18",
-            "docker": None,
-            # Shell-side deps of the stdio-local-proxy shim. bash/shasum/grep
-            # support `--version` on both GNU and BSD; cut/mktemp/tee accept
-            # it on GNU but not on BSD — the BSD-None case is exercised here
-            # via `mktemp` so the payload contract for the shim deps stays
-            # pinned alongside the original runtimes set.
-            "bash": "GNU bash, version 5.2.15",
-            "shasum": "shasum (perl) version 6.04",
-            "cut": "cut (GNU coreutils) 9.4",
-            "mktemp": None,
-            "tee": "tee (GNU coreutils) 9.4",
-            "grep": "grep (GNU grep) 3.11",
-        }
-
-    monkeypatch.setattr(bootstrap_module, "get_tool_versions", fake_probes)
-
-    payload = await bootstrap_module._build_request("scan", None, None, [])
-    runtimes = payload.model_dump()["host"]["runtimes"]
-
-    assert runtimes["python"] == "Python 3.12.5"
-    assert runtimes["node"] == "v20.10.0"
-    assert runtimes["npx"] == "10.2.3"
-    assert runtimes["uvx"] == "0.4.18"
-    # `None` means "we probed and the tool isn't installed" — it must be
-    # preserved as an explicit null in the payload, not dropped.
-    assert runtimes["docker"] is None
-    # Shim deps: each is reported verbatim, including the BSD-None case
-    # for mktemp (where `--version` is unsupported on BSD/macOS).
-    assert runtimes["bash"] == "GNU bash, version 5.2.15"
-    assert runtimes["shasum"] == "shasum (perl) version 6.04"
-    assert runtimes["cut"] == "cut (GNU coreutils) 9.4"
-    assert runtimes["mktemp"] is None
-    assert runtimes["tee"] == "tee (GNU coreutils) 9.4"
-    assert runtimes["grep"] == "grep (GNU grep) 3.11"
+    # Tool-version probing has been removed: the payload no longer carries a
+    # `runtimes` dict, so the bootstrap handshake never shells out to probe
+    # python/node/docker/etc.
+    assert "runtimes" not in data["host"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli_bootstrap_wrapper.py
+++ b/tests/unit/test_cli_bootstrap_wrapper.py
@@ -131,49 +131,6 @@ async def test_bootstrap_runtime_config_with_no_bootstrap_makes_zero_http_calls(
 
 
 @pytest.mark.asyncio
-async def test_bootstrap_runtime_config_forwards_scan_all_users():
-    """args.scan_all_users must reach bootstrap_first_control_server unchanged.
-
-    The bootstrap payload's home-directory enumeration mirrors the scan: when
-    --scan-all-users is set, both touch every readable home; otherwise both
-    stay limited to the current user. The wrapper is the only place that maps
-    args -> helper kwarg, so a regression here would silently widen what gets
-    sent to the control server.
-    """
-    fake_helper = AsyncMock(return_value=RuntimeConfig())
-    args = Namespace(
-        control_servers=[_control_server("http://example/mcp-scan/push")],
-        no_bootstrap=False,
-        scan_all_users=True,
-    )
-
-    with patch("agent_scan.cli.bootstrap_first_control_server", fake_helper):
-        await cli.bootstrap_runtime_config(args, command="scan")
-
-    assert fake_helper.call_args.kwargs["scan_all_users"] is True
-
-
-@pytest.mark.asyncio
-async def test_bootstrap_runtime_config_defaults_scan_all_users_to_false_when_attr_missing():
-    """Subparsers that omit --scan-all-users (e.g. guard) must not crash the wrapper.
-
-    Default is False so the bootstrap payload stays narrow when the flag was
-    never registered on the parser.
-    """
-    fake_helper = AsyncMock(return_value=RuntimeConfig())
-    args = Namespace(
-        control_servers=[_control_server("http://example/mcp-scan/push")],
-        no_bootstrap=False,
-    )
-    # Deliberately no `scan_all_users` attribute on args.
-
-    with patch("agent_scan.cli.bootstrap_first_control_server", fake_helper):
-        await cli.bootstrap_runtime_config(args, command="scan")
-
-    assert fake_helper.call_args.kwargs["scan_all_users"] is False
-
-
-@pytest.mark.asyncio
 async def test_bootstrap_runtime_config_stores_helper_result_in_runtime_config():
     """The wrapper must call `set_runtime_config` with whatever the helper returns.
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,11 +9,9 @@ import pytest
 from agent_scan import utils as utils_module
 from agent_scan.models import CommandParsingError, rebalance_command_args
 from agent_scan.utils import (
-    _probe_tool_version,
     calculate_distance,
     get_readable_home_directories,
     get_relative_path,
-    get_tool_versions,
     suppress_stdout,
 )
 
@@ -147,135 +145,6 @@ class TestSuppressStdout:
 
         # Only the final print should appear
         assert captured_output.getvalue() == "Final line\n"
-
-
-class TestProbeToolVersion:
-    """`_probe_tool_version` runs `<cmd> --version` and must never raise.
-
-    Bootstrap folds its result straight into telemetry; an exception here
-    would break the whole payload build. These tests pin each failure
-    mode to None explicitly, so future refactors that swap one exception
-    type for another can't accidentally turn "tool missing" into a crash.
-    """
-
-    def test_returns_first_stdout_line_on_success(self, monkeypatch):
-        def fake_run(cmd, **kwargs):
-            return SimpleNamespace(
-                returncode=0,
-                stdout="v20.10.0\nextra debug line\n",
-                stderr="",
-            )
-
-        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
-        assert _probe_tool_version("node") == "v20.10.0"
-
-    def test_falls_back_to_stderr_when_stdout_empty(self, monkeypatch):
-        # Older npm versions and some Java tools print --version to stderr.
-        # We don't want to specialize per tool, so stderr is the documented
-        # fallback when stdout is empty but the exit code is clean.
-        def fake_run(cmd, **kwargs):
-            return SimpleNamespace(
-                returncode=0,
-                stdout="",
-                stderr="6.14.18\n",
-            )
-
-        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
-        assert _probe_tool_version("npm") == "6.14.18"
-
-    def test_missing_binary_returns_none(self, monkeypatch):
-        def fake_run(cmd, **kwargs):
-            raise FileNotFoundError(cmd)
-
-        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
-        assert _probe_tool_version("definitely-not-installed") is None
-
-    def test_timeout_returns_none(self, monkeypatch):
-        # A hung `docker --version` (Docker Desktop spinning up on macOS)
-        # must not stall the bootstrap — the timeout converts to None.
-        def fake_run(cmd, **kwargs):
-            raise subprocess.TimeoutExpired(cmd, timeout=2.0)
-
-        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
-        assert _probe_tool_version("docker") is None
-
-    def test_nonzero_exit_returns_none(self, monkeypatch):
-        # A binary that exists but exits non-zero is treated as unprobeable
-        # rather than returning a garbage version string.
-        def fake_run(cmd, **kwargs):
-            return SimpleNamespace(returncode=2, stdout="usage: ...", stderr="")
-
-        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
-        assert _probe_tool_version("broken") is None
-
-    def test_permission_error_returns_none(self, monkeypatch):
-        def fake_run(cmd, **kwargs):
-            raise PermissionError("nope")
-
-        monkeypatch.setattr(utils_module.subprocess, "run", fake_run)
-        assert _probe_tool_version("locked-down") is None
-
-
-@pytest.mark.asyncio
-async def test_get_tool_versions_returns_one_entry_per_tool(monkeypatch):
-    # `get_tool_versions` must always return a key for every requested
-    # tool, even when probing fails. The dict shape — keys for asked-about
-    # tools, None for unprobeable ones — is the contract the bootstrap
-    # payload depends on to distinguish "not installed" from "not asked."
-    fake_results = {"node": "v20.10.0", "docker": None}
-
-    def fake_probe(command):
-        return fake_results[command]
-
-    monkeypatch.setattr(utils_module, "_probe_tool_version", fake_probe)
-
-    result = await get_tool_versions(("node", "docker"))
-
-    assert result == {"node": "v20.10.0", "docker": None}
-
-
-@pytest.mark.asyncio
-async def test_get_tool_versions_runs_probes_concurrently(monkeypatch):
-    # Probes are I/O-bound (subprocess + waitpid) and independent, so they
-    # must run in parallel via asyncio.to_thread. If a future refactor
-    # accidentally serializes them, total wall time would be sum(per-probe),
-    # which violates the 2s-per-bootstrap budget on hosts with 4+ probed
-    # tools. We assert parallelism by ensuring all probes have started
-    # before any has finished — a serial implementation can't satisfy this.
-    import asyncio
-    import threading
-
-    started = threading.Event()
-    pending = [threading.Event() for _ in range(3)]
-    release = threading.Event()
-
-    counter = {"started": 0}
-    lock = threading.Lock()
-
-    def slow_probe(command):
-        with lock:
-            counter["started"] += 1
-            idx = counter["started"] - 1
-        pending[idx].set()
-        if counter["started"] == 3:
-            started.set()
-        release.wait(timeout=2)
-        return f"{command}-ok"
-
-    monkeypatch.setattr(utils_module, "_probe_tool_version", slow_probe)
-
-    async def driver():
-        task = asyncio.create_task(get_tool_versions(("a", "b", "c")))
-        # Wait until all three probes have entered slow_probe before
-        # releasing them. If probes ran serially, only one would be
-        # in-flight at a time and `started` would never set.
-        await asyncio.to_thread(started.wait, 2)
-        release.set()
-        return await task
-
-    result = await driver()
-    assert set(result) == {"a", "b", "c"}
-    assert started.is_set(), "probes did not run concurrently"
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only behavior")


### PR DESCRIPTION
## What

Removes two pieces of best-effort work the bootstrap handshake did at startup, neither of which the control server depends on:

1. **Tool-version probing** 
2. **Discarded home-directory enumeration** 
