### PR TITLE
feat: PromptArtifact abstraction for prompt-based files

### DIFF
--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -190,10 +190,28 @@ class StdioServer(BaseModel):
         return self
 
 
+# Kinds of prompt-bearing, disk-resident capability artifact a client can load.
+# They all share the same on-disk shape -- a path to a markdown/prompt file or
+# dir -- so they ride a single ``SkillServer`` model; ``type`` distinguishes the
+# kind so the backend can tell them apart. Supporting a new prompt-file kind is
+# adding a value here.
+#
+# WARNING: this value set is hand-mirrored downstream -- ``SkillServer.type`` in
+# invariant-mcp-scan-backend (server/models.py) and invariant-platform
+# (backend/models/base.py), plus ``ScanError.server_type`` in invariant-platform.
+# There is NO automated enforcement (cf. the sync warning above ``HomeDirectoryEntry``);
+# emitting a value those repos don't accept fails their Pydantic validation and
+# sinks the whole payload, exactly like the ``ws`` transport (TODO(ADS-384)). Add
+# a value in all three repos in a coordinated change.
+PromptArtifact = Literal["skill", "command", "agent", "power"]
+
+
 class SkillServer(BaseModel):
     model_config = ConfigDict()
     path: str
-    type: Literal["skill"] | None = "skill"
+    # ``skill`` stays the default so existing discovery (skills, plus commands
+    # folded onto skills) is unchanged; new kinds are opt-in per discoverer.
+    type: PromptArtifact | None = "skill"
 
 
 class MCPConfig(BaseModel):

--- a/src/agent_scan/printer.py
+++ b/src/agent_scan/printer.py
@@ -13,6 +13,7 @@ from agent_scan.models import (
     Issue,
     ScanError,
     ScanPathResult,
+    SkillServer,
     ToxicFlowExtraData,
 )
 
@@ -313,7 +314,10 @@ def print_scan_path_result(
     server_count = 0
     skill_count = 0
     for server in result.servers or []:
-        if server.server.type == "skill":
+        # Any prompt-based artifact (skill/command/agent/power) is a SkillServer;
+        # key off the model, not ``type == "skill"``, so non-skill kinds aren't
+        # miscounted as MCP servers.
+        if isinstance(server.server, SkillServer):
             skill_count += 1
         else:
             server_count += 1
@@ -353,7 +357,7 @@ def print_scan_path_result(
                     entity,
                     issues,
                     inspect_mode,
-                    is_skill=server.server.type == "skill",
+                    is_skill=isinstance(server.server, SkillServer),
                     full_description=full_description,
                 )
             )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -300,3 +300,71 @@ class TestMCPServerMap:
 
         with pytest.raises(ValidationError):
             MCPServerMap(servers={"bad": {"not_a": "server"}})
+
+
+class TestSkillServerPromptArtifact:
+    """SkillServer models any prompt-based artifact (skill/command/agent/power).
+
+    ``type`` is a ``PromptArtifact`` literal -- the single extension point for
+    new prompt-file kinds. Adding a kind = adding one value to ``PromptArtifact``,
+    mirrored in invariant-mcp-scan-backend + invariant-platform. ``skill`` stays
+    the default so existing discovery (skills + commands folded onto skills) is
+    unchanged.
+    """
+
+    def test_default_type_is_skill(self):
+        from agent_scan.models import SkillServer
+
+        assert SkillServer(path="/x/SKILL.md").type == "skill"
+
+    @pytest.mark.parametrize("artifact_type", ["skill", "command", "agent", "power"])
+    def test_accepts_each_prompt_artifact_type(self, artifact_type):
+        from agent_scan.models import SkillServer
+
+        assert SkillServer(path="/x/file.md", type=artifact_type).type == artifact_type
+
+    def test_rejects_unknown_type(self):
+        from agent_scan.models import SkillServer
+
+        with pytest.raises(ValidationError):
+            SkillServer(path="/x/file.md", type="bogus")
+
+    def test_prompt_artifact_lists_supported_kinds(self):
+        from typing import get_args
+
+        from agent_scan.models import PromptArtifact
+
+        assert set(get_args(PromptArtifact)) == {"skill", "command", "agent", "power"}
+
+    @pytest.mark.parametrize("artifact_type", ["command", "agent", "power"])
+    def test_new_type_round_trips_through_backend_payload(self, artifact_type):
+        """A new prompt-artifact type survives serialization to the upload payload
+        and back -- the end-to-end wire shape the backend/platform must accept."""
+        from agent_scan.models import (
+            ScanPathResult,
+            ScanPathResultsCreate,
+            ScanUserInfo,
+            ServerScanResult,
+            SkillServer,
+        )
+
+        payload = ScanPathResultsCreate(
+            scan_path_results=[
+                ScanPathResult(
+                    path="/home/u/.claude",
+                    servers=[
+                        ServerScanResult(
+                            name="my-artifact",
+                            server=SkillServer(path="/home/u/.claude/x.md", type=artifact_type),
+                        )
+                    ],
+                )
+            ],
+            scan_user_info=ScanUserInfo(),
+        )
+
+        roundtripped = ScanPathResultsCreate.model_validate_json(payload.model_dump_json())
+
+        server = roundtripped.scan_path_results[0].servers[0].server
+        assert isinstance(server, SkillServer)
+        assert server.type == artifact_type

--- a/tests/unit/test_printer.py
+++ b/tests/unit/test_printer.py
@@ -79,3 +79,29 @@ class TestFormatEntityLine:
         result = format_entity_line(entity, issues=[], is_skill=True, full_description=True).plain
         assert "instruction SKILL.md" in result
         assert "instructionSKILL.md" not in result
+
+
+class TestPrintScanPathResultArtifactCounting:
+    """Any prompt-based artifact (skill/command/agent/power) is counted and
+    rendered as a skill -- never mistaken for an MCP server. The counting must
+    key off the artifact model, not the literal ``type == "skill"``."""
+
+    def test_command_artifact_counted_as_skill(self, capsys):
+        from agent_scan.models import ScanPathResult, ServerScanResult, SkillServer
+        from agent_scan.printer import print_scan_path_result
+
+        result = ScanPathResult(
+            path="/home/u/.claude/commands",
+            servers=[
+                ServerScanResult(
+                    name="git:commit",
+                    server=SkillServer(path="/home/u/.claude/commands/git/commit.md", type="command"),
+                )
+            ],
+        )
+
+        print_scan_path_result(result)
+
+        out = capsys.readouterr().out
+        assert "skill" in out
+        assert "mcp server" not in out


### PR DESCRIPTION
## What

Introduces `PromptArtifact = Literal["skill", "command", "agent", "power"]` and uses it for `SkillServer.type`, so supporting a new prompt-based artifact kind is just adding one literal value. The default stays `"skill"`, so existing skill discovery (and commands, which are folded onto skills) is unchanged.

`printer.print_scan_path_result` now counts/renders any `SkillServer` as a skill (keyed off the model, not `type == "skill"`), so non-skill prompt artifacts aren't miscounted as MCP servers.

## Scope

This wires the abstraction end-to-end through the upload payload **only**. No new discovery — nothing emits `command`/`agent`/`power` yet; that's deliberately out of scope. This PR makes those kinds *representable* and *accepted downstream*.

## Cross-repo (hand-mirrored, no automated enforcement)

`SkillServer.type` is duplicated in the backend + platform; a value they reject sinks the whole payload (cf. the `ws` transport, ADS-384). Companion PRs expand the matching literals:
- invariant-mcp-scan-backend: snyk/invariant-mcp-scan-backend#352
- invariant-platform: snyk/invariant-platform#601

Merge order is independent — agent-scan won't emit the new values until discovery lands.

## Tests

- `SkillServer` accepts each `PromptArtifact` value / rejects unknown
- a new type round-trips through `ScanPathResultsCreate` (the upload wire shape)
- printer counts a `command` artifact as a skill, not an MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
