### PR TITLE
refactor: remove commands discovery from ClaudeCodeDiscoverer

### DIFF
--- a/src/agent_scan/agents/claude_code.py
+++ b/src/agent_scan/agents/claude_code.py
@@ -19,7 +19,7 @@ from agent_scan.models import (
     MCPConfig,
     PluginMCPConfigFile,
 )
-from agent_scan.skill_client import inspect_commands_dir, inspect_skills_dir
+from agent_scan.skill_client import inspect_skills_dir
 from agent_scan.well_known_clients import CLAUDE_CODE_NAME, expand_path
 
 logger = logging.getLogger(__name__)
@@ -99,9 +99,6 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         result.update(self._discover_global_skill())
         result.update(self._discover_project_skills())
         result.update(self._discover_plugin_skills())
-        result.update(self._discover_global_commands())
-        result.update(self._discover_project_commands())
-        result.update(self._discover_plugin_commands())
         result.update(self._discover_plugin_manifest_skills())
         # NOTE: enterprise/managed skills are a documented Claude Code scope (the
         # "Enterprise" tier in the skills hierarchy, which overrides personal and
@@ -322,35 +319,6 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
     def _discover_plugin_skills(self) -> SkillsDirsResult:
         """Scan ``skills/`` subdirs under every plugin base dir."""
         return self._discover_skill_and_command_dirs(self._plugin_base_dirs(), "skills", inspect_skills_dir)
-
-    # --- private: commands discovery ---
-    # Commands are currently surfaced as skills (hence the ``SkillsDirsResult``
-    # return type and the shared ``inspect_*`` machinery), matching how the docs
-    # treat them today. This is a deliberate choice for now, not a permanent one:
-    # if commands gain a distinct identity we may need to map them as commands in
-    # their own right rather than folding them into skills.
-
-    def _discover_global_commands(self) -> SkillsDirsResult:
-        """Scan ``<install>/commands`` for command files under each global folder."""
-        result: SkillsDirsResult = {}
-        for folder in self._discover_global_folders():
-            commands_dir = folder / "commands"
-            if commands_dir.exists():
-                result[commands_dir.as_posix()] = inspect_commands_dir(str(commands_dir))
-        return result
-
-    def _discover_project_commands(self) -> SkillsDirsResult:
-        """For each project (and ancestor), scan ``<path>/.claude/commands`` if present."""
-        result: SkillsDirsResult = {}
-        for path in self._project_paths_with_ancestors():
-            commands_dir = path / self._project_dotclaude_subdir / "commands"
-            if commands_dir.exists():
-                result[commands_dir.as_posix()] = inspect_commands_dir(str(commands_dir))
-        return result
-
-    def _discover_plugin_commands(self) -> SkillsDirsResult:
-        """Scan ``commands/`` subdirs under every plugin base dir."""
-        return self._discover_skill_and_command_dirs(self._plugin_base_dirs(), "commands", inspect_commands_dir)
 
     # --- private: enterprise/managed MCP discovery ---
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -4785,40 +4785,6 @@ def test_managed_mcp_path_falls_back_to_default_program_files_on_windows(tmp_pat
     assert "Program Files" in path.as_posix()
 
 
-def test_claude_code_discovers_global_command_files(tmp_path):
-    """``~/.claude/commands/*.md`` are surfaced as skill entries."""
-    from agent_scan.agents import ClaudeCodeDiscoverer
-
-    commands = tmp_path / ".claude" / "commands"
-    commands.mkdir(parents=True)
-    (commands / "deploy.md").write_text("# Deploy")
-
-    skills = ClaudeCodeDiscoverer(tmp_path).discover_skills()
-
-    keys = [k for k in skills if k.endswith("/.claude/commands")]
-    assert len(keys) == 1
-    names = {n for n, _ in skills[keys[0]]}
-    assert names == {"deploy"}
-
-
-def test_claude_code_discovers_project_command_files(tmp_path):
-    """``<project>/.claude/commands/*.md`` are surfaced for opened projects."""
-    from agent_scan.agents import ClaudeCodeDiscoverer
-
-    project = tmp_path / "repo"
-    cmds = project / ".claude" / "commands"
-    cmds.mkdir(parents=True)
-    (cmds / "test.md").write_text("# Test")
-    (tmp_path / ".claude").mkdir()
-    (tmp_path / ".claude.json").write_text(f'{{"projects": {{"{project.as_posix()}": {{"mcpServers": {{}}}}}}}}')
-
-    skills = ClaudeCodeDiscoverer(tmp_path).discover_skills()
-
-    keys = [k for k in skills if k.endswith("/repo/.claude/commands")]
-    assert len(keys) == 1
-    assert {n for n, _ in skills[keys[0]]} == {"test"}
-
-
 def test_claude_code_honors_claude_config_dir_on_own_home_scan(tmp_path, monkeypatch):
     """When CLAUDE_CONFIG_DIR is set and no explicit home is passed (own-home
     scan), MCP config is read from ``<CLAUDE_CONFIG_DIR>/.claude.json``."""


### PR DESCRIPTION
## Summary

Removes command discovery entirely from `ClaudeCodeDiscoverer` in agent-scan.

### Changes

- **Removed private methods** from `ClaudeCodeDiscoverer`:
  - `_discover_global_commands`
  - `_discover_project_commands`
  - `_discover_plugin_commands`
- **Removed calls** to those three methods from `discover_skills()`
- **Cleaned up unused import**: `inspect_commands_dir` is no longer imported from `agent_scan.skill_client`
- **Removed two related unit tests** from `tests/unit/test_agent_discovery.py`:
  - `test_claude_code_discovers_global_command_files`
  - `test_claude_code_discovers_project_command_files`