### PR TITLE
chore: bump version to 0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,4 @@
 - `0.5.6` Per-agent discovery refactor with Claude Code support. Bundle all detect_secrets plugins in PyInstaller binary. Starlette security update.
 - `0.5.8` Reverting changes.
 - `0.5.9` Don't handshake (launch) stdio MCP servers by default. Add VSCode family discoverers (VSCode, Cursor, Windsurf, Kiro, Antigravity); only scan installed extensions and plugins. Upgrade aiohttp to fix CVEs.
+- `0.5.10` Add Codex discoverer for MCP servers and skills. Add Claude Desktop support. Attach config-file path to each MCP server on upload. Fix remote URL handling. Stop probing host tool versions and enumerating home directories during bootstrap.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snyk-agent-scan"
-version = "0.5.9"
+version = "0.5.10"
 description = "Agent supply chain security scanner."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -2059,7 +2059,7 @@ wheels = [
 
 [[package]]
 name = "snyk-agent-scan"
-version = "0.5.9"
+version = "0.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bumps the version to `0.5.10` in `pyproject.toml`, `uv.lock`, and `CHANGELOG.md`.

### Changelog entry
> `0.5.10` Add Codex discoverer for MCP servers and skills. Add Claude Desktop support. Attach config-file path to each MCP server on upload. Fix remote URL handling. Stop probing host tool versions and enumerating home directories during bootstrap.

### Included since `0.5.9`
- #348 — Codex discoverer for MCP servers and skills
- #358 — attach config-file path to each MCP server on upload
- #357 — fix remote URLs
- #359 — Claude Desktop support
- #360 — docs: agent detection table (internal)
- #361 — strip bootstrap tool-version probing and discarded home-dir enumeration