### PR TITLE
feat: discover Cursor's built-in/managed skills

### DIFF
--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -269,15 +269,6 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
     # Cursor and Windsurf are verified on disk — every other entry is INFERRED
     # and tagged ``inferred — verify`` at its definition. See ADS-367.
     _builtin_extension_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {}
-    # Per-OS templates for the editor's *built-in* (bundled) skills directory — a
-    # ``skills`` folder shipped directly inside the application install (NOT under
-    # extensions). Keyed by the normalized platform ("darwin"/"win32"/"linux");
-    # ``~``-prefixed entries expand against the scanned user's home, absolute
-    # entries are used as-is. Empty by default so each fork opts in; a platform
-    # absent from a fork's map is a documented coverage gap. Cursor ships built-in
-    # skills (e.g. ``/migrate-to-skills``, ``/loop``) directly in
-    # ``resources/app/skills`` as of Cursor 2.4. See cursor.com/docs/skills.
-    _builtin_skills_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {}
     # Home-relative ``settings.json`` files that may carry MCP under a top-level
     # ``mcpServers``/``mcp`` key (e.g. Antigravity's ``~/.gemini/settings.json``).
     # Parsed with the same presence-gate as ``_discover_user_settings_mcp``.
@@ -329,7 +320,6 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         result.update(self._discover_system_skills_dirs())
         result.update(self._discover_workspace_skills())
         result.update(self._discover_extension_skills())
-        result.update(self._discover_builtin_skills())
         result.update(self._discover_settings_skill_locations())
         result.update(self._discover_code_workspace_skills())
         return result
@@ -738,23 +728,6 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
             expand_path(Path(raw), self.home_directory) for raw in self._builtin_extension_dir_templates.get(key, ())
         ]
 
-    def _builtin_skills_dirs(self) -> list[Path]:
-        """Absolute paths to the editor's *built-in* (bundled) skills dir(s).
-
-        These live directly inside the application install (e.g. Cursor ships
-        ``resources/app/skills`` with skills like ``/migrate-to-skills`` and
-        ``/loop`` as of Cursor 2.4), NOT under the extensions tree. They are
-        machine-global but the per-user install variants (e.g. macOS
-        ``~/Applications``) are expressed ``~``-relative and expand against the
-        scanned user's home. Resolved from :attr:`_builtin_skills_dir_templates`
-        for the current platform; empty when the fork declares nothing for it
-        (a documented coverage gap).
-        """
-        key = "linux" if sys.platform in ("linux", "linux2") else sys.platform
-        return [
-            expand_path(Path(raw), self.home_directory) for raw in self._builtin_skills_dir_templates.get(key, ())
-        ]
-
     # --- private: install-manifest gating (don't scan uninstalled extensions) ---
 
     @staticmethod
@@ -886,25 +859,6 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
             for skills_dir in _walk_under_depth(root, "skills", _MAX_PLUGIN_RGLOB_DEPTH, want_file=False):
                 if skills_dir.is_dir():
                     result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
-        return result
-
-    def _discover_builtin_skills(self) -> SkillsDirsResult:
-        """Scan the application-bundled (built-in) skills directories from
-        :meth:`_builtin_skills_dirs`.
-
-        Unlike the extension walk, the built-in skills directory is a flat
-        ``skills/`` folder directly inside the app install (e.g. Cursor's
-        ``resources/app/skills``). It is treated as an unmanaged root —
-        every present subdir that carries a ``SKILL.md`` is a skill. The dir
-        itself (e.g. ``…/resources/app/skills``) is passed directly to
-        :meth:`_scan_skills_dir`, which calls ``inspect_skills_dir`` and skips
-        absent or unreadable paths gracefully.
-        """
-        result: SkillsDirsResult = {}
-        for skills_dir in self._builtin_skills_dirs():
-            entries = self._scan_skills_dir(skills_dir)
-            if entries is not None:
-                result[skills_dir.as_posix()] = entries
         return result
 
     # --- private: chat.agentSkillsLocations ---

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -269,6 +269,15 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
     # Cursor and Windsurf are verified on disk — every other entry is INFERRED
     # and tagged ``inferred — verify`` at its definition. See ADS-367.
     _builtin_extension_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {}
+    # Per-OS templates for the editor's *built-in* (bundled) skills directory — a
+    # ``skills`` folder shipped directly inside the application install (NOT under
+    # extensions). Keyed by the normalized platform ("darwin"/"win32"/"linux");
+    # ``~``-prefixed entries expand against the scanned user's home, absolute
+    # entries are used as-is. Empty by default so each fork opts in; a platform
+    # absent from a fork's map is a documented coverage gap. Cursor ships built-in
+    # skills (e.g. ``/migrate-to-skills``, ``/loop``) directly in
+    # ``resources/app/skills`` as of Cursor 2.4. See cursor.com/docs/skills.
+    _builtin_skills_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {}
     # Home-relative ``settings.json`` files that may carry MCP under a top-level
     # ``mcpServers``/``mcp`` key (e.g. Antigravity's ``~/.gemini/settings.json``).
     # Parsed with the same presence-gate as ``_discover_user_settings_mcp``.
@@ -320,6 +329,7 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         result.update(self._discover_system_skills_dirs())
         result.update(self._discover_workspace_skills())
         result.update(self._discover_extension_skills())
+        result.update(self._discover_builtin_skills())
         result.update(self._discover_settings_skill_locations())
         result.update(self._discover_code_workspace_skills())
         return result
@@ -728,6 +738,23 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
             expand_path(Path(raw), self.home_directory) for raw in self._builtin_extension_dir_templates.get(key, ())
         ]
 
+    def _builtin_skills_dirs(self) -> list[Path]:
+        """Absolute paths to the editor's *built-in* (bundled) skills dir(s).
+
+        These live directly inside the application install (e.g. Cursor ships
+        ``resources/app/skills`` with skills like ``/migrate-to-skills`` and
+        ``/loop`` as of Cursor 2.4), NOT under the extensions tree. They are
+        machine-global but the per-user install variants (e.g. macOS
+        ``~/Applications``) are expressed ``~``-relative and expand against the
+        scanned user's home. Resolved from :attr:`_builtin_skills_dir_templates`
+        for the current platform; empty when the fork declares nothing for it
+        (a documented coverage gap).
+        """
+        key = "linux" if sys.platform in ("linux", "linux2") else sys.platform
+        return [
+            expand_path(Path(raw), self.home_directory) for raw in self._builtin_skills_dir_templates.get(key, ())
+        ]
+
     # --- private: install-manifest gating (don't scan uninstalled extensions) ---
 
     @staticmethod
@@ -859,6 +886,25 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
             for skills_dir in _walk_under_depth(root, "skills", _MAX_PLUGIN_RGLOB_DEPTH, want_file=False):
                 if skills_dir.is_dir():
                     result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
+        return result
+
+    def _discover_builtin_skills(self) -> SkillsDirsResult:
+        """Scan the application-bundled (built-in) skills directories from
+        :meth:`_builtin_skills_dirs`.
+
+        Unlike the extension walk, the built-in skills directory is a flat
+        ``skills/`` folder directly inside the app install (e.g. Cursor's
+        ``resources/app/skills``). It is treated as an unmanaged root —
+        every present subdir that carries a ``SKILL.md`` is a skill. The dir
+        itself (e.g. ``…/resources/app/skills``) is passed directly to
+        :meth:`_scan_skills_dir`, which calls ``inspect_skills_dir`` and skips
+        absent or unreadable paths gracefully.
+        """
+        result: SkillsDirsResult = {}
+        for skills_dir in self._builtin_skills_dirs():
+            entries = self._scan_skills_dir(skills_dir)
+            if entries is not None:
+                result[skills_dir.as_posix()] = entries
         return result
 
     # --- private: chat.agentSkillsLocations ---

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -1,6 +1,5 @@
 """Cursor discoverer."""
 
-import sys
 from pathlib import Path
 from typing import ClassVar
 
@@ -35,13 +34,12 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
         ".codex/skills",
     )
     # Per cursor.com/docs/skills the same four paths apply at the user/home level
-    # for skills available across all workspaces.
-    # ``~/.cursor/skills-cursor/`` is not documented but observed on disk as
-    # the location Cursor uses for its own built-in (synced/managed) skills at
-    # the user level — distinct from user-authored ``~/.cursor/skills/``.
+    # for skills available across all workspaces. (Cursor's own synced built-in /
+    # managed skills live separately at ``~/.cursor/skills-cursor`` — scanned via
+    # ``_builtin_skills_dir_paths`` below, kept out of this tuple to avoid a
+    # double scan.)
     _skills_dir_paths = (
         "~/.cursor/skills",
-        "~/.cursor/skills-cursor",
         "~/.agents/skills",
         "~/.claude/skills",
         "~/.codex/skills",
@@ -60,31 +58,24 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
         # is omitted.
         "linux": ("/usr/share/cursor/resources/app/extensions",),
     }
-    # Per-OS paths to the app-bundled ``skills/`` directory, parallel to
-    # ``resources/app/extensions`` above. Cursor 2.4 introduced built-in skills
-    # (``/migrate-to-skills``); later versions added more (``/loop``,
-    # ``/multitask``, ``/review``, …). No other VSCode-family fork ships a
-    # standalone app-level skills dir, so this is Cursor-specific rather than a
-    # base-class extension point. See cursor.com/docs/skills.
-    _builtin_skills_dir_paths: ClassVar[dict[str, tuple[str, ...]]] = {
-        "darwin": (
-            "/Applications/Cursor.app/Contents/Resources/app/skills",  # inferred — verify: mirrors extensions layout
-            "~/Applications/Cursor.app/Contents/Resources/app/skills",  # inferred — verify (user-local install)
-        ),
-        # inferred — verify: per-user NSIS install; mirrors extensions layout.
-        "win32": ("~/AppData/Local/Programs/Cursor/resources/app/skills",),
-        # inferred — verify: deb install root; mirrors extensions layout.
-        # The Linux AppImage build has no stable path and is omitted.
-        "linux": ("/usr/share/cursor/resources/app/skills",),
-    }
+    # Cursor's own built-in / managed skills (``migrate-to-skills``, ``loop``,
+    # ``review``, …) are not user-authored: Cursor *syncs* them into
+    # ``~/.cursor/skills-cursor`` at the user level (alongside
+    # ``.cursor-managed-skills-manifest.json`` / ``.sync-manifest.json``),
+    # distinct from the user-authored ``~/.cursor/skills``. Home-relative and the
+    # same on every OS (Cursor's user dir is ``~/.cursor`` everywhere), so this is
+    # a flat tuple rather than the per-OS map ``_builtin_extension_dir_templates``
+    # above needs. Kept out of ``_skills_dir_paths`` so the dir is scanned once,
+    # not twice. No other VSCode-family fork ships such a dir. See
+    # cursor.com/docs/skills.
+    _builtin_skills_dir_paths: ClassVar[tuple[str, ...]] = ("~/.cursor/skills-cursor",)
 
     def _builtin_skills_dirs(self) -> list[Path]:
-        """Resolve the per-OS app-bundled skills directories for this install."""
-        key = "linux" if sys.platform in ("linux", "linux2") else sys.platform
-        return [expand_path(Path(raw), self.home_directory) for raw in self._builtin_skills_dir_paths.get(key, ())]
+        """Resolve the home-relative built-in / managed skills directories."""
+        return [expand_path(Path(raw), self.home_directory) for raw in self._builtin_skills_dir_paths]
 
     def _discover_builtin_skills(self) -> SkillsDirsResult:
-        """Scan the Cursor app-bundled skills directories (``resources/app/skills``)."""
+        """Scan Cursor's synced built-in / managed skills dir(s) (``~/.cursor/skills-cursor``)."""
         result: SkillsDirsResult = {}
         for skills_dir in self._builtin_skills_dirs():
             entries = self._scan_skills_dir(skills_dir)

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -81,10 +81,7 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
     def _builtin_skills_dirs(self) -> list[Path]:
         """Resolve the per-OS app-bundled skills directories for this install."""
         key = "linux" if sys.platform in ("linux", "linux2") else sys.platform
-        return [
-            expand_path(Path(raw), self.home_directory)
-            for raw in self._builtin_skills_dir_paths.get(key, ())
-        ]
+        return [expand_path(Path(raw), self.home_directory) for raw in self._builtin_skills_dir_paths.get(key, ())]
 
     def _discover_builtin_skills(self) -> SkillsDirsResult:
         """Scan the Cursor app-bundled skills directories (``resources/app/skills``)."""

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -82,10 +82,16 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
             for raw in self._builtin_skills_dir_paths.get(key, ())
         ]
 
-    def discover_skills(self) -> SkillsDirsResult:
-        result = super().discover_skills()
+    def _discover_builtin_skills(self) -> SkillsDirsResult:
+        """Scan the Cursor app-bundled skills directories (``resources/app/skills``)."""
+        result: SkillsDirsResult = {}
         for skills_dir in self._builtin_skills_dirs():
             entries = self._scan_skills_dir(skills_dir)
             if entries is not None:
                 result[skills_dir.as_posix()] = entries
+        return result
+
+    def discover_skills(self) -> SkillsDirsResult:
+        result = super().discover_skills()
+        result.update(self._discover_builtin_skills())
         return result

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -36,8 +36,12 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
     )
     # Per cursor.com/docs/skills the same four paths apply at the user/home level
     # for skills available across all workspaces.
+    # ``~/.cursor/skills-cursor/`` is not documented but observed on disk as
+    # the location Cursor uses for its own built-in (synced/managed) skills at
+    # the user level — distinct from user-authored ``~/.cursor/skills/``.
     _skills_dir_paths = (
         "~/.cursor/skills",
+        "~/.cursor/skills-cursor",
         "~/.agents/skills",
         "~/.claude/skills",
         "~/.codex/skills",

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -1,8 +1,11 @@
 """Cursor discoverer."""
 
+import sys
+from pathlib import Path
 from typing import ClassVar
 
-from agent_scan.agents.vscode.base import VSCodeFamilyDiscoverer
+from agent_scan.agents.vscode.base import SkillsDirsResult, VSCodeFamilyDiscoverer
+from agent_scan.well_known_clients import expand_path
 
 
 class CursorDiscoverer(VSCodeFamilyDiscoverer):
@@ -53,14 +56,13 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
         # is omitted.
         "linux": ("/usr/share/cursor/resources/app/extensions",),
     }
-    # Built-in (bundled) skills shipped directly inside the Cursor application —
-    # at ``resources/app/skills``, parallel to ``resources/app/extensions``.
-    # Cursor 2.4 introduced built-in skills (``/migrate-to-skills``); later
-    # versions added more (``/loop``, ``/multitask``, ``/review``, …). These live
-    # in the app bundle, NOT under a user extensions dir, so they need their own
-    # discovery path separate from ``_builtin_extension_dir_templates``.
-    # See cursor.com/docs/skills ("Migrating rules and commands to skills").
-    _builtin_skills_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {
+    # Per-OS paths to the app-bundled ``skills/`` directory, parallel to
+    # ``resources/app/extensions`` above. Cursor 2.4 introduced built-in skills
+    # (``/migrate-to-skills``); later versions added more (``/loop``,
+    # ``/multitask``, ``/review``, …). No other VSCode-family fork ships a
+    # standalone app-level skills dir, so this is Cursor-specific rather than a
+    # base-class extension point. See cursor.com/docs/skills.
+    _builtin_skills_dir_paths: ClassVar[dict[str, tuple[str, ...]]] = {
         "darwin": (
             "/Applications/Cursor.app/Contents/Resources/app/skills",  # inferred — verify: mirrors extensions layout
             "~/Applications/Cursor.app/Contents/Resources/app/skills",  # inferred — verify (user-local install)
@@ -71,3 +73,19 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
         # The Linux AppImage build has no stable path and is omitted.
         "linux": ("/usr/share/cursor/resources/app/skills",),
     }
+
+    def _builtin_skills_dirs(self) -> list[Path]:
+        """Resolve the per-OS app-bundled skills directories for this install."""
+        key = "linux" if sys.platform in ("linux", "linux2") else sys.platform
+        return [
+            expand_path(Path(raw), self.home_directory)
+            for raw in self._builtin_skills_dir_paths.get(key, ())
+        ]
+
+    def discover_skills(self) -> SkillsDirsResult:
+        result = super().discover_skills()
+        for skills_dir in self._builtin_skills_dirs():
+            entries = self._scan_skills_dir(skills_dir)
+            if entries is not None:
+                result[skills_dir.as_posix()] = entries
+        return result

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -53,3 +53,21 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
         # is omitted.
         "linux": ("/usr/share/cursor/resources/app/extensions",),
     }
+    # Built-in (bundled) skills shipped directly inside the Cursor application —
+    # at ``resources/app/skills``, parallel to ``resources/app/extensions``.
+    # Cursor 2.4 introduced built-in skills (``/migrate-to-skills``); later
+    # versions added more (``/loop``, ``/multitask``, ``/review``, …). These live
+    # in the app bundle, NOT under a user extensions dir, so they need their own
+    # discovery path separate from ``_builtin_extension_dir_templates``.
+    # See cursor.com/docs/skills ("Migrating rules and commands to skills").
+    _builtin_skills_dir_templates: ClassVar[dict[str, tuple[str, ...]]] = {
+        "darwin": (
+            "/Applications/Cursor.app/Contents/Resources/app/skills",  # inferred — verify: mirrors extensions layout
+            "~/Applications/Cursor.app/Contents/Resources/app/skills",  # inferred — verify (user-local install)
+        ),
+        # inferred — verify: per-user NSIS install; mirrors extensions layout.
+        "win32": ("~/AppData/Local/Programs/Cursor/resources/app/skills",),
+        # inferred — verify: deb install root; mirrors extensions layout.
+        # The Linux AppImage build has no stable path and is omitted.
+        "linux": ("/usr/share/cursor/resources/app/skills",),
+    }

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -5694,9 +5694,7 @@ def test_cursor_builtin_skills_discovered_in_discover_skills(tmp_path, monkeypat
     )
     loop_skill = app_skills / "loop"
     loop_skill.mkdir(parents=True)
-    (loop_skill / "SKILL.md").write_text(
-        "---\nname: loop\ndescription: Run a prompt on a schedule.\n---\n\nbody\n"
-    )
+    (loop_skill / "SKILL.md").write_text("---\nname: loop\ndescription: Run a prompt on a schedule.\n---\n\nbody\n")
     (tmp_path / ".cursor").mkdir()
 
     discoverer = CursorDiscoverer(tmp_path)
@@ -5726,7 +5724,7 @@ def test_cursor_builtin_skills_absent_dir_not_surfaced(tmp_path, monkeypatch):
     skills_dirs = discoverer.discover_skills()
 
     assert absent.as_posix() not in skills_dirs, (
-        "absent built-in skills dir must not produce a key; got: {list(skills_dirs)}"
+        f"absent built-in skills dir must not produce a key; got: {list(skills_dirs)}"
     )
 
 
@@ -5788,6 +5786,46 @@ def test_cursor_builtin_skills_dirs_empty_on_unsupported_platform(tmp_path, monk
     monkeypatch.setattr(cursor_mod.sys, "platform", "sunos5")
 
     assert CursorDiscoverer(tmp_path)._builtin_skills_dirs() == []
+
+
+# ---------------------------------------------------------------------------
+# Cursor managed/synced skills (``~/.cursor/skills-cursor``)
+# ---------------------------------------------------------------------------
+# Cursor delivers its own built-in/managed skills (``migrate-to-skills``,
+# ``loop``, ``review``, …) by *syncing* them into ``~/.cursor/skills-cursor``,
+# distinct from the user-authored ``~/.cursor/skills``. The dir is declared in
+# ``_skills_dir_paths`` so it flows through the standard home-skills scan
+# (``_discover_home_skills_dirs``) — no bespoke wiring.
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_skills_cursor_declared_in_skills_dir_paths():
+    """``~/.cursor/skills-cursor`` is declared among CursorDiscoverer's home skill
+    paths, alongside the user-authored ``~/.cursor/skills``."""
+    from agent_scan.agents import CursorDiscoverer
+
+    assert "~/.cursor/skills-cursor" in CursorDiscoverer._skills_dir_paths
+    assert "~/.cursor/skills" in CursorDiscoverer._skills_dir_paths
+
+
+def test_cursor_skills_cursor_dir_discovered(tmp_path):
+    """Skills synced into ``~/.cursor/skills-cursor`` are surfaced by
+    ``discover_skills`` under their own key — exercises the real
+    ``_skills_dir_paths`` wiring (no mock), so it guards the path staying live."""
+    from agent_scan.agents import CursorDiscoverer
+
+    skills_cursor = tmp_path / ".cursor" / "skills-cursor"
+    for name in ("migrate-to-skills", "loop"):
+        skill = skills_cursor / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"---\nname: {name}\ndescription: Cursor managed skill {name}.\n---\n\nbody\n")
+
+    skills_dirs = CursorDiscoverer(tmp_path).discover_skills()
+
+    key = skills_cursor.as_posix()
+    assert key in skills_dirs, f"~/.cursor/skills-cursor must be surfaced; got: {list(skills_dirs)}"
+    skill_names = {name for name, _ in skills_dirs[key]}
+    assert {"migrate-to-skills", "loop"} <= skill_names, f"managed skills must be discovered; got: {skill_names}"
 
 
 # --- _walk_under_depth: PermissionError tolerance (--scan-all-users) ---

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -5645,67 +5645,71 @@ def test_vscode_builtin_extension_dirs_per_platform(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Cursor built-in (application-bundled) skills
+# Cursor built-in / managed skills (``~/.cursor/skills-cursor``)
 # ---------------------------------------------------------------------------
-# Cursor ships built-in skills (``/migrate-to-skills``, ``/loop``, etc.) directly
-# in the application bundle at ``resources/app/skills``, NOT inside an extension
-# subdir. No other VSCode-family fork does this, so the logic lives entirely in
-# CursorDiscoverer: ``_builtin_skills_dir_paths`` (class-level path map) →
-# ``_builtin_skills_dirs()`` → overridden ``discover_skills()``.
-# See cursor.com/docs/skills ("Migrating rules and commands to skills").
+# Cursor's own first-party skills (``migrate-to-skills``, ``loop``, ``review``,
+# …) are not user-authored: Cursor *syncs* them into ``~/.cursor/skills-cursor``
+# (alongside ``.cursor-managed-skills-manifest.json`` / ``.sync-manifest.json``),
+# distinct from the user-authored ``~/.cursor/skills``. No other VSCode-family
+# fork ships such a dir, so the logic lives entirely in CursorDiscoverer:
+# ``_builtin_skills_dir_paths`` → ``_builtin_skills_dirs()`` → overridden
+# ``discover_skills()``. The dir is deliberately kept OUT of ``_skills_dir_paths``
+# so it is scanned once (by the built-in-skills path), not twice.
+# See cursor.com/docs/skills.
 # ---------------------------------------------------------------------------
 
 
-def test_cursor_builtin_skills_dir_paths_non_empty():
-    """CursorDiscoverer declares ``_builtin_skills_dir_paths`` with at least
-    the macOS, Windows, and Linux entries — one per platform Cursor ships on."""
+def test_cursor_builtin_skills_dir_paths_targets_skills_cursor():
+    """CursorDiscoverer's built-in-skills paths point at ``~/.cursor/skills-cursor``
+    (home-relative, platform-independent — not the old per-OS app-bundle map)."""
     from agent_scan.agents import CursorDiscoverer
 
-    paths = CursorDiscoverer._builtin_skills_dir_paths
-    assert "darwin" in paths, "macOS (darwin) entry must be declared"
-    assert "win32" in paths, "Windows (win32) entry must be declared"
-    assert "linux" in paths, "Linux entry must be declared"
+    assert "~/.cursor/skills-cursor" in CursorDiscoverer._builtin_skills_dir_paths
 
 
-def test_cursor_builtin_skills_dirs_macos_path(tmp_path, monkeypatch):
-    """On macOS the system-wide Cursor install path includes
-    ``/Applications/Cursor.app/Contents/Resources/app/skills``."""
-    import agent_scan.agents.vscode.cursor as cursor_mod
+def test_cursor_skills_cursor_scanned_once_not_in_skills_dir_paths():
+    """``~/.cursor/skills-cursor`` is owned by the built-in-skills scan, NOT by
+    ``_skills_dir_paths`` — otherwise ``discover_skills`` would scan it twice. The
+    user-authored ``~/.cursor/skills`` stays in ``_skills_dir_paths``."""
     from agent_scan.agents import CursorDiscoverer
 
-    monkeypatch.setattr(cursor_mod.sys, "platform", "darwin")
+    assert "~/.cursor/skills-cursor" not in CursorDiscoverer._skills_dir_paths
+    assert "~/.cursor/skills" in CursorDiscoverer._skills_dir_paths
+
+
+def test_cursor_builtin_skills_dirs_resolves_skills_cursor(tmp_path):
+    """``_builtin_skills_dirs`` resolves ``~/.cursor/skills-cursor`` against the
+    scanned home — no per-OS branching, so it is the same on every platform."""
+    from agent_scan.agents import CursorDiscoverer
+
     dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
-
-    expected = "/Applications/Cursor.app/Contents/Resources/app/skills"
-    assert any(d == expected for d in dirs), f"expected {expected!r} in built-in skills dirs; got: {dirs}"
+    assert dirs == [(tmp_path / ".cursor" / "skills-cursor").as_posix()]
 
 
 def test_cursor_builtin_skills_discovered_in_discover_skills(tmp_path, monkeypatch):
-    """Skills shipped inside the Cursor app bundle (``resources/app/skills``) are
-    surfaced by ``discover_skills`` — the ``/migrate-to-skills`` / ``/loop`` layout."""
+    """Skills under the built-in / managed skills dir are surfaced by
+    ``discover_skills`` — the override merges ``_discover_builtin_skills`` results."""
     from agent_scan.agents import CursorDiscoverer
 
-    # Simulate the application-level skills directory.
-    app_skills = tmp_path / "app" / "skills"
-    migrate_skill = app_skills / "migrate-to-skills"
+    # A built-in / managed skills dir (stands in for ~/.cursor/skills-cursor).
+    builtin_dir = tmp_path / "skills-cursor"
+    migrate_skill = builtin_dir / "migrate-to-skills"
     migrate_skill.mkdir(parents=True)
     (migrate_skill / "SKILL.md").write_text(
         "---\nname: migrate-to-skills\ndescription: Migrate rules and commands to skills.\n---\n\nbody\n"
     )
-    loop_skill = app_skills / "loop"
+    loop_skill = builtin_dir / "loop"
     loop_skill.mkdir(parents=True)
     (loop_skill / "SKILL.md").write_text("---\nname: loop\ndescription: Run a prompt on a schedule.\n---\n\nbody\n")
     (tmp_path / ".cursor").mkdir()
 
     discoverer = CursorDiscoverer(tmp_path)
-    monkeypatch.setattr(discoverer, "_builtin_skills_dirs", lambda: [app_skills])
+    monkeypatch.setattr(discoverer, "_builtin_skills_dirs", lambda: [builtin_dir])
 
     skills_dirs = discoverer.discover_skills()
 
-    assert app_skills.as_posix() in skills_dirs, (
-        f"application-bundled skills dir must be surfaced; got: {list(skills_dirs)}"
-    )
-    skill_names = {name for name, _ in skills_dirs[app_skills.as_posix()]}
+    assert builtin_dir.as_posix() in skills_dirs, f"built-in skills dir must be surfaced; got: {list(skills_dirs)}"
+    skill_names = {name for name, _ in skills_dirs[builtin_dir.as_posix()]}
     assert "migrate-to-skills" in skill_names, f"migrate-to-skills must be discovered; got: {skill_names}"
     assert "loop" in skill_names, f"loop must be discovered; got: {skill_names}"
 
@@ -5739,79 +5743,20 @@ def test_family_base_has_no_builtin_skills_logic():
 
 def test_other_vscode_family_discoverers_have_no_builtin_skills_logic(tmp_path):
     """VSCode, Windsurf, Kiro, and Antigravity have no ``_builtin_skills_dirs``
-    method — only Cursor ships a dedicated app-bundled skills dir."""
+    method — only Cursor ships a dedicated built-in / managed skills dir."""
     from agent_scan.agents import AntigravityDiscoverer, KiroDiscoverer, VSCodeDiscoverer, WindsurfDiscoverer
 
     for cls in (VSCodeDiscoverer, WindsurfDiscoverer, KiroDiscoverer, AntigravityDiscoverer):
         assert not hasattr(cls, "_builtin_skills_dirs"), (
             f"{cls.__name__} must not define _builtin_skills_dirs "
-            f"(only Cursor ships a dedicated app-bundled skills dir)"
+            f"(only Cursor ships a dedicated built-in / managed skills dir)"
         )
-
-
-@pytest.mark.parametrize("linux_platform", ["linux", "linux2"])
-def test_cursor_builtin_skills_dirs_linux(tmp_path, monkeypatch, linux_platform):
-    """On Linux the deb-installed Cursor path includes
-    ``/usr/share/cursor/resources/app/skills``."""
-    import agent_scan.agents.vscode.cursor as cursor_mod
-    from agent_scan.agents import CursorDiscoverer
-
-    monkeypatch.setattr(cursor_mod.sys, "platform", linux_platform)
-    dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
-
-    assert any("/usr/share/cursor/resources/app/skills" in d for d in dirs), (
-        f"Linux Cursor built-in skills path not found; got: {dirs}"
-    )
-
-
-def test_cursor_builtin_skills_dirs_windows(tmp_path, monkeypatch):
-    """On Windows the per-user NSIS install path includes
-    ``AppData/Local/Programs/Cursor/resources/app/skills``."""
-    import agent_scan.agents.vscode.cursor as cursor_mod
-    from agent_scan.agents import CursorDiscoverer
-
-    monkeypatch.setattr(cursor_mod.sys, "platform", "win32")
-    dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
-
-    assert any("Cursor/resources/app/skills" in d for d in dirs), (
-        f"Windows Cursor built-in skills path not found; got: {dirs}"
-    )
-
-
-def test_cursor_builtin_skills_dirs_empty_on_unsupported_platform(tmp_path, monkeypatch):
-    """An unrecognized platform yields no built-in skills dirs."""
-    import agent_scan.agents.vscode.cursor as cursor_mod
-    from agent_scan.agents import CursorDiscoverer
-
-    monkeypatch.setattr(cursor_mod.sys, "platform", "sunos5")
-
-    assert CursorDiscoverer(tmp_path)._builtin_skills_dirs() == []
-
-
-# ---------------------------------------------------------------------------
-# Cursor managed/synced skills (``~/.cursor/skills-cursor``)
-# ---------------------------------------------------------------------------
-# Cursor delivers its own built-in/managed skills (``migrate-to-skills``,
-# ``loop``, ``review``, …) by *syncing* them into ``~/.cursor/skills-cursor``,
-# distinct from the user-authored ``~/.cursor/skills``. The dir is declared in
-# ``_skills_dir_paths`` so it flows through the standard home-skills scan
-# (``_discover_home_skills_dirs``) — no bespoke wiring.
-# ---------------------------------------------------------------------------
-
-
-def test_cursor_skills_cursor_declared_in_skills_dir_paths():
-    """``~/.cursor/skills-cursor`` is declared among CursorDiscoverer's home skill
-    paths, alongside the user-authored ``~/.cursor/skills``."""
-    from agent_scan.agents import CursorDiscoverer
-
-    assert "~/.cursor/skills-cursor" in CursorDiscoverer._skills_dir_paths
-    assert "~/.cursor/skills" in CursorDiscoverer._skills_dir_paths
 
 
 def test_cursor_skills_cursor_dir_discovered(tmp_path):
     """Skills synced into ``~/.cursor/skills-cursor`` are surfaced by
-    ``discover_skills`` under their own key — exercises the real
-    ``_skills_dir_paths`` wiring (no mock), so it guards the path staying live."""
+    ``discover_skills`` via the built-in-skills scan — exercises the real
+    ``_builtin_skills_dir_paths`` wiring (no mock), so the path can't regress."""
     from agent_scan.agents import CursorDiscoverer
 
     skills_cursor = tmp_path / ".cursor" / "skills-cursor"

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -5649,31 +5649,31 @@ def test_vscode_builtin_extension_dirs_per_platform(tmp_path):
 # ---------------------------------------------------------------------------
 # Cursor ships built-in skills (``/migrate-to-skills``, ``/loop``, etc.) directly
 # in the application bundle at ``resources/app/skills``, NOT inside an extension
-# subdir. These require a dedicated discovery path:
-# ``_builtin_skills_dir_templates`` → ``_builtin_skills_dirs()`` →
-# ``_discover_builtin_skills()``, wired into ``discover_skills()``.
+# subdir. No other VSCode-family fork does this, so the logic lives entirely in
+# CursorDiscoverer: ``_builtin_skills_dir_paths`` (class-level path map) →
+# ``_builtin_skills_dirs()`` → overridden ``discover_skills()``.
 # See cursor.com/docs/skills ("Migrating rules and commands to skills").
 # ---------------------------------------------------------------------------
 
 
-def test_cursor_builtin_skills_dir_templates_non_empty():
-    """CursorDiscoverer declares ``_builtin_skills_dir_templates`` with at least
+def test_cursor_builtin_skills_dir_paths_non_empty():
+    """CursorDiscoverer declares ``_builtin_skills_dir_paths`` with at least
     the macOS, Windows, and Linux entries — one per platform Cursor ships on."""
     from agent_scan.agents import CursorDiscoverer
 
-    templates = CursorDiscoverer._builtin_skills_dir_templates
-    assert "darwin" in templates, "macOS (darwin) entry must be declared"
-    assert "win32" in templates, "Windows (win32) entry must be declared"
-    assert "linux" in templates, "Linux entry must be declared"
+    paths = CursorDiscoverer._builtin_skills_dir_paths
+    assert "darwin" in paths, "macOS (darwin) entry must be declared"
+    assert "win32" in paths, "Windows (win32) entry must be declared"
+    assert "linux" in paths, "Linux entry must be declared"
 
 
 def test_cursor_builtin_skills_dirs_macos_path(tmp_path, monkeypatch):
     """On macOS the system-wide Cursor install path includes
     ``/Applications/Cursor.app/Contents/Resources/app/skills``."""
-    import agent_scan.agents.vscode.base as base
+    import agent_scan.agents.vscode.cursor as cursor_mod
     from agent_scan.agents import CursorDiscoverer
 
-    monkeypatch.setattr(base.sys, "platform", "darwin")
+    monkeypatch.setattr(cursor_mod.sys, "platform", "darwin")
     dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
 
     expected = "/Applications/Cursor.app/Contents/Resources/app/skills"
@@ -5730,22 +5730,23 @@ def test_cursor_builtin_skills_absent_dir_not_surfaced(tmp_path, monkeypatch):
     )
 
 
-def test_family_base_builtin_skills_dir_templates_default_empty():
-    """The family base declares no built-in skills templates; each fork opts in.
-    Guards against a newly-added fork silently inheriting another fork's paths."""
+def test_family_base_has_no_builtin_skills_logic():
+    """``VSCodeFamilyDiscoverer`` has no ``_builtin_skills_dirs`` method — builtin
+    skills are Cursor-specific and live entirely in ``CursorDiscoverer``."""
     from agent_scan.agents.vscode.base import VSCodeFamilyDiscoverer
 
-    assert VSCodeFamilyDiscoverer._builtin_skills_dir_templates == {}
+    assert not hasattr(VSCodeFamilyDiscoverer, "_builtin_skills_dirs")
+    assert not hasattr(VSCodeFamilyDiscoverer, "_builtin_skills_dir_paths")
 
 
-def test_other_vscode_family_discoverers_have_no_builtin_skills_templates(tmp_path):
-    """VSCode, Windsurf, Kiro, and Antigravity declare no built-in skills templates
-    (only Cursor ships a dedicated app-bundled skills dir)."""
+def test_other_vscode_family_discoverers_have_no_builtin_skills_logic(tmp_path):
+    """VSCode, Windsurf, Kiro, and Antigravity have no ``_builtin_skills_dirs``
+    method — only Cursor ships a dedicated app-bundled skills dir."""
     from agent_scan.agents import AntigravityDiscoverer, KiroDiscoverer, VSCodeDiscoverer, WindsurfDiscoverer
 
     for cls in (VSCodeDiscoverer, WindsurfDiscoverer, KiroDiscoverer, AntigravityDiscoverer):
-        assert cls._builtin_skills_dir_templates == {}, (
-            f"{cls.__name__} must not declare _builtin_skills_dir_templates "
+        assert not hasattr(cls, "_builtin_skills_dirs"), (
+            f"{cls.__name__} must not define _builtin_skills_dirs "
             f"(only Cursor ships a dedicated app-bundled skills dir)"
         )
 
@@ -5754,10 +5755,10 @@ def test_other_vscode_family_discoverers_have_no_builtin_skills_templates(tmp_pa
 def test_cursor_builtin_skills_dirs_linux(tmp_path, monkeypatch, linux_platform):
     """On Linux the deb-installed Cursor path includes
     ``/usr/share/cursor/resources/app/skills``."""
-    import agent_scan.agents.vscode.base as base
+    import agent_scan.agents.vscode.cursor as cursor_mod
     from agent_scan.agents import CursorDiscoverer
 
-    monkeypatch.setattr(base.sys, "platform", linux_platform)
+    monkeypatch.setattr(cursor_mod.sys, "platform", linux_platform)
     dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
 
     assert any("/usr/share/cursor/resources/app/skills" in d for d in dirs), (
@@ -5768,10 +5769,10 @@ def test_cursor_builtin_skills_dirs_linux(tmp_path, monkeypatch, linux_platform)
 def test_cursor_builtin_skills_dirs_windows(tmp_path, monkeypatch):
     """On Windows the per-user NSIS install path includes
     ``AppData/Local/Programs/Cursor/resources/app/skills``."""
-    import agent_scan.agents.vscode.base as base
+    import agent_scan.agents.vscode.cursor as cursor_mod
     from agent_scan.agents import CursorDiscoverer
 
-    monkeypatch.setattr(base.sys, "platform", "win32")
+    monkeypatch.setattr(cursor_mod.sys, "platform", "win32")
     dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
 
     assert any("Cursor/resources/app/skills" in d for d in dirs), (
@@ -5781,10 +5782,10 @@ def test_cursor_builtin_skills_dirs_windows(tmp_path, monkeypatch):
 
 def test_cursor_builtin_skills_dirs_empty_on_unsupported_platform(tmp_path, monkeypatch):
     """An unrecognized platform yields no built-in skills dirs."""
-    import agent_scan.agents.vscode.base as base
+    import agent_scan.agents.vscode.cursor as cursor_mod
     from agent_scan.agents import CursorDiscoverer
 
-    monkeypatch.setattr(base.sys, "platform", "sunos5")
+    monkeypatch.setattr(cursor_mod.sys, "platform", "sunos5")
 
     assert CursorDiscoverer(tmp_path)._builtin_skills_dirs() == []
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -5644,6 +5644,151 @@ def test_vscode_builtin_extension_dirs_per_platform(tmp_path):
         assert any(d.endswith("Microsoft VS Code/resources/app/extensions") for d in dirs)
 
 
+# ---------------------------------------------------------------------------
+# Cursor built-in (application-bundled) skills
+# ---------------------------------------------------------------------------
+# Cursor ships built-in skills (``/migrate-to-skills``, ``/loop``, etc.) directly
+# in the application bundle at ``resources/app/skills``, NOT inside an extension
+# subdir. These require a dedicated discovery path:
+# ``_builtin_skills_dir_templates`` → ``_builtin_skills_dirs()`` →
+# ``_discover_builtin_skills()``, wired into ``discover_skills()``.
+# See cursor.com/docs/skills ("Migrating rules and commands to skills").
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_builtin_skills_dir_templates_non_empty():
+    """CursorDiscoverer declares ``_builtin_skills_dir_templates`` with at least
+    the macOS, Windows, and Linux entries — one per platform Cursor ships on."""
+    from agent_scan.agents import CursorDiscoverer
+
+    templates = CursorDiscoverer._builtin_skills_dir_templates
+    assert "darwin" in templates, "macOS (darwin) entry must be declared"
+    assert "win32" in templates, "Windows (win32) entry must be declared"
+    assert "linux" in templates, "Linux entry must be declared"
+
+
+def test_cursor_builtin_skills_dirs_macos_path(tmp_path, monkeypatch):
+    """On macOS the system-wide Cursor install path includes
+    ``/Applications/Cursor.app/Contents/Resources/app/skills``."""
+    import agent_scan.agents.vscode.base as base
+    from agent_scan.agents import CursorDiscoverer
+
+    monkeypatch.setattr(base.sys, "platform", "darwin")
+    dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
+
+    expected = "/Applications/Cursor.app/Contents/Resources/app/skills"
+    assert any(d == expected for d in dirs), f"expected {expected!r} in built-in skills dirs; got: {dirs}"
+
+
+def test_cursor_builtin_skills_discovered_in_discover_skills(tmp_path, monkeypatch):
+    """Skills shipped inside the Cursor app bundle (``resources/app/skills``) are
+    surfaced by ``discover_skills`` — the ``/migrate-to-skills`` / ``/loop`` layout."""
+    from agent_scan.agents import CursorDiscoverer
+
+    # Simulate the application-level skills directory.
+    app_skills = tmp_path / "app" / "skills"
+    migrate_skill = app_skills / "migrate-to-skills"
+    migrate_skill.mkdir(parents=True)
+    (migrate_skill / "SKILL.md").write_text(
+        "---\nname: migrate-to-skills\ndescription: Migrate rules and commands to skills.\n---\n\nbody\n"
+    )
+    loop_skill = app_skills / "loop"
+    loop_skill.mkdir(parents=True)
+    (loop_skill / "SKILL.md").write_text(
+        "---\nname: loop\ndescription: Run a prompt on a schedule.\n---\n\nbody\n"
+    )
+    (tmp_path / ".cursor").mkdir()
+
+    discoverer = CursorDiscoverer(tmp_path)
+    monkeypatch.setattr(discoverer, "_builtin_skills_dirs", lambda: [app_skills])
+
+    skills_dirs = discoverer.discover_skills()
+
+    assert app_skills.as_posix() in skills_dirs, (
+        f"application-bundled skills dir must be surfaced; got: {list(skills_dirs)}"
+    )
+    skill_names = {name for name, _ in skills_dirs[app_skills.as_posix()]}
+    assert "migrate-to-skills" in skill_names, f"migrate-to-skills must be discovered; got: {skill_names}"
+    assert "loop" in skill_names, f"loop must be discovered; got: {skill_names}"
+
+
+def test_cursor_builtin_skills_absent_dir_not_surfaced(tmp_path, monkeypatch):
+    """A non-existent built-in skills dir produces no entry in ``discover_skills``
+    — the app is not installed on this machine."""
+    from agent_scan.agents import CursorDiscoverer
+
+    absent = tmp_path / "app" / "skills"  # not created
+    (tmp_path / ".cursor").mkdir()
+
+    discoverer = CursorDiscoverer(tmp_path)
+    monkeypatch.setattr(discoverer, "_builtin_skills_dirs", lambda: [absent])
+
+    skills_dirs = discoverer.discover_skills()
+
+    assert absent.as_posix() not in skills_dirs, (
+        "absent built-in skills dir must not produce a key; got: {list(skills_dirs)}"
+    )
+
+
+def test_family_base_builtin_skills_dir_templates_default_empty():
+    """The family base declares no built-in skills templates; each fork opts in.
+    Guards against a newly-added fork silently inheriting another fork's paths."""
+    from agent_scan.agents.vscode.base import VSCodeFamilyDiscoverer
+
+    assert VSCodeFamilyDiscoverer._builtin_skills_dir_templates == {}
+
+
+def test_other_vscode_family_discoverers_have_no_builtin_skills_templates(tmp_path):
+    """VSCode, Windsurf, Kiro, and Antigravity declare no built-in skills templates
+    (only Cursor ships a dedicated app-bundled skills dir)."""
+    from agent_scan.agents import AntigravityDiscoverer, KiroDiscoverer, VSCodeDiscoverer, WindsurfDiscoverer
+
+    for cls in (VSCodeDiscoverer, WindsurfDiscoverer, KiroDiscoverer, AntigravityDiscoverer):
+        assert cls._builtin_skills_dir_templates == {}, (
+            f"{cls.__name__} must not declare _builtin_skills_dir_templates "
+            f"(only Cursor ships a dedicated app-bundled skills dir)"
+        )
+
+
+@pytest.mark.parametrize("linux_platform", ["linux", "linux2"])
+def test_cursor_builtin_skills_dirs_linux(tmp_path, monkeypatch, linux_platform):
+    """On Linux the deb-installed Cursor path includes
+    ``/usr/share/cursor/resources/app/skills``."""
+    import agent_scan.agents.vscode.base as base
+    from agent_scan.agents import CursorDiscoverer
+
+    monkeypatch.setattr(base.sys, "platform", linux_platform)
+    dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
+
+    assert any("/usr/share/cursor/resources/app/skills" in d for d in dirs), (
+        f"Linux Cursor built-in skills path not found; got: {dirs}"
+    )
+
+
+def test_cursor_builtin_skills_dirs_windows(tmp_path, monkeypatch):
+    """On Windows the per-user NSIS install path includes
+    ``AppData/Local/Programs/Cursor/resources/app/skills``."""
+    import agent_scan.agents.vscode.base as base
+    from agent_scan.agents import CursorDiscoverer
+
+    monkeypatch.setattr(base.sys, "platform", "win32")
+    dirs = [p.as_posix() for p in CursorDiscoverer(tmp_path)._builtin_skills_dirs()]
+
+    assert any("Cursor/resources/app/skills" in d for d in dirs), (
+        f"Windows Cursor built-in skills path not found; got: {dirs}"
+    )
+
+
+def test_cursor_builtin_skills_dirs_empty_on_unsupported_platform(tmp_path, monkeypatch):
+    """An unrecognized platform yields no built-in skills dirs."""
+    import agent_scan.agents.vscode.base as base
+    from agent_scan.agents import CursorDiscoverer
+
+    monkeypatch.setattr(base.sys, "platform", "sunos5")
+
+    assert CursorDiscoverer(tmp_path)._builtin_skills_dirs() == []
+
+
 # --- _walk_under_depth: PermissionError tolerance (--scan-all-users) ---
 # Every depth-bounded directory walk goes through ``_walk_under_depth``, which
 # skips an unreadable base (the routine ``--scan-all-users`` case where an


### PR DESCRIPTION
## Summary

`CursorDiscoverer` now surfaces Cursor's own built-in / managed skills (`migrate-to-skills`, `loop`, `review`, …) — which the existing home / workspace / extension skill scans did not reach. Cursor *syncs* these into **`~/.cursor/skills-cursor`** at the user level (verified on disk, alongside `.cursor-managed-skills-manifest.json` / `.sync-manifest.json`), distinct from the user-authored `~/.cursor/skills`. All logic lives in `CursorDiscoverer` — no `VSCodeFamilyDiscoverer` base-class changes (built-in skills are Cursor-specific).

## Changes

### `src/agent_scan/agents/vscode/cursor.py` — `CursorDiscoverer`
- `_builtin_skills_dir_paths = ("~/.cursor/skills-cursor",)` — a flat, home-relative tuple. The dir is the same on every OS (Cursor's user dir is `~/.cursor` everywhere), so no per-OS map is needed.
- `_builtin_skills_dirs()` resolves it against the scanned home; `_discover_builtin_skills()` scans each; wired via an overridden `discover_skills()` that augments `super().discover_skills()`.
- `~/.cursor/skills-cursor` is deliberately kept **out** of `_skills_dir_paths` so `discover_skills` scans it once (via the built-in-skills path), not twice.

### `tests/unit/test_agent_discovery.py`
- Built-in-skills coverage: target is `~/.cursor/skills-cursor`; the single-owner / no-double-scan invariant; home resolution (platform-independent); mocked + real-wiring discovery; absent-dir; and negatives asserting the base class and the other forks (VSCode / Windsurf / Kiro / Antigravity) carry no built-in-skills logic.

## Test Results

`tests/unit/test_agent_discovery.py`: **380 passed** (`uv run pytest`; ruff / ruff-format / mypy pre-commit hooks green).
