### PR TITLE
Add --trusted-urls to suppress internal-URL false positives

### DIFF
--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -894,10 +894,12 @@ def _classify_trusted_patterns(
     domains: list[str] = []
     for raw in patterns:
         p = raw.strip().lower()
-        if not p:
-            continue
         if p.startswith("*."):
             p = p[2:]
+        if not p:
+            # Skip blanks and bare globs ("*.") that would strip to an empty
+            # domain, which would otherwise match almost any host via endswith(".").
+            continue
         try:
             networks.append(ipaddress.ip_network(p, strict=False))
             continue
@@ -915,7 +917,9 @@ def _host_is_trusted(
     """True if ``host`` is an IP inside a trusted network, or a trusted domain/subdomain."""
     if not host:
         return False
-    host = host.lower().strip("[]")  # strip IPv6 literal brackets
+    # Lowercase, strip IPv6 literal brackets, and drop a trailing dot so a
+    # fully-qualified host ("nexus.corp.") matches the trusted "nexus.corp".
+    host = host.lower().strip("[]").rstrip(".")
     try:
         ip = ipaddress.ip_address(host)
         return any(ip in net for net in networks)
@@ -942,6 +946,33 @@ def _message_urls_all_trusted(
     return all(_host_is_trusted(urlparse(url).hostname or "", networks, domains) for url in urls)
 
 
+def _trusted_urls_config_error(message: str) -> None:
+    """Report an invalid trusted-urls configuration and exit with the usage code."""
+    rich.print(f"[bold red]Error: {message}[/bold red]", file=sys.stderr)
+    sys.exit(2)
+
+
+def _load_trusted_urls_file(file_path: str) -> list[str]:
+    """Read and validate the trusted-urls JSON file, returning its patterns."""
+    try:
+        with open(file_path) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        _trusted_urls_config_error(f"--trusted-urls-file not found: {file_path}")
+    except json.JSONDecodeError as e:
+        _trusted_urls_config_error(f"--trusted-urls-file is not valid JSON: {e}")
+
+    if not isinstance(data, dict) or "trusted_urls" not in data:
+        _trusted_urls_config_error(
+            f'--trusted-urls-file must contain a JSON object with a "trusted_urls" '
+            f"list (got: {type(data).__name__})."
+        )
+    file_patterns = data["trusted_urls"]
+    if not isinstance(file_patterns, list):
+        _trusted_urls_config_error('"trusted_urls" in --trusted-urls-file must be a list.')
+    return [p for p in file_patterns if isinstance(p, str) and p.strip()]
+
+
 def _load_trusted_urls(args) -> list[str]:
     """Merge trusted URL patterns from --trusted-urls and --trusted-urls-file."""
     patterns: list[str] = []
@@ -952,36 +983,7 @@ def _load_trusted_urls(args) -> list[str]:
 
     file_path = getattr(args, "trusted_urls_file", None)
     if file_path:
-        try:
-            with open(file_path) as f:
-                data = json.load(f)
-            if not isinstance(data, dict) or "trusted_urls" not in data:
-                rich.print(
-                    f"[bold red]Error: --trusted-urls-file must contain a JSON object with a "
-                    f'"trusted_urls" list (got: {type(data).__name__}).[/bold red]',
-                    file=sys.stderr,
-                )
-                sys.exit(2)
-            file_patterns = data["trusted_urls"]
-            if not isinstance(file_patterns, list):
-                rich.print(
-                    '[bold red]Error: "trusted_urls" in --trusted-urls-file must be a list.[/bold red]',
-                    file=sys.stderr,
-                )
-                sys.exit(2)
-            patterns.extend(p for p in file_patterns if isinstance(p, str) and p.strip())
-        except FileNotFoundError:
-            rich.print(
-                f"[bold red]Error: --trusted-urls-file not found: {file_path}[/bold red]",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        except json.JSONDecodeError as e:
-            rich.print(
-                f"[bold red]Error: --trusted-urls-file is not valid JSON: {e}[/bold red]",
-                file=sys.stderr,
-            )
-            sys.exit(2)
+        patterns.extend(_load_trusted_urls_file(file_path))
 
     return patterns
 

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -9,10 +9,13 @@ truststore.inject_into_ssl()
 
 import argparse
 import asyncio
+import ipaddress
 import json
 import logging
+import re
 import sys
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 import psutil
 import rich
@@ -234,6 +237,30 @@ def add_common_arguments(parser):
         type=str,
         default=None,
         help="Comma-separated list of issue codes to ignore (e.g. W001,W015)",
+    )
+    parser.add_argument(
+        "--trusted-urls",
+        type=str,
+        default=None,
+        metavar="PATTERNS",
+        help=(
+            "Comma-separated list of trusted hosts. Matching is host-aware: "
+            "domains match the host or any subdomain (e.g. 'nexus.corp', '*.internal'); "
+            "IPs/CIDRs match by address (e.g. '10.0.0.0/8', '192.168.1.5'). "
+            "Findings for E005, W011, and W012 are suppressed only when every URL "
+            "they cite resolves to a trusted host."
+        ),
+    )
+    parser.add_argument(
+        "--trusted-urls-file",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to a JSON file containing trusted hosts. "
+            'Expected format: {"trusted_urls": ["nexus.corp", "*.internal", "10.0.0.0/8"]}. '
+            "Combined with --trusted-urls if both are provided."
+        ),
     )
 
 
@@ -845,6 +872,142 @@ def _apply_ignore_codes(result: list[ScanPathResult], ignore_codes: set[str]) ->
         scan_result.issues = [i for i in scan_result.issues if i.code not in ignore_codes]
 
 
+# Issue codes that carry URL evidence and are candidates for trusted-URL suppression.
+_URL_BEARING_CODES = frozenset({"E005", "W011", "W012"})
+
+# Extract http(s) URLs from a free-text issue message. Stops at whitespace and
+# common message-punctuation delimiters so trailing quotes/brackets/commas in the
+# surrounding prose are not pulled into the host.
+_URL_RE = re.compile(r"https?://[^\s'\"<>)\]}]+", re.IGNORECASE)
+
+
+def _classify_trusted_patterns(
+    patterns: list[str],
+) -> tuple[list[ipaddress.IPv4Network | ipaddress.IPv6Network], list[str]]:
+    """Split raw trusted patterns into IP networks and domain suffixes.
+
+    A pattern that parses as an IP or CIDR (e.g. ``10.0.0.0/8``, ``192.168.1.5``)
+    becomes a network; everything else is treated as a domain suffix. A leading
+    ``*.`` glob is stripped (``*.internal`` -> ``internal``).
+    """
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    domains: list[str] = []
+    for raw in patterns:
+        p = raw.strip().lower()
+        if not p:
+            continue
+        if p.startswith("*."):
+            p = p[2:]
+        try:
+            networks.append(ipaddress.ip_network(p, strict=False))
+            continue
+        except ValueError:
+            pass
+        domains.append(p)
+    return networks, domains
+
+
+def _host_is_trusted(
+    host: str,
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+    domains: list[str],
+) -> bool:
+    """True if ``host`` is an IP inside a trusted network, or a trusted domain/subdomain."""
+    if not host:
+        return False
+    host = host.lower().strip("[]")  # strip IPv6 literal brackets
+    try:
+        ip = ipaddress.ip_address(host)
+        return any(ip in net for net in networks)
+    except ValueError:
+        pass
+    # Exact host or a subdomain of a trusted domain (suffix match on a label
+    # boundary, so "internal" does NOT match "internal.attacker.io").
+    return any(host == d or host.endswith("." + d) for d in domains)
+
+
+def _message_urls_all_trusted(
+    message: str,
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+    domains: list[str],
+) -> bool:
+    """True only if every URL in ``message`` resolves to a trusted host.
+
+    Fails closed: a message with no parseable URL, or any single untrusted URL,
+    is not suppressed.
+    """
+    urls = _URL_RE.findall(message)
+    if not urls:
+        return False
+    return all(_host_is_trusted(urlparse(url).hostname or "", networks, domains) for url in urls)
+
+
+def _load_trusted_urls(args) -> list[str]:
+    """Merge trusted URL patterns from --trusted-urls and --trusted-urls-file."""
+    patterns: list[str] = []
+
+    flag_value = getattr(args, "trusted_urls", None)
+    if flag_value:
+        patterns.extend(p.strip() for p in flag_value.split(",") if p.strip())
+
+    file_path = getattr(args, "trusted_urls_file", None)
+    if file_path:
+        try:
+            with open(file_path) as f:
+                data = json.load(f)
+            if not isinstance(data, dict) or "trusted_urls" not in data:
+                rich.print(
+                    f"[bold red]Error: --trusted-urls-file must contain a JSON object with a "
+                    f'"trusted_urls" list (got: {type(data).__name__}).[/bold red]',
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            file_patterns = data["trusted_urls"]
+            if not isinstance(file_patterns, list):
+                rich.print(
+                    '[bold red]Error: "trusted_urls" in --trusted-urls-file must be a list.[/bold red]',
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            patterns.extend(p for p in file_patterns if isinstance(p, str) and p.strip())
+        except FileNotFoundError:
+            rich.print(
+                f"[bold red]Error: --trusted-urls-file not found: {file_path}[/bold red]",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        except json.JSONDecodeError as e:
+            rich.print(
+                f"[bold red]Error: --trusted-urls-file is not valid JSON: {e}[/bold red]",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    return patterns
+
+
+def _apply_trusted_urls(result: list[ScanPathResult], trusted_urls: list[str]) -> None:
+    """Suppress URL-bearing findings whose URLs all resolve to trusted hosts.
+
+    Matching is host-aware: each URL in the finding message is parsed and its
+    host compared against trusted IP networks (CIDR/IP) and domain suffixes,
+    rather than a raw substring test against the whole message. A finding is
+    suppressed only when *every* URL it cites is trusted.
+    """
+    if not trusted_urls:
+        return
+    networks, domains = _classify_trusted_patterns(trusted_urls)
+    if not networks and not domains:
+        return
+    for scan_result in result:
+        scan_result.issues = [
+            issue
+            for issue in scan_result.issues
+            if issue.code not in _URL_BEARING_CODES
+            or not _message_urls_all_trusted(issue.message, networks, domains)
+        ]
+
+
 def _handle_ci_exit(result: list[ScanPathResult], json_output: bool, ignore_codes: set[str]) -> None:
     """In CI mode, exit with code 1 if any issues or unignored failures remain."""
     has_issues = any(scan_result.issues for scan_result in result)
@@ -872,12 +1035,16 @@ async def print_scan_inspect(mode="scan", args=None):
     verbose: bool = hasattr(args, "verbose") and args.verbose
     ci_mode: bool = hasattr(args, "ci") and args.ci
     ignore_codes = _parse_ignore_codes(args, ci_mode)
+    trusted_urls = _load_trusted_urls(args)
 
     if json_output:
         with suppress_stdout():
             result = await run_scan(args, mode=mode)
     else:
         result = await run_scan(args, mode=mode)
+
+    if trusted_urls:
+        _apply_trusted_urls(result, trusted_urls)
 
     if ci_mode and ignore_codes:
         _apply_ignore_codes(result, ignore_codes)

--- a/tests/unit/test_trusted_urls.py
+++ b/tests/unit/test_trusted_urls.py
@@ -1,0 +1,190 @@
+"""Tests for the --trusted-urls / --trusted-urls-file finding-suppression feature."""
+
+import json
+from argparse import Namespace
+
+import pytest
+
+from agent_scan.cli import (
+    _apply_trusted_urls,
+    _classify_trusted_patterns,
+    _host_is_trusted,
+    _load_trusted_urls,
+    _message_urls_all_trusted,
+)
+from agent_scan.models import Issue, ScanPathResult
+
+
+def _result(path: str, *issues: Issue) -> ScanPathResult:
+    return ScanPathResult(path=path, issues=list(issues))
+
+
+class TestClassifyTrustedPatterns:
+    def test_splits_networks_and_domains(self):
+        networks, domains = _classify_trusted_patterns(
+            ["nexus.corp", "10.0.0.0/8", "192.168.1.5", "artifacts.internal"]
+        )
+        assert [str(n) for n in networks] == ["10.0.0.0/8", "192.168.1.5/32"]
+        assert domains == ["nexus.corp", "artifacts.internal"]
+
+    def test_strips_glob_prefix_and_lowercases(self):
+        networks, domains = _classify_trusted_patterns(["*.Internal", "  Nexus.CORP  "])
+        assert networks == []
+        assert domains == ["internal", "nexus.corp"]
+
+    def test_ignores_blank_patterns(self):
+        networks, domains = _classify_trusted_patterns(["", "  ", "nexus.corp"])
+        assert networks == []
+        assert domains == ["nexus.corp"]
+
+
+class TestHostIsTrusted:
+    @pytest.fixture
+    def buckets(self):
+        return _classify_trusted_patterns(["nexus.corp", "*.internal", "10.0.0.0/8"])
+
+    def test_exact_domain(self, buckets):
+        assert _host_is_trusted("nexus.corp", *buckets)
+
+    def test_subdomain_of_trusted_domain(self, buckets):
+        assert _host_is_trusted("artifacts.internal", *buckets)
+
+    def test_ip_inside_cidr(self, buckets):
+        assert _host_is_trusted("10.5.5.5", *buckets)
+
+    def test_ip_outside_cidr(self, buckets):
+        assert not _host_is_trusted("172.16.0.1", *buckets)
+
+    def test_empty_host(self, buckets):
+        assert not _host_is_trusted("", *buckets)
+
+    # --- substring traps the old `pattern in message` logic would have allowed ---
+
+    def test_lookalike_domain_not_trusted(self, buckets):
+        # "corp" is a substring of "evil-corp.com" but not a label-boundary match.
+        assert not _host_is_trusted("evil-corp.com", *buckets)
+
+    def test_label_boundary_trap_not_trusted(self, buckets):
+        # "internal" is a prefix label of "internal.attacker.io" — must NOT match.
+        assert not _host_is_trusted("internal.attacker.io", *buckets)
+
+    def test_ipv6_brackets_stripped(self):
+        networks, domains = _classify_trusted_patterns(["::1/128"])
+        assert _host_is_trusted("[::1]", networks, domains)
+
+
+class TestMessageUrlsAllTrusted:
+    @pytest.fixture
+    def buckets(self):
+        return _classify_trusted_patterns(["nexus.corp", "*.internal", "10.0.0.0/8"])
+
+    def test_single_trusted_url(self, buckets):
+        assert _message_urls_all_trusted("Suspicious download http://nexus.corp/install.sh", *buckets)
+
+    def test_single_untrusted_url(self, buckets):
+        assert not _message_urls_all_trusted("Download http://evil.com/x.sh", *buckets)
+
+    def test_all_urls_must_be_trusted(self, buckets):
+        msg = "Two urls http://nexus.corp/a and http://evil.com/b"
+        assert not _message_urls_all_trusted(msg, *buckets)
+
+    def test_fails_closed_when_no_url(self, buckets):
+        assert not _message_urls_all_trusted("No url here at all", *buckets)
+
+    def test_trailing_punctuation_not_part_of_host(self, buckets):
+        # The closing paren/quote must not be swallowed into the host.
+        assert _message_urls_all_trusted('Fetch from "http://artifacts.internal/tool.sh".', *buckets)
+
+
+class TestApplyTrustedUrls:
+    def test_suppresses_matching_url_bearing_code(self):
+        result = [
+            _result(
+                "/p",
+                Issue(code="E005", message="Suspicious download http://nexus.corp/x.sh", reference=None),
+            )
+        ]
+        _apply_trusted_urls(result, ["nexus.corp"])
+        assert result[0].issues == []
+
+    def test_keeps_untrusted_url(self):
+        issue = Issue(code="E005", message="Download http://evil.com/x.sh", reference=None)
+        result = [_result("/p", issue)]
+        _apply_trusted_urls(result, ["nexus.corp"])
+        assert result[0].issues == [issue]
+
+    def test_does_not_touch_non_url_codes(self):
+        # A prompt-injection finding that happens to mention a trusted host must survive.
+        issue = Issue(code="E001", message="Prompt injection referencing http://nexus.corp", reference=None)
+        result = [_result("/p", issue)]
+        _apply_trusted_urls(result, ["nexus.corp"])
+        assert result[0].issues == [issue]
+
+    def test_noop_when_no_patterns(self):
+        issue = Issue(code="E005", message="http://nexus.corp/x.sh", reference=None)
+        result = [_result("/p", issue)]
+        _apply_trusted_urls(result, [])
+        assert result[0].issues == [issue]
+
+    def test_w011_and_w012_are_in_scope(self):
+        result = [
+            _result(
+                "/p",
+                Issue(code="W011", message="Untrusted content http://nexus.corp/feed", reference=None),
+                Issue(code="W012", message="Remote dep http://nexus.corp/cfg", reference=None),
+            )
+        ]
+        _apply_trusted_urls(result, ["nexus.corp"])
+        assert result[0].issues == []
+
+
+class TestLoadTrustedUrls:
+    def test_flag_only(self):
+        args = Namespace(trusted_urls="nexus.corp, 10.0.0.0/8 ", trusted_urls_file=None)
+        assert _load_trusted_urls(args) == ["nexus.corp", "10.0.0.0/8"]
+
+    def test_file_only(self, tmp_path):
+        f = tmp_path / "trusted.json"
+        f.write_text(json.dumps({"trusted_urls": ["nexus.corp", "*.internal"]}))
+        args = Namespace(trusted_urls=None, trusted_urls_file=str(f))
+        assert _load_trusted_urls(args) == ["nexus.corp", "*.internal"]
+
+    def test_flag_and_file_merged(self, tmp_path):
+        f = tmp_path / "trusted.json"
+        f.write_text(json.dumps({"trusted_urls": ["artifacts.internal"]}))
+        args = Namespace(trusted_urls="nexus.corp", trusted_urls_file=str(f))
+        assert _load_trusted_urls(args) == ["nexus.corp", "artifacts.internal"]
+
+    def test_no_sources(self):
+        args = Namespace(trusted_urls=None, trusted_urls_file=None)
+        assert _load_trusted_urls(args) == []
+
+    def test_missing_file_exits(self, tmp_path):
+        args = Namespace(trusted_urls=None, trusted_urls_file=str(tmp_path / "nope.json"))
+        with pytest.raises(SystemExit) as exc:
+            _load_trusted_urls(args)
+        assert exc.value.code == 2
+
+    def test_invalid_json_exits(self, tmp_path):
+        f = tmp_path / "bad.json"
+        f.write_text("{not json")
+        args = Namespace(trusted_urls=None, trusted_urls_file=str(f))
+        with pytest.raises(SystemExit) as exc:
+            _load_trusted_urls(args)
+        assert exc.value.code == 2
+
+    def test_wrong_shape_exits(self, tmp_path):
+        f = tmp_path / "shape.json"
+        f.write_text(json.dumps(["nexus.corp"]))  # list, not {"trusted_urls": [...]}
+        args = Namespace(trusted_urls=None, trusted_urls_file=str(f))
+        with pytest.raises(SystemExit) as exc:
+            _load_trusted_urls(args)
+        assert exc.value.code == 2
+
+    def test_trusted_urls_not_a_list_exits(self, tmp_path):
+        f = tmp_path / "shape2.json"
+        f.write_text(json.dumps({"trusted_urls": "nexus.corp"}))
+        args = Namespace(trusted_urls=None, trusted_urls_file=str(f))
+        with pytest.raises(SystemExit) as exc:
+            _load_trusted_urls(args)
+        assert exc.value.code == 2

--- a/tests/unit/test_trusted_urls.py
+++ b/tests/unit/test_trusted_urls.py
@@ -37,6 +37,14 @@ class TestClassifyTrustedPatterns:
         assert networks == []
         assert domains == ["nexus.corp"]
 
+    def test_bare_glob_does_not_produce_empty_domain(self):
+        # "*." strips to "" — must not become a trusted domain (would match
+        # almost any host via endswith(".")).
+        networks, domains = _classify_trusted_patterns(["*.", " *. ", "nexus.corp"])
+        assert networks == []
+        assert "" not in domains
+        assert domains == ["nexus.corp"]
+
 
 class TestHostIsTrusted:
     @pytest.fixture
@@ -71,6 +79,16 @@ class TestHostIsTrusted:
     def test_ipv6_brackets_stripped(self):
         networks, domains = _classify_trusted_patterns(["::1/128"])
         assert _host_is_trusted("[::1]", networks, domains)
+
+    def test_trailing_dot_fqdn_matches(self, buckets):
+        # A fully-qualified host with a trailing dot must match the trusted domain.
+        assert _host_is_trusted("nexus.corp.", *buckets)
+        assert _host_is_trusted("artifacts.internal.", *buckets)
+
+    def test_bare_glob_pattern_does_not_match_arbitrary_host(self):
+        # Regression: "*." must not be usable to trust everything.
+        networks, domains = _classify_trusted_patterns(["*."])
+        assert not _host_is_trusted("anything.evil.com", networks, domains)
 
 
 class TestMessageUrlsAllTrusted:


### PR DESCRIPTION
Skills and MCP servers that reference internal infrastructure (private artifact servers, internal registries) trigger CRITICAL E005 "Suspicious download URL" and W011/W012 findings, because the analysis backend treats any non-public domain as an "unknown/untrusted" download source. There was no way for operators to assert that a given host is internal and trusted.

This adds two flags:
  --trusted-urls        comma-separated trusted hosts
  --trusted-urls-file   JSON file: {"trusted_urls": [...]}

Matching is host-aware, not a raw substring test: each URL in a finding's message is parsed and its host compared against trusted IP networks (CIDR/IP) and domain suffixes. Trusting "acme.net" matches acme.net and *.acme.net but NOT evil-acme.net.attacker.io. A finding is suppressed only when every URL it cites is trusted, and only for the URL-bearing codes E005/W011/W012 — prompt-injection and malware codes are never touched.

The filter runs on the post-scan display/CI path, mirroring the existing --ignore-issues-codes behaviour (silent removal, no new logging).

Note for reviewers with backend access: the URL extractor is tolerant of free-text phrasing, but the exact E005 message string was not verified end-to-end (no SNYK_TOKEN available during development).