### PR TITLE
feat: discover Kiro Power POWER.md (+ steering) as skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Legend: **✓** detected · **✗** the agent supports this but Agent Scan does 
 | Gemini CLI | N/A | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
 | OpenClaw | N/A | N/A | ✓ | ✗ | ✓ † | N/A | ✗ | ✗ |
 | Amp | N/A | ✗ | ✓ | ✗ | ✗ ‡ | ✗ | ✗ | ✗ |
-| Kiro | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Kiro | N/A | N/A | ✓ § | ✓ | ✓ | ✓ | ✓ | ✓ |
 | OpenCode | N/A | ✗ | ✗ | ✗ | ✗ | ✗ | N/A | N/A |
 | Antigravity | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -103,6 +103,8 @@ Legend: **✓** detected · **✗** the agent supports this but Agent Scan does 
 † OpenClaw has no opened-project enumeration: its project/workspace skills are found only at the fixed `~/.openclaw/workspace/skills`
 
 ‡ Amp stores project/workspace skills at `.agents/skills` (and the `.claude/skills` compatibility path); only the user-scope `~/.config/agents/skills` is detected today, so project-scope skills are supported but not yet scanned.
+
+§ Kiro user skills include installed **Powers** at `~/.kiro/powers/installed/<name>/`, whose instruction file is `POWER.md` (the per-Power equivalent of `SKILL.md`) and which also surface their `steering/*.md` files. Powers are user-global only — no system/project/extension Power location is documented.
 
 ## Quick Start
 

--- a/src/agent_scan/agents/vscode/kiro.py
+++ b/src/agent_scan/agents/vscode/kiro.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import ClassVar
 
+from agent_scan.agents.base import SkillsDirsResult
 from agent_scan.agents.vscode.base import VSCodeFamilyDiscoverer
 from agent_scan.well_known_clients import expand_path
 
@@ -97,3 +98,28 @@ class KiroDiscoverer(VSCodeFamilyDiscoverer):
         if base in unmanaged:
             return self._immediate_subdirs(base)
         return super()._installed_extension_dirs(base)
+
+    def _discover_power_skills(self) -> SkillsDirsResult:
+        """Surface each installed Kiro Power's instruction file as a skill.
+
+        A Power ships a ``POWER.md`` steering file (Kiro's per-Power equivalent of
+        ``SKILL.md``) plus an optional ``steering/`` dir, living user-global at
+        ``~/.kiro/powers/installed/<name>/``. Treating the powers ``installed/``
+        root as a skills dir means :func:`inspect_skills_dir` lists each Power
+        subdir and keeps the ones holding a ``POWER.md`` (recognized alongside
+        ``SKILL.md`` by ``skill_client``); each Power's ``steering/*.md`` is then
+        surfaced when the skill is inspected. No system/project/extension Power
+        location is documented, so only this user-global level is covered.
+        """
+        result: SkillsDirsResult = {}
+        for raw in self._unmanaged_extension_paths:
+            root = expand_path(Path(raw), self.home_directory)
+            entries = self._scan_skills_dir(root)
+            if entries is not None:
+                result[root.as_posix()] = entries
+        return result
+
+    def discover_skills(self) -> SkillsDirsResult:
+        result = super().discover_skills()
+        result.update(self._discover_power_skills())
+        return result

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -27,9 +27,19 @@ logger = logging.getLogger(__name__)
 _MAX_COMMANDS_WALK_DEPTH = 10
 
 
+# Filenames that mark a directory as a skill. ``skill.md`` is the open Agent
+# Skills standard; ``power.md`` is Kiro's per-Power steering/instruction file
+# (the SKILL.md equivalent), which ships inside each installed Power directory
+# at ~/.kiro/powers/installed/<name>/. POWER.md is unique to Kiro Powers, so
+# recognizing it here does not affect any other agent's skill discovery. (No
+# system/project/extension Power location is documented — that is a coverage
+# gap by design, not handled here.)
+_SKILL_MD_FILENAMES = ("skill.md", "power.md")
+
+
 def get_skill_md_path(path: str) -> str | None:
     for file in os.listdir(path):
-        if file.lower() == "skill.md":
+        if file.lower() in _SKILL_MD_FILENAMES:
             return file
     return None
 
@@ -89,7 +99,7 @@ def inspect_skill(config: SkillServer) -> ServerSignature:
         return _inspect_skill_file(expanded_path)
     skill_md_path = get_skill_md_path(config.path)
     if skill_md_path is None:
-        raise Exception(f"neither SKILL.md nor skill.md file found at path: {config.path}")
+        raise Exception(f"neither SKILL.md, skill.md, nor POWER.md file found at path: {config.path}")
     with open(os.path.expanduser(os.path.join(config.path, skill_md_path)), encoding="utf-8") as f:
         content = f.read()
 
@@ -109,6 +119,9 @@ def inspect_skill(config: SkillServer) -> ServerSignature:
     if "name" not in yaml_data:
         raise Exception(f"Invalid SKILL.md file: {config.path}. Missing name in the YAML frontmatter.")
     name = yaml_data["name"]
+    # Both name and description are required. Kiro POWER.md frontmatter carries
+    # both (plus displayName/keywords/author); a POWER.md missing description
+    # surfaces here as a per-skill error, exactly like a malformed SKILL.md.
     if "description" not in yaml_data:
         raise Exception(f"Invalid SKILL.md file: {config.path}. Missing description in the YAML frontmatter.")
     description = yaml_data["description"]
@@ -150,7 +163,9 @@ def traverse_skill_tree(skill_path: str, relative_path: str | None) -> tuple[lis
             resources.extend(resources_sub)
             tools.extend(tools_sub)
             continue
-        elif file.lower() == "skill.md" and not relative_path:
+        elif file.lower() in _SKILL_MD_FILENAMES and not relative_path:
+            # The root skill file (SKILL.md / Kiro's POWER.md) is already surfaced
+            # as the base prompt; don't re-emit it as a nested prompt.
             continue
 
         elif file.endswith(".md"):

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -2879,7 +2879,7 @@ def test_vscode_discoverer_reads_each_documented_workspace_skills_path(tmp_path,
 
 
 def test_kiro_discoverer_has_no_skills_dir(tmp_path):
-    """Kiro doesn't ship a skills directory — ``discover_skills`` returns ``{}``."""
+    """With no skills dir and no installed Powers, ``discover_skills`` returns ``{}``."""
     from agent_scan.agents import KiroDiscoverer
 
     (tmp_path / ".kiro").mkdir()
@@ -4600,6 +4600,69 @@ def test_kiro_powers_walk_finds_multiple_installed_powers(tmp_path):
 
     keys = [k for k in mcp_configs if "/powers/installed/" in k and k.endswith("/mcp.json")]
     assert len(keys) == 2
+
+
+# --- Kiro Powers: POWER.md (+ steering/) surfaced as a skill ---
+#
+# A Power's POWER.md is Kiro's per-Power steering/instruction file — the
+# equivalent of SKILL.md for the open Agent Skills standard. Powers live
+# user-global at ~/.kiro/powers/installed/<name>/; no system/project/extension
+# Power location is documented, so only the user-global level is covered.
+
+
+def test_kiro_power_md_dir_surfaced_as_skill(tmp_path):
+    """An installed Power whose dir holds a POWER.md is surfaced as a skill,
+    keyed under the ~/.kiro/powers/installed root."""
+    from pathlib import Path
+
+    from agent_scan.agents import KiroDiscoverer
+
+    power_dir = tmp_path / ".kiro" / "powers" / "installed" / "databricks"
+    power_dir.mkdir(parents=True)
+    (power_dir / "POWER.md").write_text("---\nname: databricks\ndescription: d\n---\n\nbody\n")
+
+    skills = KiroDiscoverer(tmp_path).discover_skills()
+
+    keys = [k for k in skills if k.endswith("/powers/installed")]
+    assert len(keys) == 1
+    entries = skills[keys[0]]
+    assert isinstance(entries, list)
+    name, skill = next(e for e in entries if e[0] == "databricks")
+    assert isinstance(skill, SkillServer)
+    assert Path(skill.path) == power_dir
+
+
+def test_kiro_multiple_powers_each_surface_power_md(tmp_path):
+    """Every installed Power with a POWER.md is surfaced."""
+    from agent_scan.agents import KiroDiscoverer
+
+    installed = tmp_path / ".kiro" / "powers" / "installed"
+    for name in ("databricks", "supabase"):
+        d = installed / name
+        d.mkdir(parents=True)
+        (d / "POWER.md").write_text(f"---\nname: {name}\ndescription: d\n---\n\nbody\n")
+
+    skills = KiroDiscoverer(tmp_path).discover_skills()
+
+    skill_names = {n for v in skills.values() if isinstance(v, list) for n, _ in v}
+    assert {"databricks", "supabase"} <= skill_names
+
+
+def test_kiro_power_without_power_md_not_surfaced(tmp_path):
+    """A Power dir with only mcp.json (no POWER.md) is not surfaced as a skill,
+    though its MCP servers are still discovered."""
+    from agent_scan.agents import KiroDiscoverer
+
+    power_dir = tmp_path / ".kiro" / "powers" / "installed" / "stripe"
+    power_dir.mkdir(parents=True)
+    (power_dir / "mcp.json").write_text('{"mcpServers": {"stripe-mcp": {"command": "s"}}}')
+
+    discoverer = KiroDiscoverer(tmp_path)
+    skill_names = {n for v in discoverer.discover_skills().values() if isinstance(v, list) for n, _ in v}
+    mcp_names = {n for v in discoverer.discover_mcp_servers().values() if isinstance(v, list) for n, _ in v}
+
+    assert "stripe" not in skill_names
+    assert "stripe-mcp" in mcp_names
 
 
 # --- Kiro: custom agents / subagents with inline mcpServers ---

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -9,7 +9,7 @@ Code command files are flat ``*.md`` files, so they need their own scanner
 from pathlib import Path
 
 from agent_scan.models import SkillServer
-from agent_scan.skill_client import inspect_commands_dir, inspect_skill
+from agent_scan.skill_client import get_skill_md_path, inspect_commands_dir, inspect_skill
 
 
 def test_inspect_commands_dir_surfaces_flat_md_files(tmp_path):
@@ -150,3 +150,46 @@ def test_inspect_skill_body_horizontal_rules_not_parsed_as_frontmatter(tmp_path)
     sig = inspect_skill(SkillServer(path=str(cmd)))
 
     assert sig.metadata.serverInfo.name == "deploy"
+
+
+# --- Kiro Powers: POWER.md is the per-Power steering file (SKILL.md equivalent) ---
+
+
+def test_get_skill_md_path_matches_power_md_case_insensitive(tmp_path):
+    """Kiro Powers ship a POWER.md (not SKILL.md); the skill-file probe must
+    recognize it so a Power dir counts as a skill."""
+    power = tmp_path / "databricks"
+    power.mkdir()
+    (power / "POWER.md").write_text("---\nname: x\ndescription: y\n---\nbody")
+
+    assert get_skill_md_path(str(power)) == "POWER.md"
+
+
+def test_inspect_skill_reads_power_md_frontmatter(tmp_path):
+    """A POWER.md dir is inspected like a SKILL.md dir: frontmatter name/description
+    populate ``serverInfo`` and ``instructions``."""
+    power = tmp_path / "databricks"
+    power.mkdir()
+    (power / "POWER.md").write_text("---\nname: databricks\ndescription: Databricks power\n---\n\nUse it.\n")
+
+    sig = inspect_skill(SkillServer(path=str(power)))
+
+    assert sig.metadata.serverInfo.name == "databricks"
+    assert sig.metadata.instructions == "Databricks power"
+
+
+def test_inspect_skill_does_not_duplicate_root_power_md_prompt(tmp_path):
+    """The root POWER.md is the base prompt; the tree walk must NOT re-emit it as a
+    nested prompt. A Power's steering/*.md files ARE surfaced as prompts."""
+    power = tmp_path / "databricks"
+    (power / "steering").mkdir(parents=True)
+    (power / "POWER.md").write_text("---\nname: databricks\ndescription: d\n---\n\nbody\n")
+    (power / "steering" / "setup.md").write_text("# Setup steps")
+
+    sig = inspect_skill(SkillServer(path=str(power)))
+
+    prompt_names = [p.name for p in sig.prompts]
+    assert any(n.replace("\\", "/") == "steering/setup.md" for n in prompt_names)
+    # The root POWER.md must not appear as a nested prompt (the base prompt is
+    # emitted separately under a fixed label).
+    assert "POWER.md" not in prompt_names


### PR DESCRIPTION
## What

Adds discovery of **Kiro Power instruction content** to `KiroDiscoverer`. Powers already had their MCP servers surfaced (per-Power `mcp.json`), but a Power's `POWER.md` steering file (Kiro's per-Power equivalent of `SKILL.md`) and its optional `steering/*.md` workflow files were invisible to the scanner.

## Changes

- **`skill_client.py`** — recognize `POWER.md` alongside `SKILL.md`/`skill.md` as a skill-root file via a new `_SKILL_MD_FILENAMES` tuple (used by both `get_skill_md_path` and the `traverse_skill_tree` root-skip, so the root `POWER.md` isn't re-emitted as a duplicate nested prompt). `POWER.md` is unique to Kiro Powers, so this is a no-op for every other agent's skill discovery.
- **`KiroDiscoverer`** — add `_discover_power_skills()` over `~/.kiro/powers/installed/` and merge it into an overridden `discover_skills()`. Each Power dir holding a `POWER.md` becomes a skill; its `steering/*.md` files surface automatically on inspection (via the existing skill-tree walk). Reuses the existing `_scan_skills_dir` → `inspect_skills_dir` machinery — no new walking logic.
- **`README.md`** — footnote on the Kiro row clarifying that user skills include Powers.

## Scope (intentional)

- **User-global only.** Powers are documented to live only at `~/.kiro/powers/installed/<name>/`. There is no documented system / project / extension / plugin Power location, and Kiro has no plugin system — these are flagged as coverage gaps in code comments rather than guessed at.
- **MCP discovery unchanged.** Power MCP servers are already fully covered by per-Power `mcp.json`; the `powers.mcpServers` block in `~/.kiro/settings/mcp.json` is intentionally not parsed (redundant).

## Tests (TDD)

- `tests/unit/test_skill_client.py`: `POWER.md` recognized by `get_skill_md_path`; `inspect_skill` reads POWER.md frontmatter (name/description); root POWER.md not duplicated as a nested prompt while `steering/*.md` is surfaced.
- `tests/unit/test_agent_discovery.py`: single/multiple Powers surfaced as skills under the `~/.kiro/powers/installed` key; a Power with only `mcp.json` (no POWER.md) is **not** a skill but its MCP is still discovered.

Full unit suite: **1056 passed**; the 8 `test_verify_api.py` proxy/retry failures are pre-existing and env-only (confirmed they fail on the clean tree too — unrelated to this change).