### PR TITLE
docs: fix typo 'effectivly' -> 'effectively'

### DIFF
--- a/docs/issue-codes.md
+++ b/docs/issue-codes.md
@@ -6,7 +6,7 @@ This is the reference for all issues that can be detected via `snyk-agent-scan`.
 
 ## Compromised MCP Servers
 
-These issues highlight that the installed MCP server is acting maliciously. This yields a very important security threat, as it effectivly exposes a successful supply chain attack
+These issues highlight that the installed MCP server is acting maliciously. This yields a very important security threat, as it effectively exposes a successful supply chain attack
 
 <a id="E001"></a>
 


### PR DESCRIPTION
## Summary

Simple documentation typo fix:
-  →  in the issue codes introduction

No functional changes, just a small documentation improvement.