### PR TITLE
Redact secrets from skill file contents

### DIFF
--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -453,6 +453,19 @@ def _strip_token_edges(token: str) -> str | None:
     return core if core and core != token else None
 
 
+# Structural delimiters that commonly *separate* a secret from surrounding text
+# inside one whitespace token -- URL path/query separators, dotted paths, colon-
+# or comma-joined values. When the whole-token and edge-stripped-core scans both
+# come up clean, the token is split on these and each segment re-checked, so a
+# secret embedded between them is still found. The base64/base64url secret
+# characters ``= + _ -`` are deliberately NOT split on, so a real secret that
+# contains them is never fragmented. ``/`` is split on despite being a base64
+# char: URL-embedded tokens are overwhelmingly base64url/hex/alnum (which never
+# contain ``/``), and because this runs only as a fallback it can add coverage
+# but never remove what the earlier scans already catch.
+_TOKEN_SPLIT_DELIMS = re.compile(r"[/:.,;@?&#|\\]")
+
+
 def _redact_secrets_in_line(line: str, plugins: list) -> str:
     """Redact secret-bearing substrings within a single line of free text.
 
@@ -473,7 +486,11 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
        fallback, so a secret wrapped in markdown/punctuation (a backtick code
        span, or a trailing ``"`` from a longer quoted string) is still
        detected. Only the matched candidate substring is replaced, so the
-       surrounding markup stays intact.
+       surrounding markup stays intact. When neither the token nor its core is
+       flagged, the token is split on structural delimiters
+       (see :data:`_TOKEN_SPLIT_DELIMS`) and each segment re-checked, so a
+       secret embedded as a URL path/query segment or a dotted/colon-joined
+       value is recovered without disturbing the surrounding structure.
 
     Replacements are applied longest-first so a secret that is a substring of
     another does not corrupt the marker inserted for the longer one.
@@ -495,17 +512,31 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
     # tried first (preserving prior behaviour); only when it is not flagged is
     # the edge-stripped core consulted as a fallback.
     for token in line.split():
-        candidates = [token]
         core = _strip_token_edges(token)
-        if core is not None:
-            candidates.append(core)
+        candidates = [token] if core is None else [token, core]
+        handled = False
         for candidate in candidates:
             if candidate in replacements:
+                handled = True
                 break
             plugin_name = _detect_secret(candidate, plugins)
             if plugin_name is not None:
                 replacements[candidate] = _redaction_marker(plugin_name)
+                handled = True
                 break
+        if handled:
+            continue
+        # Fallback: a secret separated from surrounding text by a structural
+        # delimiter (a URL path/query segment, a dotted or colon-joined value)
+        # rides along inside one whitespace token and escapes the whole-token
+        # scan above. Split on those delimiters and flag each secret-shaped
+        # segment; only the matched segment is replaced, so the structure stays.
+        for segment in _TOKEN_SPLIT_DELIMS.split(token):
+            if not segment or segment in replacements:
+                continue
+            plugin_name = _detect_secret(segment, plugins)
+            if plugin_name is not None:
+                replacements[segment] = _redaction_marker(plugin_name)
 
     redacted = line
     for value in sorted(replacements, key=len, reverse=True):

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -475,15 +475,6 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
        detected. Only the matched candidate substring is replaced, so the
        surrounding markup stays intact.
 
-    ``KeywordDetector`` is intentionally NOT used here. Unlike :func:`redact_args`
-    (where a flag's value is almost always a credential), skill content is
-    free-form documentation and code: a keyword like ``password`` / ``api_key``
-    / ``token`` next to a value is usually legitimate explanatory context
-    (examples, variable names, prose), not a real secret. Redacting on keyword
-    alone would strip large amounts of context the downstream analysis relies
-    on, so detection is scoped to high-entropy and known-format secrets that
-    actually look like live credentials.
-
     Replacements are applied longest-first so a secret that is a substring of
     another does not corrupt the marker inserted for the longer one.
     """
@@ -567,7 +558,7 @@ def _is_synthetic_binary_description(text: str) -> bool:
 
 
 def redact_signature(signature: ServerSignature) -> ServerSignature:
-    """Redact secrets and absolute paths from a (skill) ``ServerSignature`` in place.
+    """Redact secrets from a (skill) ``ServerSignature`` in place.
 
     Skill signatures embed raw file contents in their prompt / resource / tool
     ``description`` fields, and the skill's frontmatter description in

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -182,6 +182,31 @@ def _wrap_for_entropy(value: str) -> str:
     return '"' + value.replace('"', r"\"") + '"'
 
 
+# Longest pure-ASCII-lowercase token (``^[a-z]+$``) safe to skip without running
+# any plugin: it matches no format detector (all need a digit/uppercase/special/
+# prefix) and no HexHighEntropyString (only [a-f] is hex -> entropy <2.58 < 3.0
+# limit). Base64HighEntropyString (limit 4.5) is bounded by log2(len), so a cap
+# up to 22 is provably safe; 15 is a conservative margin. A lower cap only skips
+# fewer tokens, never one a plugin would flag.
+_PROSE_MAX_LEN = 15
+
+
+def _could_be_secret(value: str) -> bool:
+    """Cheap O(len) pre-filter: ``True`` for every value any plugin could flag,
+    ``False`` only for short pure-ASCII-lowercase tokens (see
+    :data:`_PROSE_MAX_LEN`), which dominate prose/code and match no detector.
+
+    Must never reject a value that would match, or a secret leaks; passing
+    through a non-match is fine (it just falls to the full scan).
+    """
+    return (
+        len(value) > _PROSE_MAX_LEN  # long enough to reach a high-entropy threshold
+        or not value.isalpha()  # has a digit, separator, or other non-letter
+        or not value.islower()  # has an uppercase letter (or no cased letters at all)
+        or not value.isascii()  # has a non-ASCII character
+    )
+
+
 def _detect_secret_in_plugins(value: str, plugins: list) -> str | None:
     """Two-pass scan of ``value`` against an already-built ``plugins`` list.
 
@@ -200,6 +225,11 @@ def _detect_secret_in_plugins(value: str, plugins: list) -> str | None:
     ``transient_settings(_DETECT_SECRETS_CONFIG)`` context that ``plugins``
     was built under.
     """
+    # Cheap pre-filter: skip the full plugin battery for values that provably
+    # match nothing (see :func:`_could_be_secret`). Conservative -- never
+    # rejects a value a plugin would flag -- so output is unchanged.
+    if not _could_be_secret(value):
+        return None
     # Pass 1: format-based named detectors on the bare value.
     for plugin in plugins:
         if isinstance(plugin, HighEntropyStringsPlugin):

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -25,6 +25,16 @@ REDACTED = "**REDACTED**"
 
 _EXCLUDED_PLUGINS = frozenset({"IPPublicDetector"})
 
+# Synthetic description that ``skill_client.traverse_skill_tree`` emits for a
+# binary resource: this fixed prefix followed by the file's sha256 hex digest.
+# It is generated entirely by us and contains no user content, so it is exempt
+# from secret redaction (see ``_is_synthetic_binary_description``) -- otherwise
+# the 64-char digest trips the hex high-entropy detector and every binary
+# collapses to an identical, useless description. ``skill_client`` imports this
+# constant to build the marker so the two cannot drift apart.
+BINARY_FILE_DESCRIPTION_PREFIX = "Binary file. Hash: "
+_BINARY_FILE_DESCRIPTION_RE = re.compile(rf"^{re.escape(BINARY_FILE_DESCRIPTION_PREFIX)}[0-9a-f]{{64}}$")
+
 
 def _build_detect_secrets_config() -> dict:
     """
@@ -106,12 +116,10 @@ def _wrap_for_entropy(value: str) -> str:
     return '"' + value.replace('"', r"\"") + '"'
 
 
-def _detect_secret(value: str) -> str | None:
-    """
-    Return the class name of the first detect-secrets plugin that flags
-    ``value``, or ``None`` if no plugin flags it.
+def _detect_secret_in_plugins(value: str, plugins: list) -> str | None:
+    """Two-pass scan of ``value`` against an already-built ``plugins`` list.
 
-    Two-pass scan to give each plugin family the input format it expects:
+    Each plugin family gets the input format it expects:
 
     1. Named-format detectors (``AWSKeyDetector``, ``GitHubTokenDetector``,
        etc.) match self-contained format patterns and work on the raw
@@ -121,25 +129,49 @@ def _detect_secret(value: str) -> str | None:
        wrapped as ``"<value>"``, ``'<value>'``, or ``"<escaped>"`` so
        their regex tokenizes the whole value, then the entropy ``limit``
        filter is applied.
+
+    The caller is responsible for holding an active
+    ``transient_settings(_DETECT_SECRETS_CONFIG)`` context that ``plugins``
+    was built under.
+    """
+    # Pass 1: format-based named detectors on the bare value.
+    for plugin in plugins:
+        if isinstance(plugin, HighEntropyStringsPlugin):
+            continue
+        if plugin.analyze_line(filename="adhoc", line=value, line_number=1):
+            return type(plugin).__name__
+    # Pass 2: entropy plugins on the quote-wrapped value.
+    wrapped = _wrap_for_entropy(value)
+    for plugin in plugins:
+        if not isinstance(plugin, HighEntropyStringsPlugin):
+            continue
+        if plugin.analyze_line(filename="adhoc", line=wrapped, line_number=1):
+            return type(plugin).__name__
+    return None
+
+
+def _detect_secret(value: str, plugins: list | None = None) -> str | None:
+    """
+    Return the class name of the first detect-secrets plugin that flags
+    ``value``, or ``None`` if no plugin flags it. See
+    :func:`_detect_secret_in_plugins` for the two-pass detection logic.
+
+    When ``plugins`` is supplied, the caller is assumed to already hold an
+    active ``transient_settings(_DETECT_SECRETS_CONFIG)`` context (as
+    :func:`redact_text` does), so this reuses that plugin set and does NOT
+    re-enter the context. Re-entering it per call runs detect-secrets'
+    ``cache_bust`` twice each time (~1.3ms), so a per-token caller would be
+    O(tokens) in context churn -- tens of seconds for a large bundled script.
+
+    With ``plugins=None`` (the :func:`redact_args` path) it builds and tears
+    down its own context per call, exactly as before.
     """
     if not value:
         return None
+    if plugins is not None:
+        return _detect_secret_in_plugins(value, plugins)
     with transient_settings(_DETECT_SECRETS_CONFIG):
-        plugins = list(get_plugins())
-        # Pass 1: format-based named detectors on the bare value.
-        for plugin in plugins:
-            if isinstance(plugin, HighEntropyStringsPlugin):
-                continue
-            if plugin.analyze_line(filename="adhoc", line=value, line_number=1):
-                return type(plugin).__name__
-        # Pass 2: entropy plugins on the quote-wrapped value.
-        wrapped = _wrap_for_entropy(value)
-        for plugin in plugins:
-            if not isinstance(plugin, HighEntropyStringsPlugin):
-                continue
-            if plugin.analyze_line(filename="adhoc", line=wrapped, line_number=1):
-                return type(plugin).__name__
-    return None
+        return _detect_secret_in_plugins(value, list(get_plugins()))
 
 
 def _detect_keyword(prev_normalized: str, curr_raw: str) -> str | None:
@@ -374,11 +406,13 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
             if value:
                 replacements.setdefault(value, _redaction_marker(type(plugin).__name__))
 
-    # Pass 2: whole-token detection for format/entropy-shaped tokens.
+    # Pass 2: whole-token detection for format/entropy-shaped tokens. Reuse the
+    # caller's already-built ``plugins`` (under its single transient_settings
+    # context) so we don't re-enter that context per token.
     for token in line.split():
         if token in replacements:
             continue
-        plugin_name = _detect_secret(token)
+        plugin_name = _detect_secret(token, plugins)
         if plugin_name is not None:
             replacements[token] = _redaction_marker(plugin_name)
 
@@ -408,6 +442,16 @@ def redact_text(text: str | None) -> str | None:
     return redact_absolute_paths(redacted)
 
 
+def _is_synthetic_binary_description(text: str) -> bool:
+    """True if ``text`` is the synthetic binary-file marker emitted for a binary
+    skill resource (see :data:`BINARY_FILE_DESCRIPTION_PREFIX`).
+
+    Such a description is self-generated (a fixed prefix + sha256 digest) and
+    contains no user content, so it is left untouched by redaction.
+    """
+    return bool(_BINARY_FILE_DESCRIPTION_RE.match(text))
+
+
 def redact_signature(signature: ServerSignature) -> ServerSignature:
     """Redact secrets and absolute paths from a (skill) ``ServerSignature`` in place.
 
@@ -415,7 +459,9 @@ def redact_signature(signature: ServerSignature) -> ServerSignature:
     ``description`` fields, and the skill's frontmatter description in
     ``metadata.instructions``. Any of these can carry secrets, so every
     free-text field is run through :func:`redact_text` before the signature
-    leaves the machine.
+    leaves the machine. The one exception is a resource whose description is the
+    synthetic binary-file marker (see :func:`_is_synthetic_binary_description`),
+    which is left intact so the file's hash digest survives.
 
     This is the single redaction point for skill content: it runs once when the
     skill is read (in ``skill_client.inspect_skill``), so the later
@@ -425,7 +471,7 @@ def redact_signature(signature: ServerSignature) -> ServerSignature:
     if signature.metadata is not None and signature.metadata.instructions:
         signature.metadata.instructions = redact_text(signature.metadata.instructions)
     for entity in (*signature.prompts, *signature.resources, *signature.resource_templates, *signature.tools):
-        if entity.description:
+        if entity.description and not _is_synthetic_binary_description(entity.description):
             entity.description = redact_text(entity.description)
     return signature
 

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -420,23 +420,27 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
 
 
 def redact_text(text: str | None) -> str | None:
-    """Redact secrets and absolute paths from a block of free text.
+    """Redact secrets from a block of free text.
 
     Used for content read out of skill files (SKILL.md, command markdown,
     bundled scripts, and other resources), which may contain credentials a
-    user pasted into a skill, as well as absolute paths that leak usernames.
+    user pasted into a skill.
+
+    Absolute paths are intentionally left intact: skill content is documentation
+    and code that legitimately references real paths, and stripping them would
+    remove context the downstream analysis relies on. (Path redaction still
+    applies to tracebacks and server output via :func:`redact_server` /
+    :func:`redact_scan_result`, where paths are noise rather than user content.)
 
     Detection runs line by line so the plugin set is built once and reused;
-    secret values are spliced out in place (see :func:`_redact_secrets_in_line`)
-    and the whole result then has absolute paths redacted. Returns ``None`` for
-    ``None`` input and the input unchanged when it is empty.
+    secret values are spliced out in place (see :func:`_redact_secrets_in_line`).
+    Returns ``None`` for ``None`` input and the input unchanged when it is empty.
     """
     if not text:
         return text
     with transient_settings(_DETECT_SECRETS_CONFIG):
         plugins = list(get_plugins())
-        redacted = "\n".join(_redact_secrets_in_line(line, plugins) for line in text.split("\n"))
-    return redact_absolute_paths(redacted)
+        return "\n".join(_redact_secrets_in_line(line, plugins) for line in text.split("\n"))
 
 
 def _is_synthetic_binary_description(text: str) -> bool:

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -17,7 +17,7 @@ from detect_secrets.plugins.high_entropy_strings import HighEntropyStringsPlugin
 from detect_secrets.plugins.keyword import KeywordDetector
 from detect_secrets.settings import default_settings, get_plugins, transient_settings
 
-from agent_scan.models import RemoteServer, ScanPathResult, ServerScanResult, StdioServer
+from agent_scan.models import RemoteServer, ScanPathResult, ServerScanResult, ServerSignature, StdioServer
 
 logger = logging.getLogger(__name__)
 
@@ -332,6 +332,102 @@ def redact_args(args: list[str]) -> list[str]:
             flag = args[arg_idx].partition("=")[0]
             out[arg_idx] = f"{flag}={_redaction_marker(mark)}"
     return out
+
+
+def _redact_secrets_in_line(line: str, plugins: list) -> str:
+    """Redact secret-bearing substrings within a single line of free text.
+
+    Reuses the detect-secrets plugin set in two complementary passes that each
+    preserve the line's surrounding text and whitespace:
+
+    1. Raw-line scan with the high-entropy plugins only. They report the
+       *complete* secret value via ``secret_value`` (unlike some format
+       detectors -- e.g. the GitHub token detector reports only the ``ghp``
+       prefix), so their value is safe to splice out by substring. They fire on
+       the quoted forms common in skill code snippets (``key = "value"``).
+    2. Whitespace-token scan with :func:`_detect_secret`, which runs format
+       detectors on the bare token and entropy detectors on a quote-wrapped
+       copy. A whole secret-shaped token (AWS key, GitHub token, bare
+       high-entropy string) is therefore replaced wholesale -- no partial
+       prefix can leak.
+
+    ``KeywordDetector`` is intentionally NOT used here. Unlike :func:`redact_args`
+    (where a flag's value is almost always a credential), skill content is
+    free-form documentation and code: a keyword like ``password`` / ``api_key``
+    / ``token`` next to a value is usually legitimate explanatory context
+    (examples, variable names, prose), not a real secret. Redacting on keyword
+    alone would strip large amounts of context the downstream analysis relies
+    on, so detection is scoped to high-entropy and known-format secrets that
+    actually look like live credentials.
+
+    Replacements are applied longest-first so a secret that is a substring of
+    another does not corrupt the marker inserted for the longer one.
+    """
+    replacements: dict[str, str] = {}
+
+    # Pass 1: high-entropy detectors on the raw line (catches quoted literals).
+    for plugin in plugins:
+        if not isinstance(plugin, HighEntropyStringsPlugin):
+            continue
+        for secret in plugin.analyze_line(filename="adhoc", line=line, line_number=1) or []:
+            value = getattr(secret, "secret_value", None)
+            if value:
+                replacements.setdefault(value, _redaction_marker(type(plugin).__name__))
+
+    # Pass 2: whole-token detection for format/entropy-shaped tokens.
+    for token in line.split():
+        if token in replacements:
+            continue
+        plugin_name = _detect_secret(token)
+        if plugin_name is not None:
+            replacements[token] = _redaction_marker(plugin_name)
+
+    redacted = line
+    for value in sorted(replacements, key=len, reverse=True):
+        redacted = redacted.replace(value, replacements[value])
+    return redacted
+
+
+def redact_text(text: str | None) -> str | None:
+    """Redact secrets and absolute paths from a block of free text.
+
+    Used for content read out of skill files (SKILL.md, command markdown,
+    bundled scripts, and other resources), which may contain credentials a
+    user pasted into a skill, as well as absolute paths that leak usernames.
+
+    Detection runs line by line so the plugin set is built once and reused;
+    secret values are spliced out in place (see :func:`_redact_secrets_in_line`)
+    and the whole result then has absolute paths redacted. Returns ``None`` for
+    ``None`` input and the input unchanged when it is empty.
+    """
+    if not text:
+        return text
+    with transient_settings(_DETECT_SECRETS_CONFIG):
+        plugins = list(get_plugins())
+        redacted = "\n".join(_redact_secrets_in_line(line, plugins) for line in text.split("\n"))
+    return redact_absolute_paths(redacted)
+
+
+def redact_signature(signature: ServerSignature) -> ServerSignature:
+    """Redact secrets and absolute paths from a (skill) ``ServerSignature`` in place.
+
+    Skill signatures embed raw file contents in their prompt / resource / tool
+    ``description`` fields, and the skill's frontmatter description in
+    ``metadata.instructions``. Any of these can carry secrets, so every
+    free-text field is run through :func:`redact_text` before the signature
+    leaves the machine.
+
+    This is the single redaction point for skill content: it runs once when the
+    skill is read (in ``skill_client.inspect_skill``), so the later
+    ``redact_scan_result`` passes on the upload / analysis paths find the
+    signature already sanitized.
+    """
+    if signature.metadata is not None and signature.metadata.instructions:
+        signature.metadata.instructions = redact_text(signature.metadata.instructions)
+    for entity in (*signature.prompts, *signature.resources, *signature.resource_templates, *signature.tools):
+        if entity.description:
+            entity.description = redact_text(entity.description)
+    return signature
 
 
 def redact_server(server_scan_result: ServerScanResult) -> ServerScanResult:

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -443,11 +443,14 @@ def redact_args(args: list[str]) -> list[str]:
 _TOKEN_EDGE_CHARS = "`'\"()[]{}<>.,;:!?"
 
 
-def _strip_token_edges(token: str) -> str | None:
-    """Return ``token`` stripped of wrapping markup/punctuation.
+def _unwrapped_token_core(token: str) -> str | None:
+    """Return ``token``'s inner core with wrapping markup/punctuation stripped
+    from its edges -- a fresh candidate to re-scan for secrets.
 
-    Returns ``None`` when stripping changes nothing, so the caller can skip a
-    redundant re-scan of the identical value.
+    Returns ``None`` when stripping yields nothing new: either no wrapper was
+    present (the core equals ``token``) or the token was all edge characters
+    (the core is empty). In both cases the caller has already scanned that exact
+    value, so it can skip a redundant re-scan.
     """
     core = token.strip(_TOKEN_EDGE_CHARS)
     return core if core and core != token else None
@@ -482,7 +485,7 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
        copy. A whole secret-shaped token (AWS key, GitHub token, bare
        high-entropy string) is therefore replaced wholesale -- no partial
        prefix can leak. The raw token is tried first; when it is not flagged,
-       an edge-stripped *core* (see :func:`_strip_token_edges`) is tried as a
+       an edge-stripped *core* (see :func:`_unwrapped_token_core`) is tried as a
        fallback, so a secret wrapped in markdown/punctuation (a backtick code
        span, or a trailing ``"`` from a longer quoted string) is still
        detected. Only the matched candidate substring is replaced, so the
@@ -512,7 +515,7 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
     # tried first (preserving prior behaviour); only when it is not flagged is
     # the edge-stripped core consulted as a fallback.
     for token in line.split():
-        core = _strip_token_edges(token)
+        core = _unwrapped_token_core(token)
         candidates = [token] if core is None else [token, core]
         handled = False
         for candidate in candidates:

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -432,6 +432,27 @@ def redact_args(args: list[str]) -> list[str]:
     return out
 
 
+# Markup/punctuation that commonly *wraps* a secret in skill docs/code but is
+# never part of the secret itself: matched-pair wrappers (quotes, backticks,
+# brackets, parens, angle brackets) plus trailing sentence punctuation. Used to
+# recover a detectable "core" from a whitespace token whose glued wrappers defeat
+# detection (a trailing ``"`` breaks the entropy plugin's quoted-literal regex; a
+# leading backtick fails a format detector's boundary class). Deliberately
+# excludes ``= + / - _`` (legitimate secret characters); ``.`` is only removed as
+# an edge character (``str.strip`` touches the ends only), never internally.
+_TOKEN_EDGE_CHARS = "`'\"()[]{}<>.,;:!?"
+
+
+def _strip_token_edges(token: str) -> str | None:
+    """Return ``token`` stripped of wrapping markup/punctuation.
+
+    Returns ``None`` when stripping changes nothing, so the caller can skip a
+    redundant re-scan of the identical value.
+    """
+    core = token.strip(_TOKEN_EDGE_CHARS)
+    return core if core and core != token else None
+
+
 def _redact_secrets_in_line(line: str, plugins: list) -> str:
     """Redact secret-bearing substrings within a single line of free text.
 
@@ -447,7 +468,12 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
        detectors on the bare token and entropy detectors on a quote-wrapped
        copy. A whole secret-shaped token (AWS key, GitHub token, bare
        high-entropy string) is therefore replaced wholesale -- no partial
-       prefix can leak.
+       prefix can leak. The raw token is tried first; when it is not flagged,
+       an edge-stripped *core* (see :func:`_strip_token_edges`) is tried as a
+       fallback, so a secret wrapped in markdown/punctuation (a backtick code
+       span, or a trailing ``"`` from a longer quoted string) is still
+       detected. Only the matched candidate substring is replaced, so the
+       surrounding markup stays intact.
 
     ``KeywordDetector`` is intentionally NOT used here. Unlike :func:`redact_args`
     (where a flag's value is almost always a credential), skill content is
@@ -474,13 +500,21 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
 
     # Pass 2: whole-token detection for format/entropy-shaped tokens. Reuse the
     # caller's already-built ``plugins`` (under its single transient_settings
-    # context) so we don't re-enter that context per token.
+    # context) so we don't re-enter that context per token. The raw token is
+    # tried first (preserving prior behaviour); only when it is not flagged is
+    # the edge-stripped core consulted as a fallback.
     for token in line.split():
-        if token in replacements:
-            continue
-        plugin_name = _detect_secret(token, plugins)
-        if plugin_name is not None:
-            replacements[token] = _redaction_marker(plugin_name)
+        candidates = [token]
+        core = _strip_token_edges(token)
+        if core is not None:
+            candidates.append(core)
+        for candidate in candidates:
+            if candidate in replacements:
+                break
+            plugin_name = _detect_secret(candidate, plugins)
+            if plugin_name is not None:
+                replacements[candidate] = _redaction_marker(plugin_name)
+                break
 
     redacted = line
     for value in sorted(replacements, key=len, reverse=True):

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -599,14 +599,14 @@ def redact_signature(signature: ServerSignature) -> ServerSignature:
     synthetic binary-file marker (see :func:`_is_synthetic_binary_description`),
     which is left intact so the file's hash digest survives.
 
-    This is the single redaction point for skill content: it runs once when the
-    skill is read (in ``skill_client.inspect_skill``), so the later
-    ``redact_scan_result`` passes on the upload / analysis paths find the
-    signature already sanitized.
+    This is the single redaction point for skill content: nothing downstream
+    redacts the signature (``redact_scan_result`` / ``redact_server`` only touch
+    the server config and errors, never ``.signature``), so it must be sanitized
+    here. It runs once when the skill is read (in ``skill_client.inspect_skill``).
     """
     if signature.metadata is not None and signature.metadata.instructions:
         signature.metadata.instructions = redact_text(signature.metadata.instructions)
-    for entity in (*signature.prompts, *signature.resources, *signature.resource_templates, *signature.tools):
+    for entity in signature.entities:
         if entity.description and not _is_synthetic_binary_description(entity.description):
             entity.description = redact_text(entity.description)
     return signature

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -25,15 +25,12 @@ REDACTED = "**REDACTED**"
 
 _EXCLUDED_PLUGINS = frozenset({"IPPublicDetector"})
 
-# Synthetic description that ``skill_client.traverse_skill_tree`` emits for a
-# binary resource: this fixed prefix followed by the file's sha256 hex digest.
-# It is generated entirely by us and contains no user content, so it is exempt
-# from secret redaction (see ``_is_synthetic_binary_description``) -- otherwise
-# the 64-char digest trips the hex high-entropy detector and every binary
-# collapses to an identical, useless description. ``skill_client`` imports this
-# constant to build the marker so the two cannot drift apart.
-BINARY_FILE_DESCRIPTION_PREFIX = "Binary file. Hash: "
-_BINARY_FILE_DESCRIPTION_RE = re.compile(rf"^{re.escape(BINARY_FILE_DESCRIPTION_PREFIX)}[0-9a-f]{{64}}$")
+# Matches the synthetic binary-file marker that ``skill_client`` emits for a
+# binary resource (its ``BINARY_FILE_DESCRIPTION_PREFIX`` followed by a sha256
+# hex digest). Compiled lazily on first use: the prefix lives in
+# ``skill_client``, which imports ``redact_signature`` from this module, so
+# importing it at module scope here would create a circular import.
+_BINARY_FILE_DESCRIPTION_RE: re.Pattern[str] | None = None
 
 
 def _build_detect_secrets_config() -> dict:
@@ -444,11 +441,21 @@ def redact_text(text: str | None) -> str | None:
 
 def _is_synthetic_binary_description(text: str) -> bool:
     """True if ``text`` is the synthetic binary-file marker emitted for a binary
-    skill resource (see :data:`BINARY_FILE_DESCRIPTION_PREFIX`).
+    skill resource (see ``skill_client.BINARY_FILE_DESCRIPTION_PREFIX``).
 
     Such a description is self-generated (a fixed prefix + sha256 digest) and
     contains no user content, so it is left untouched by redaction.
+
+    The prefix is imported lazily and the compiled pattern cached, so the
+    per-entity redaction path stays off the import and ``skill_client`` (which
+    imports :func:`redact_signature` from this module) can own the constant
+    without a circular import.
     """
+    global _BINARY_FILE_DESCRIPTION_RE
+    if _BINARY_FILE_DESCRIPTION_RE is None:
+        from agent_scan.skill_client import BINARY_FILE_DESCRIPTION_PREFIX
+
+        _BINARY_FILE_DESCRIPTION_RE = re.compile(rf"^{re.escape(BINARY_FILE_DESCRIPTION_PREFIX)}[0-9a-f]{{64}}$")
     return bool(_BINARY_FILE_DESCRIPTION_RE.match(text))
 
 

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -17,6 +17,7 @@ from mcp.types import (
 from yaml.error import YAMLError
 
 from agent_scan.models import ServerSignature, SkillServer
+from agent_scan.redact import redact_signature
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,16 @@ def _inspect_skill_file(expanded_path: str) -> ServerSignature:
 
 
 def inspect_skill(config: SkillServer) -> ServerSignature:
+    """Read a skill (single file or ``<name>/SKILL.md`` directory) into a signature.
+
+    Secrets and absolute paths in the skill's contents are redacted in place
+    here -- the single point where skill files are read -- so the signature is
+    already sanitized by the time it reaches the analysis / upload calls.
+    """
+    return redact_signature(_inspect_skill(config))
+
+
+def _inspect_skill(config: SkillServer) -> ServerSignature:
     logger.info(f"Scanning skill at path: {config.path}")
     expanded_path = os.path.expanduser(config.path)
     if os.path.isfile(expanded_path):

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -17,7 +17,7 @@ from mcp.types import (
 from yaml.error import YAMLError
 
 from agent_scan.models import ServerSignature, SkillServer
-from agent_scan.redact import redact_signature
+from agent_scan.redact import BINARY_FILE_DESCRIPTION_PREFIX, redact_signature
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +195,7 @@ def traverse_skill_tree(skill_path: str, relative_path: str | None) -> tuple[lis
                 logger.exception(f"Error reading file: {file}. The file is not a bianry")
                 with open(os.path.expanduser(full_path), "rb") as f:
                     content_hash = hashlib.sha256(f.read()).hexdigest()
-                content = f"Binary file. Hash: {content_hash}"
+                content = f"{BINARY_FILE_DESCRIPTION_PREFIX}{content_hash}"
             resources.append(
                 Resource(
                     name=file,

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -96,9 +96,9 @@ def _inspect_skill_file(expanded_path: str) -> ServerSignature:
 def inspect_skill(config: SkillServer) -> ServerSignature:
     """Read a skill (single file or ``<name>/SKILL.md`` directory) into a signature.
 
-    Secrets and absolute paths in the skill's contents are redacted in place
-    here -- the single point where skill files are read -- so the signature is
-    already sanitized by the time it reaches the analysis / upload calls.
+    Secrets in the skill's contents are redacted in place here -- the single
+    point where skill files are read -- so the signature is already sanitized by
+    the time it reaches the analysis / upload calls.
     """
     return redact_signature(_inspect_skill(config))
 

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -17,9 +17,19 @@ from mcp.types import (
 from yaml.error import YAMLError
 
 from agent_scan.models import ServerSignature, SkillServer
-from agent_scan.redact import BINARY_FILE_DESCRIPTION_PREFIX, redact_signature
+from agent_scan.redact import redact_signature
 
 logger = logging.getLogger(__name__)
+
+# Synthetic description that ``traverse_skill_tree`` emits for a binary resource:
+# this fixed prefix followed by the file's sha256 hex digest. It is generated
+# entirely by us and contains no user content, so ``redact``'s
+# ``_is_synthetic_binary_description`` exempts it from secret redaction --
+# otherwise the 64-char digest trips the hex high-entropy detector and every
+# binary collapses to an identical, useless description. ``redact`` imports this
+# constant (lazily, to avoid an import cycle) so the marker and matcher cannot
+# drift apart.
+BINARY_FILE_DESCRIPTION_PREFIX = "Binary file. Hash: "
 
 # Cap traversal depth when walking a commands dir, mirroring the value used by
 # the discoverer plugin/extension walks (``agents.base._MAX_PLUGIN_RGLOB_DEPTH``).

--- a/tests/unit/_secret_fixtures.py
+++ b/tests/unit/_secret_fixtures.py
@@ -1,0 +1,20 @@
+"""Test-only helpers for synthesizing fake high-entropy credentials.
+
+Redaction tests need a value that detect-secrets flags as a secret, but checking
+a static high-entropy literal into the repo trips secret scanners (e.g.
+GitGuardian). These helpers derive such a value at runtime instead.
+"""
+
+import base64
+import hashlib
+
+
+def synthetic_secret(seed: bytes = b"agent-scan synthetic test credential") -> str:
+    """Return a reproducible, high-entropy alphanumeric token for redaction tests.
+
+    Derived from a SHA-256 of ``seed`` (base64-encoded, alphanumerics only) so it
+    trips detect-secrets' Base64HighEntropyString plugin in both quoted and
+    unquoted contexts, without being a hardcoded secret literal.
+    """
+    encoded = base64.b64encode(hashlib.sha256(seed).digest()).decode()
+    return "".join(c for c in encoded if c.isalnum())

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -678,6 +678,66 @@ class TestRedactText:
         text = "see (example) and `config` here, then stop."
         assert redact_text(text) == text
 
+    @pytest.mark.parametrize(
+        "embedded",
+        [
+            "https://host/{tok}/more",  # secret as a URL path segment
+            "https://h/p?token={tok}&x=1",  # secret as a URL query value
+            "prefix.{tok}.suffix",  # dot-delimited
+            "scope:{tok}:end",  # colon-delimited
+            "a,{tok},b",  # comma-delimited
+            "user@{tok}@host",  # at-delimited
+        ],
+    )
+    def test_redact_text_redacts_delimiter_embedded_token(self, embedded):
+        """A high-entropy secret separated from surrounding text by a structural
+        delimiter (a URL path/query segment, a dotted or colon-joined value)
+        rides along inside one whitespace token; it is recovered by splitting on
+        those delimiters and redacted."""
+        text = embedded.format(tok=FAKE_API_KEY)
+        result = redact_text(text)
+        assert FAKE_API_KEY not in result
+        assert "**REDACTED_SECRET_" in result
+
+    def test_redact_text_preserves_structure_around_delimited_secret(self):
+        """Only the secret segment is replaced; the surrounding URL structure is
+        left intact."""
+        text = f"https://host/{FAKE_API_KEY}/more"
+        result = redact_text(text)
+        assert FAKE_API_KEY not in result
+        assert result.startswith("https://host/")
+        assert result.endswith("/more")
+
+    def test_redact_text_redacts_multiple_delimited_secrets_in_one_token(self):
+        """Two secrets joined by a delimiter in a single token are both redacted.
+
+        A ``.`` joiner (unlike ``/``) is outside the base64 charset, so the
+        token is not flagged wholesale by the entropy scan -- both halves are
+        recovered by the delimiter split.
+        """
+        second = synthetic_secret(b"second delimiter-embedded probe token")
+        assert second != FAKE_API_KEY
+        text = f"{FAKE_API_KEY}.{second}"
+        result = redact_text(text)
+        assert FAKE_API_KEY not in result
+        assert second not in result
+
+    @pytest.mark.parametrize(
+        "benign",
+        [
+            "/usr/local/bin/python3",  # filesystem path
+            "release 1.22.333.4444 now",  # dotted version
+            "connect to 192.168.10.254 ok",  # IPv4 address
+            "import os.path.join here",  # dotted module path
+            "see https://example.com/docs/guide here",  # plain URL, no secret
+        ],
+    )
+    def test_redact_text_preserves_benign_delimited_text(self, benign):
+        """Splitting on structural delimiters must not over-redact benign
+        delimited text: paths, versions, IPs, dotted names, and secret-free URLs
+        are returned unchanged."""
+        assert redact_text(benign) == benign
+
 
 def _skill_signature(*, instructions="", prompts=None, resources=None, tools=None) -> ServerSignature:
     return ServerSignature(

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -570,21 +570,9 @@ class TestRedactText:
         assert "AKIAIOSFODNN7EXAMPLE" not in result
         assert "**REDACTED_SECRET_AWSKEYDETECTOR**" in result
 
-    def test_redact_text_preserves_low_entropy_keyword_value(self):
-        """Keyword-only, low-entropy values are intentionally NOT redacted.
-
-        Skill content is documentation/code where a ``password``/``api_key``
-        keyword next to a value is usually legitimate context, not a live
-        secret. Redacting on keyword alone would strip analysis context, so
-        only high-entropy / known-format secrets are removed.
-        """
-        text = 'config = {"password": "changeme"}'
-        result = redact_text(text)
-        assert result == text
-
-    def test_redact_text_redacts_high_entropy_keyword_value(self):
-        """A keyword value that IS high-entropy is still redacted (by the
-        entropy detector, not by keyword context)."""
+    def test_redact_text_redacts_high_entropy_value_in_assignment(self):
+        """A high-entropy value in a quoted assignment is redacted by the
+        entropy detector."""
         text = f'config = {{"password": "{FAKE_API_KEY}"}}'
         result = redact_text(text)
         assert FAKE_API_KEY not in result

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -397,6 +397,147 @@ class TestRedactArgs:
         assert result[1] == "**REDACTED_SECRET_SENSITIVEFLAGNAME**"
 
 
+class TestRedactData:
+    """Unit tests for redact_data function."""
+
+    def test_no_match_preserves_values(self):
+        patterns = [re.compile(r"SECRET=(\w+)")]
+        data = {"key": "no match here", "nested": {"deep": "also safe"}}
+        redact_data(data, patterns)
+        assert data == {"key": "no match here", "nested": {"deep": "also safe"}}
+
+    def test_simple_capture_group_replaced(self):
+        patterns = [re.compile(r"TOKEN=(\w+)")]
+        data = {"cmd": "TOKEN=abc123 OTHER=keep"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "TOKEN=**REDACTED** OTHER=keep"
+
+    def test_multiple_patterns_applied(self):
+        patterns = [
+            re.compile(r"KEY='([^']*)'"),
+            re.compile(r"SECRET='([^']*)'"),
+        ]
+        data = {"cmd": "KEY='val1' SECRET='val2' FLAG=ok"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "KEY='**REDACTED**' SECRET='**REDACTED**' FLAG=ok"
+
+    def test_deep_nested_dict(self):
+        patterns = [re.compile(r"password=(\S+)")]
+        data = {"a": {"b": {"c": "password=hunter2 user=admin"}}}
+        redact_data(data, patterns)
+        assert data["a"]["b"]["c"] == "password=**REDACTED** user=admin"
+
+    def test_list_values_traversed(self):
+        patterns = [re.compile(r"secret:(\w+)")]
+        data = {"items": ["secret:abc", "safe", "secret:def"]}
+        redact_data(data, patterns)
+        assert data["items"] == ["secret:**REDACTED**", "safe", "secret:**REDACTED**"]
+
+    def test_nested_list_of_dicts(self):
+        patterns = [re.compile(r"KEY='([^']*)'")]
+        data = {"hooks": [{"command": "KEY='secret1'"}, {"command": "KEY='secret2'"}]}
+        redact_data(data, patterns)
+        assert data["hooks"][0]["command"] == "KEY='**REDACTED**'"
+        assert data["hooks"][1]["command"] == "KEY='**REDACTED**'"
+
+    def test_multiple_matches_in_same_string(self):
+        patterns = [re.compile(r"TOKEN=([0-9a-f]+)", re.IGNORECASE)]
+        data = {"cmd": "TOKEN=aabb TOKEN=ccdd"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "TOKEN=**REDACTED** TOKEN=**REDACTED**"
+
+    def test_capture_group_with_lookahead(self):
+        patterns = [re.compile(r"PUSH_KEY='([^']*)'")]
+        data = {"cmd": "PUSH_KEY='my-secret' URL='https://example.com'"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "PUSH_KEY='**REDACTED**' URL='https://example.com'"
+
+    def test_uuid_pattern(self):
+        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        patterns = [re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE)]
+        data = {"cmd": "PUSH_KEY='a1b2c3d4-e5f6-7890-abcd-ef1234567890' bash script.sh"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "PUSH_KEY='**REDACTED**' bash script.sh"
+
+    def test_uuid_pattern_non_uuid_value_preserved(self):
+        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        patterns = [re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE)]
+        data = {"cmd": "PUSH_KEY='not-a-uuid' bash script.sh"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "PUSH_KEY='not-a-uuid' bash script.sh"
+
+    def test_non_string_values_ignored(self):
+        patterns = [re.compile(r"secret=(\w+)")]
+        data = {"count": 42, "flag": True, "empty": None, "text": "secret=abc"}
+        redact_data(data, patterns)
+        assert data["count"] == 42
+        assert data["flag"] is True
+        assert data["empty"] is None
+        assert data["text"] == "secret=**REDACTED**"
+
+    def test_empty_dict(self):
+        patterns = [re.compile(r"KEY=(\w+)")]
+        data: dict = {}
+        result = redact_data(data, patterns)
+        assert result == {}
+
+    def test_empty_patterns_list(self):
+        data = {"cmd": "KEY='secret' VALUE=123"}
+        redact_data(data, [])
+        assert data == {"cmd": "KEY='secret' VALUE=123"}
+
+    def test_mutates_in_place_and_returns(self):
+        patterns = [re.compile(r"KEY=(\w+)")]
+        data = {"cmd": "KEY=secret"}
+        result = redact_data(data, patterns)
+        assert result is data
+        assert data["cmd"] == "KEY=**REDACTED**"
+
+    def test_mixed_list_with_non_strings(self):
+        patterns = [re.compile(r"tok=(\w+)")]
+        data = {"items": ["tok=abc", 42, {"nested": "tok=def"}, True, None]}
+        redact_data(data, patterns)
+        assert data["items"][0] == "tok=**REDACTED**"
+        assert data["items"][1] == 42
+        assert data["items"][2] == {"nested": "tok=**REDACTED**"}
+        assert data["items"][3] is True
+        assert data["items"][4] is None
+
+    def test_hooks_diff_realistic_payload(self):
+        """Realistic hooks diff payload with push keys in command strings."""
+        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        patterns = [
+            re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE),
+            re.compile(rf"-PushKey\s+'({uuid_re})'", re.IGNORECASE),
+        ]
+        push_key = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        command = f"PUSH_KEY='{push_key}' REMOTE_HOOKS_BASE_URL='https://api.snyk.io' bash /path/to/script.sh --client claude-code"
+        data = {
+            "hook_event_name": "hooksConfigured",
+            "session_id": "hooks-setup",
+            "first_install": False,
+            "config_changed": True,
+            "added": {},
+            "modified": {
+                "PreToolUse": {
+                    "expected_value": [{"hooks": [{"type": "command", "command": command}]}],
+                    "actual_value": [{"hooks": [{"type": "command", "command": "old-command"}]}],
+                },
+            },
+            "removed": {
+                "Stop": [{"hooks": [{"type": "command", "command": command}]}],
+            },
+        }
+        redact_data(data, patterns)
+        assert push_key not in str(data)
+        assert "**REDACTED**" in data["modified"]["PreToolUse"]["expected_value"][0]["hooks"][0]["command"]
+        assert (
+            "REMOTE_HOOKS_BASE_URL='https://api.snyk.io'"
+            in data["modified"]["PreToolUse"]["expected_value"][0]["hooks"][0]["command"]
+        )
+        assert data["session_id"] == "hooks-setup"
+
+
 class TestRedactText:
     """Unit tests for redact_text (free-text secret + path redaction)."""
 
@@ -724,147 +865,6 @@ def test_redact_scan_result_removes_api_key(server, kind):
 # ---------------------------------------------------------------------------
 # _is_uuid_like
 # ---------------------------------------------------------------------------
-
-
-class TestRedactData:
-    """Unit tests for redact_data function."""
-
-    def test_no_match_preserves_values(self):
-        patterns = [re.compile(r"SECRET=(\w+)")]
-        data = {"key": "no match here", "nested": {"deep": "also safe"}}
-        redact_data(data, patterns)
-        assert data == {"key": "no match here", "nested": {"deep": "also safe"}}
-
-    def test_simple_capture_group_replaced(self):
-        patterns = [re.compile(r"TOKEN=(\w+)")]
-        data = {"cmd": "TOKEN=abc123 OTHER=keep"}
-        redact_data(data, patterns)
-        assert data["cmd"] == "TOKEN=**REDACTED** OTHER=keep"
-
-    def test_multiple_patterns_applied(self):
-        patterns = [
-            re.compile(r"KEY='([^']*)'"),
-            re.compile(r"SECRET='([^']*)'"),
-        ]
-        data = {"cmd": "KEY='val1' SECRET='val2' FLAG=ok"}
-        redact_data(data, patterns)
-        assert data["cmd"] == "KEY='**REDACTED**' SECRET='**REDACTED**' FLAG=ok"
-
-    def test_deep_nested_dict(self):
-        patterns = [re.compile(r"password=(\S+)")]
-        data = {"a": {"b": {"c": "password=hunter2 user=admin"}}}
-        redact_data(data, patterns)
-        assert data["a"]["b"]["c"] == "password=**REDACTED** user=admin"
-
-    def test_list_values_traversed(self):
-        patterns = [re.compile(r"secret:(\w+)")]
-        data = {"items": ["secret:abc", "safe", "secret:def"]}
-        redact_data(data, patterns)
-        assert data["items"] == ["secret:**REDACTED**", "safe", "secret:**REDACTED**"]
-
-    def test_nested_list_of_dicts(self):
-        patterns = [re.compile(r"KEY='([^']*)'")]
-        data = {"hooks": [{"command": "KEY='secret1'"}, {"command": "KEY='secret2'"}]}
-        redact_data(data, patterns)
-        assert data["hooks"][0]["command"] == "KEY='**REDACTED**'"
-        assert data["hooks"][1]["command"] == "KEY='**REDACTED**'"
-
-    def test_multiple_matches_in_same_string(self):
-        patterns = [re.compile(r"TOKEN=([0-9a-f]+)", re.IGNORECASE)]
-        data = {"cmd": "TOKEN=aabb TOKEN=ccdd"}
-        redact_data(data, patterns)
-        assert data["cmd"] == "TOKEN=**REDACTED** TOKEN=**REDACTED**"
-
-    def test_capture_group_with_lookahead(self):
-        patterns = [re.compile(r"PUSH_KEY='([^']*)'")]
-        data = {"cmd": "PUSH_KEY='my-secret' URL='https://example.com'"}
-        redact_data(data, patterns)
-        assert data["cmd"] == "PUSH_KEY='**REDACTED**' URL='https://example.com'"
-
-    def test_uuid_pattern(self):
-        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-        patterns = [re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE)]
-        data = {"cmd": "PUSH_KEY='a1b2c3d4-e5f6-7890-abcd-ef1234567890' bash script.sh"}
-        redact_data(data, patterns)
-        assert data["cmd"] == "PUSH_KEY='**REDACTED**' bash script.sh"
-
-    def test_uuid_pattern_non_uuid_value_preserved(self):
-        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-        patterns = [re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE)]
-        data = {"cmd": "PUSH_KEY='not-a-uuid' bash script.sh"}
-        redact_data(data, patterns)
-        assert data["cmd"] == "PUSH_KEY='not-a-uuid' bash script.sh"
-
-    def test_non_string_values_ignored(self):
-        patterns = [re.compile(r"secret=(\w+)")]
-        data = {"count": 42, "flag": True, "empty": None, "text": "secret=abc"}
-        redact_data(data, patterns)
-        assert data["count"] == 42
-        assert data["flag"] is True
-        assert data["empty"] is None
-        assert data["text"] == "secret=**REDACTED**"
-
-    def test_empty_dict(self):
-        patterns = [re.compile(r"KEY=(\w+)")]
-        data: dict = {}
-        result = redact_data(data, patterns)
-        assert result == {}
-
-    def test_empty_patterns_list(self):
-        data = {"cmd": "KEY='secret' VALUE=123"}
-        redact_data(data, [])
-        assert data == {"cmd": "KEY='secret' VALUE=123"}
-
-    def test_mutates_in_place_and_returns(self):
-        patterns = [re.compile(r"KEY=(\w+)")]
-        data = {"cmd": "KEY=secret"}
-        result = redact_data(data, patterns)
-        assert result is data
-        assert data["cmd"] == "KEY=**REDACTED**"
-
-    def test_mixed_list_with_non_strings(self):
-        patterns = [re.compile(r"tok=(\w+)")]
-        data = {"items": ["tok=abc", 42, {"nested": "tok=def"}, True, None]}
-        redact_data(data, patterns)
-        assert data["items"][0] == "tok=**REDACTED**"
-        assert data["items"][1] == 42
-        assert data["items"][2] == {"nested": "tok=**REDACTED**"}
-        assert data["items"][3] is True
-        assert data["items"][4] is None
-
-    def test_hooks_diff_realistic_payload(self):
-        """Realistic hooks diff payload with push keys in command strings."""
-        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-        patterns = [
-            re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE),
-            re.compile(rf"-PushKey\s+'({uuid_re})'", re.IGNORECASE),
-        ]
-        push_key = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        command = f"PUSH_KEY='{push_key}' REMOTE_HOOKS_BASE_URL='https://api.snyk.io' bash /path/to/script.sh --client claude-code"
-        data = {
-            "hook_event_name": "hooksConfigured",
-            "session_id": "hooks-setup",
-            "first_install": False,
-            "config_changed": True,
-            "added": {},
-            "modified": {
-                "PreToolUse": {
-                    "expected_value": [{"hooks": [{"type": "command", "command": command}]}],
-                    "actual_value": [{"hooks": [{"type": "command", "command": "old-command"}]}],
-                },
-            },
-            "removed": {
-                "Stop": [{"hooks": [{"type": "command", "command": command}]}],
-            },
-        }
-        redact_data(data, patterns)
-        assert push_key not in str(data)
-        assert "**REDACTED**" in data["modified"]["PreToolUse"]["expected_value"][0]["hooks"][0]["command"]
-        assert (
-            "REMOTE_HOOKS_BASE_URL='https://api.snyk.io'"
-            in data["modified"]["PreToolUse"]["expected_value"][0]["hooks"][0]["command"]
-        )
-        assert data["session_id"] == "hooks-setup"
 
 
 class TestIsUuidLike:

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -18,6 +18,7 @@ from agent_scan.redact import (
     _is_uuid_like,
     redact_absolute_paths,
     redact_args,
+    redact_data,
     redact_push_keys,
     redact_push_keys_in_data,
     redact_scan_result,
@@ -723,6 +724,147 @@ def test_redact_scan_result_removes_api_key(server, kind):
 # ---------------------------------------------------------------------------
 # _is_uuid_like
 # ---------------------------------------------------------------------------
+
+
+class TestRedactData:
+    """Unit tests for redact_data function."""
+
+    def test_no_match_preserves_values(self):
+        patterns = [re.compile(r"SECRET=(\w+)")]
+        data = {"key": "no match here", "nested": {"deep": "also safe"}}
+        redact_data(data, patterns)
+        assert data == {"key": "no match here", "nested": {"deep": "also safe"}}
+
+    def test_simple_capture_group_replaced(self):
+        patterns = [re.compile(r"TOKEN=(\w+)")]
+        data = {"cmd": "TOKEN=abc123 OTHER=keep"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "TOKEN=**REDACTED** OTHER=keep"
+
+    def test_multiple_patterns_applied(self):
+        patterns = [
+            re.compile(r"KEY='([^']*)'"),
+            re.compile(r"SECRET='([^']*)'"),
+        ]
+        data = {"cmd": "KEY='val1' SECRET='val2' FLAG=ok"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "KEY='**REDACTED**' SECRET='**REDACTED**' FLAG=ok"
+
+    def test_deep_nested_dict(self):
+        patterns = [re.compile(r"password=(\S+)")]
+        data = {"a": {"b": {"c": "password=hunter2 user=admin"}}}
+        redact_data(data, patterns)
+        assert data["a"]["b"]["c"] == "password=**REDACTED** user=admin"
+
+    def test_list_values_traversed(self):
+        patterns = [re.compile(r"secret:(\w+)")]
+        data = {"items": ["secret:abc", "safe", "secret:def"]}
+        redact_data(data, patterns)
+        assert data["items"] == ["secret:**REDACTED**", "safe", "secret:**REDACTED**"]
+
+    def test_nested_list_of_dicts(self):
+        patterns = [re.compile(r"KEY='([^']*)'")]
+        data = {"hooks": [{"command": "KEY='secret1'"}, {"command": "KEY='secret2'"}]}
+        redact_data(data, patterns)
+        assert data["hooks"][0]["command"] == "KEY='**REDACTED**'"
+        assert data["hooks"][1]["command"] == "KEY='**REDACTED**'"
+
+    def test_multiple_matches_in_same_string(self):
+        patterns = [re.compile(r"TOKEN=([0-9a-f]+)", re.IGNORECASE)]
+        data = {"cmd": "TOKEN=aabb TOKEN=ccdd"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "TOKEN=**REDACTED** TOKEN=**REDACTED**"
+
+    def test_capture_group_with_lookahead(self):
+        patterns = [re.compile(r"PUSH_KEY='([^']*)'")]
+        data = {"cmd": "PUSH_KEY='my-secret' URL='https://example.com'"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "PUSH_KEY='**REDACTED**' URL='https://example.com'"
+
+    def test_uuid_pattern(self):
+        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        patterns = [re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE)]
+        data = {"cmd": "PUSH_KEY='a1b2c3d4-e5f6-7890-abcd-ef1234567890' bash script.sh"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "PUSH_KEY='**REDACTED**' bash script.sh"
+
+    def test_uuid_pattern_non_uuid_value_preserved(self):
+        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        patterns = [re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE)]
+        data = {"cmd": "PUSH_KEY='not-a-uuid' bash script.sh"}
+        redact_data(data, patterns)
+        assert data["cmd"] == "PUSH_KEY='not-a-uuid' bash script.sh"
+
+    def test_non_string_values_ignored(self):
+        patterns = [re.compile(r"secret=(\w+)")]
+        data = {"count": 42, "flag": True, "empty": None, "text": "secret=abc"}
+        redact_data(data, patterns)
+        assert data["count"] == 42
+        assert data["flag"] is True
+        assert data["empty"] is None
+        assert data["text"] == "secret=**REDACTED**"
+
+    def test_empty_dict(self):
+        patterns = [re.compile(r"KEY=(\w+)")]
+        data: dict = {}
+        result = redact_data(data, patterns)
+        assert result == {}
+
+    def test_empty_patterns_list(self):
+        data = {"cmd": "KEY='secret' VALUE=123"}
+        redact_data(data, [])
+        assert data == {"cmd": "KEY='secret' VALUE=123"}
+
+    def test_mutates_in_place_and_returns(self):
+        patterns = [re.compile(r"KEY=(\w+)")]
+        data = {"cmd": "KEY=secret"}
+        result = redact_data(data, patterns)
+        assert result is data
+        assert data["cmd"] == "KEY=**REDACTED**"
+
+    def test_mixed_list_with_non_strings(self):
+        patterns = [re.compile(r"tok=(\w+)")]
+        data = {"items": ["tok=abc", 42, {"nested": "tok=def"}, True, None]}
+        redact_data(data, patterns)
+        assert data["items"][0] == "tok=**REDACTED**"
+        assert data["items"][1] == 42
+        assert data["items"][2] == {"nested": "tok=**REDACTED**"}
+        assert data["items"][3] is True
+        assert data["items"][4] is None
+
+    def test_hooks_diff_realistic_payload(self):
+        """Realistic hooks diff payload with push keys in command strings."""
+        uuid_re = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        patterns = [
+            re.compile(rf"PUSH_KEY='({uuid_re})'", re.IGNORECASE),
+            re.compile(rf"-PushKey\s+'({uuid_re})'", re.IGNORECASE),
+        ]
+        push_key = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        command = f"PUSH_KEY='{push_key}' REMOTE_HOOKS_BASE_URL='https://api.snyk.io' bash /path/to/script.sh --client claude-code"
+        data = {
+            "hook_event_name": "hooksConfigured",
+            "session_id": "hooks-setup",
+            "first_install": False,
+            "config_changed": True,
+            "added": {},
+            "modified": {
+                "PreToolUse": {
+                    "expected_value": [{"hooks": [{"type": "command", "command": command}]}],
+                    "actual_value": [{"hooks": [{"type": "command", "command": "old-command"}]}],
+                },
+            },
+            "removed": {
+                "Stop": [{"hooks": [{"type": "command", "command": command}]}],
+            },
+        }
+        redact_data(data, patterns)
+        assert push_key not in str(data)
+        assert "**REDACTED**" in data["modified"]["PreToolUse"]["expected_value"][0]["hooks"][0]["command"]
+        assert (
+            "REMOTE_HOOKS_BASE_URL='https://api.snyk.io'"
+            in data["modified"]["PreToolUse"]["expected_value"][0]["hooks"][0]["command"]
+        )
+        assert data["session_id"] == "hooks-setup"
 
 
 class TestIsUuidLike:

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -4,16 +4,30 @@ import re
 from urllib.parse import parse_qsl, urlsplit
 
 import pytest
+from mcp.types import (
+    Implementation,
+    InitializeResult,
+    Prompt,
+    Resource,
+    ServerCapabilities,
+    Tool,
+)
 
-from agent_scan.models import RemoteServer, ScanPathResult, ServerScanResult, StdioServer
-from agent_scan.redact import redact_absolute_paths, redact_args, redact_scan_result
+from agent_scan.models import RemoteServer, ScanPathResult, ServerScanResult, ServerSignature, StdioServer
+from agent_scan.redact import (
+    redact_absolute_paths,
+    redact_args,
+    redact_scan_result,
+    redact_signature,
+    redact_text,
+)
+from tests.unit._secret_fixtures import synthetic_secret
 
-# High-entropy 40-char mixed-case+digit literal that should be flagged by
-# detect-secrets' default high-entropy plugins. NOT a known-prefix token
-# (the user explicitly forbade ghp_/sk-proj-/etc.). If during the red phase
-# this exact string is not flagged by the default plugins, swap to another
-# high-entropy random string of similar shape.
-FAKE_API_KEY = "Xk9mPq2vNwBzRtY7Lc4hJfDsAe6uGiQoVpWbZxMr"
+# High-entropy fake credential that detect-secrets' default high-entropy plugins
+# flag. Derived at runtime (see ``synthetic_secret``) rather than a hardcoded
+# literal so repo secret scanners don't flag a checked-in secret. NOT a
+# known-prefix token (ghp_/sk-proj-/etc. are intentionally avoided).
+FAKE_API_KEY = synthetic_secret()
 
 # Match the **REDACTED_SECRET_<PLUGIN>** marker shape without hardcoding which
 # detect-secrets plugin won the race. The plugin set may change across
@@ -377,6 +391,116 @@ class TestRedactArgs:
         args = ["--push-key", "foo123"]
         result = redact_args(args)
         assert result[1] == "**REDACTED_SECRET_SENSITIVEFLAGNAME**"
+
+
+class TestRedactText:
+    """Unit tests for redact_text (free-text secret + path redaction)."""
+
+    def test_redact_text_none(self):
+        assert redact_text(None) is None
+
+    def test_redact_text_empty(self):
+        assert redact_text("") == ""
+
+    def test_redact_text_preserves_innocuous_content(self):
+        text = "# My Skill\n\nThis skill fetches the weather for a given city.\n"
+        assert redact_text(text) == text
+
+    def test_redact_text_redacts_bare_high_entropy_token(self):
+        text = f"Use this token: {FAKE_API_KEY}\n"
+        result = redact_text(text)
+        assert FAKE_API_KEY not in result
+        assert "**REDACTED_SECRET_" in result
+
+    def test_redact_text_redacts_known_format_token(self):
+        text = "Authenticate with AKIAIOSFODNN7EXAMPLE before running."
+        result = redact_text(text)
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+        assert "**REDACTED_SECRET_AWSKEYDETECTOR**" in result
+
+    def test_redact_text_preserves_low_entropy_keyword_value(self):
+        """Keyword-only, low-entropy values are intentionally NOT redacted.
+
+        Skill content is documentation/code where a ``password``/``api_key``
+        keyword next to a value is usually legitimate context, not a live
+        secret. Redacting on keyword alone would strip analysis context, so
+        only high-entropy / known-format secrets are removed.
+        """
+        text = 'config = {"password": "changeme"}'
+        result = redact_text(text)
+        assert result == text
+
+    def test_redact_text_redacts_high_entropy_keyword_value(self):
+        """A keyword value that IS high-entropy is still redacted (by the
+        entropy detector, not by keyword context)."""
+        text = f'config = {{"password": "{FAKE_API_KEY}"}}'
+        result = redact_text(text)
+        assert FAKE_API_KEY not in result
+        assert "**REDACTED_SECRET_" in result
+
+    def test_redact_text_redacts_absolute_paths(self):
+        text = "Loading from /Users/alice/project/config.json"
+        result = redact_text(text)
+        assert "/Users/alice/project/config.json" not in result
+        assert "**REDACTED**" in result
+
+    def test_redact_text_preserves_line_structure(self):
+        text = f"line one\n{FAKE_API_KEY}\nline three"
+        result = redact_text(text)
+        lines = result.split("\n")
+        assert lines[0] == "line one"
+        assert is_secret_marker(lines[1])
+        assert lines[2] == "line three"
+
+
+def _skill_signature(*, instructions="", prompts=None, resources=None, tools=None) -> ServerSignature:
+    return ServerSignature(
+        metadata=InitializeResult(
+            protocolVersion="built-in",
+            instructions=instructions,
+            capabilities=ServerCapabilities(),
+            serverInfo=Implementation(name="skill", version="skills"),
+        ),
+        prompts=prompts or [],
+        resources=resources or [],
+        tools=tools or [],
+    )
+
+
+class TestRedactSignature:
+    """Unit tests for redact_signature (skill ServerSignature redaction)."""
+
+    def test_redact_signature_redacts_instructions(self):
+        sig = _skill_signature(instructions=f"Skill that uses {FAKE_API_KEY}")
+        redact_signature(sig)
+        assert FAKE_API_KEY not in sig.metadata.instructions
+
+    def test_redact_signature_redacts_prompt_description(self):
+        sig = _skill_signature(prompts=[Prompt(name="SKILL.md", description=f"key: {FAKE_API_KEY}")])
+        redact_signature(sig)
+        assert FAKE_API_KEY not in (sig.prompts[0].description or "")
+
+    def test_redact_signature_redacts_resource_and_tool_descriptions(self):
+        sig = _skill_signature(
+            resources=[Resource(name="data", uri="skill://data", description=f"secret {FAKE_API_KEY}")],
+            tools=[
+                Tool(name="run.sh", description=f"Script: run.sh. Code:\nexport TOKEN={FAKE_API_KEY}", inputSchema={})
+            ],
+        )
+        redact_signature(sig)
+        assert FAKE_API_KEY not in (sig.resources[0].description or "")
+        assert FAKE_API_KEY not in (sig.tools[0].description or "")
+        # The non-secret structure around the secret is preserved.
+        assert sig.tools[0].description.startswith("Script: run.sh. Code:")
+
+    def test_redact_signature_preserves_clean_content(self):
+        sig = _skill_signature(
+            instructions="A helpful skill",
+            prompts=[Prompt(name="SKILL.md", description="# Title\nDoes something useful.")],
+        )
+        redact_signature(sig)
+        assert sig.metadata.instructions == "A helpful skill"
+        assert sig.prompts[0].description == "# Title\nDoes something useful."
 
 
 def test_redact_remote_url_query_and_headers():

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -33,6 +33,13 @@ from tests.unit._secret_fixtures import synthetic_secret
 # known-prefix token (ghp_/sk-proj-/etc. are intentionally avoided).
 FAKE_API_KEY = synthetic_secret()
 
+# Artifactory-format fake token (matches ``AKC[A-Za-z0-9]{10,}``). Built from a
+# synthetic seed so no high-entropy literal is checked in. ArtifactoryDetector
+# anchors on the char *before* ``AKC`` (must be one of ``\s = : " ^``), so a bare
+# token is flagged but a backtick-wrapped one is not -- the edge-strip fallback
+# is what closes that gap.
+FAKE_ARTIFACTORY_TOKEN = "AKC" + synthetic_secret(b"artifactory fixture token")
+
 # Match the **REDACTED_SECRET_<PLUGIN>** marker shape without hardcoding which
 # detect-secrets plugin won the race. The plugin set may change across
 # detect-secrets versions; the marker shape will not.
@@ -637,6 +644,51 @@ class TestRedactText:
         # ...and detection still works under the single-context path.
         assert FAKE_API_KEY not in result
         assert "**REDACTED_SECRET_" in result
+
+    @pytest.mark.parametrize(
+        "wrapped",
+        [
+            'key: "the deploy value is {tok}"',  # token last word in a longer quoted string
+            "use `{tok}` now",  # markdown code span
+            "see ({tok}) here",  # parenthesised
+            "see [{tok}] here",  # bracketed
+            "token {tok}. done",  # trailing sentence period
+            "token {tok}, done",  # trailing comma
+        ],
+    )
+    def test_redact_text_redacts_wrapped_high_entropy_token(self, wrapped):
+        """A high-entropy token wrapped in markup/punctuation is still redacted.
+
+        Pass 2 splits on whitespace, so wrapping characters ride along with the
+        token: a trailing ``"`` defeats the entropy plugin's quoted-literal
+        regex, and a long low-entropy quoted string hides the secret from the
+        raw-line scan. The edge-strip fallback recovers the bare core and
+        redacts it. (Fully-quoted single-token forms like ``"<tok>"`` are
+        already covered by the Pass-1 raw-line scan and are not retested here.)
+        """
+        text = wrapped.format(tok=FAKE_API_KEY)
+        result = redact_text(text)
+        assert FAKE_API_KEY not in result
+        assert "**REDACTED_SECRET_" in result
+
+    def test_redact_text_redacts_backtick_wrapped_format_token(self):
+        r"""A boundary-anchored format token (Artifactory) in a markdown code span
+        is redacted via the edge-strip fallback.
+
+        ``ArtifactoryDetector`` requires the char before ``AKC`` to be one of
+        ``\s = : " ^``; a backtick is not, so the raw backtick-wrapped token
+        never matched. Stripping the backticks recovers a detectable core.
+        """
+        text = f"use the token `{FAKE_ARTIFACTORY_TOKEN}` to publish"
+        result = redact_text(text)
+        assert FAKE_ARTIFACTORY_TOKEN not in result
+        assert "**REDACTED_SECRET_ARTIFACTORYDETECTOR**" in result
+
+    def test_redact_text_preserves_wrapped_non_secret(self):
+        """Edge-stripping must not over-redact: non-secret tokens wrapped in
+        punctuation are returned unchanged."""
+        text = "see (example) and `config` here, then stop."
+        assert redact_text(text) == text
 
 
 def _skill_signature(*, instructions="", prompts=None, resources=None, tools=None) -> ServerSignature:

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -438,11 +438,14 @@ class TestRedactText:
         assert FAKE_API_KEY not in result
         assert "**REDACTED_SECRET_" in result
 
-    def test_redact_text_redacts_absolute_paths(self):
+    def test_redact_text_preserves_absolute_paths(self):
+        """Skill content (docs/code) routinely references real paths as legitimate
+        context, so redact_text leaves absolute paths intact and only strips
+        secrets. (Tracebacks and server output still get path redaction via
+        redact_server / redact_scan_result.)"""
         text = "Loading from /Users/alice/project/config.json"
         result = redact_text(text)
-        assert "/Users/alice/project/config.json" not in result
-        assert "**REDACTED**" in result
+        assert result == text
 
     def test_redact_text_preserves_line_structure(self):
         text = f"line one\n{FAKE_API_KEY}\nline three"

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -452,6 +452,44 @@ class TestRedactText:
         assert is_secret_marker(lines[1])
         assert lines[2] == "line three"
 
+    def test_redact_text_enters_detect_secrets_context_once(self, monkeypatch):
+        """redact_text must enter the detect-secrets settings context exactly
+        once for the whole text, not once per token.
+
+        Re-entering ``transient_settings`` runs detect-secrets' ``cache_bust``
+        twice each time (~1.3ms), so a per-token re-entry makes redaction
+        O(tokens) -- a large bundled script then takes tens of seconds. The
+        per-token detection path must reuse the already-built plugin set under
+        the single outer context instead.
+        """
+        import contextlib
+
+        import agent_scan.redact as redact_mod
+
+        real_transient_settings = redact_mod.transient_settings
+        entries = 0
+
+        @contextlib.contextmanager
+        def counting_transient_settings(*args, **kwargs):
+            nonlocal entries
+            entries += 1
+            with real_transient_settings(*args, **kwargs) as value:
+                yield value
+
+        monkeypatch.setattr(redact_mod, "transient_settings", counting_transient_settings)
+
+        # Many whitespace tokens across several lines, including a real secret,
+        # so the per-token detection pass runs repeatedly.
+        text = "\n".join("alpha beta gamma delta epsilon zeta" for _ in range(20))
+        text += f"\nthe secret is {FAKE_API_KEY}\n"
+
+        result = redact_mod.redact_text(text)
+
+        assert entries == 1
+        # ...and detection still works under the single-context path.
+        assert FAKE_API_KEY not in result
+        assert "**REDACTED_SECRET_" in result
+
 
 def _skill_signature(*, instructions="", prompts=None, resources=None, tools=None) -> ServerSignature:
     return ServerSignature(
@@ -501,6 +539,31 @@ class TestRedactSignature:
         redact_signature(sig)
         assert sig.metadata.instructions == "A helpful skill"
         assert sig.prompts[0].description == "# Title\nDoes something useful."
+
+    def test_redact_signature_preserves_binary_file_hash(self):
+        """The synthetic 'Binary file. Hash: <sha256>' marker is self-generated
+        and secret-free, so redaction must leave the digest intact -- otherwise
+        the 64-char hash trips the hex high-entropy detector and every binary
+        collapses to an identical, useless description."""
+        import hashlib
+
+        digest = hashlib.sha256(b"\x00\x01\x02 binary blob \x80\x81").hexdigest()
+        desc = f"Binary file. Hash: {digest}"
+        sig = _skill_signature(resources=[Resource(name="logo.bin", uri="skill://logo.bin", description=desc)])
+        redact_signature(sig)
+        assert sig.resources[0].description == desc
+
+    def test_redact_signature_still_redacts_text_resembling_binary_marker(self):
+        """The exemption is an exact whole-string match: a description that only
+        starts like the binary marker but carries extra (possibly secret) text
+        is NOT exempt and is still redacted."""
+        import hashlib
+
+        digest = hashlib.sha256(b"blob").hexdigest()
+        desc = f"Binary file. Hash: {digest} -- also token {FAKE_API_KEY}"
+        sig = _skill_signature(resources=[Resource(name="logo.bin", uri="skill://logo.bin", description=desc)])
+        redact_signature(sig)
+        assert FAKE_API_KEY not in (sig.resources[0].description or "")
 
 
 def test_redact_remote_url_query_and_headers():

--- a/tests/unit/test_redact_prefilter_equivalence.py
+++ b/tests/unit/test_redact_prefilter_equivalence.py
@@ -1,0 +1,107 @@
+"""Equivalence/fuzz check for the redact_text pre-filter (_could_be_secret).
+
+The pre-filter is a conservative speed optimization: it may only skip values that
+provably match no detect-secrets plugin. To prove it introduces NO false
+negatives (a skipped secret = a leak), this runs redact_text over a large
+adversarial corpus twice -- with the gate on, and with it forced off -- and
+asserts byte-identical output.
+"""
+
+import random
+import string
+
+import pytest
+
+import agent_scan.redact as redact_mod
+from agent_scan.redact import redact_text
+
+# Realistic known-format secrets the format detectors should catch regardless.
+_KNOWN_FORMAT = [
+    "AKIAIOSFODNN7EXAMPLE",  # AWS
+    "ghp_" + "a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8",  # GitHub PAT
+    "sk_live_" + "4eC39HqLyjWDarjtT1zdp7dc",  # Stripe
+    "xoxb-123456789012-1234567890123-" + "abcdefghijklmnopqrstuvwx",  # Slack
+    "glpat-" + "ABCDEF1234567890abcd",  # GitLab
+]
+
+
+def _rand_lower(rng, lo, hi):
+    return "".join(rng.choice(string.ascii_lowercase) for _ in range(rng.randint(lo, hi)))
+
+
+def _rand_hexish(rng, lo, hi):
+    return "".join(rng.choice("0123456789abcdef") for _ in range(rng.randint(lo, hi)))
+
+
+def _rand_base64(rng, lo, hi):
+    alphabet = string.ascii_letters + string.digits + "+/"
+    return "".join(rng.choice(alphabet) for _ in range(rng.randint(lo, hi)))
+
+
+def _rand_mixed(rng, lo, hi):
+    alphabet = string.ascii_letters + string.digits + "-_.:/@"
+    return "".join(rng.choice(alphabet) for _ in range(rng.randint(lo, hi)))
+
+
+def _build_tokens(rng, n):
+    tokens = []
+    for _ in range(n):
+        kind = rng.randint(0, 8)
+        if kind == 0:  # short prose word (gate skips these)
+            tokens.append(_rand_lower(rng, 1, 12))
+        elif kind == 1:  # boundary-length pure-lowercase (21..25 around the cap of 22)
+            tokens.append(_rand_lower(rng, 21, 25))
+        elif kind == 2:  # long, high-distinct lowercase that CAN trip Base64 (>22 distinct)
+            tokens.append("".join(rng.sample(string.ascii_lowercase, rng.randint(20, 26))))
+        elif kind == 3:  # hex-ish (Hex detector territory)
+            tokens.append(_rand_hexish(rng, 4, 40))
+        elif kind == 4:  # base64-ish high entropy
+            tokens.append(_rand_base64(rng, 8, 48))
+        elif kind == 5:  # mixed punctuation/url-ish
+            tokens.append(_rand_mixed(rng, 5, 40))
+        elif kind == 6:  # known-format secret, sometimes wrapped in markup
+            sec = rng.choice(_KNOWN_FORMAT)
+            wrap = rng.randint(0, 3)
+            tokens.append({0: sec, 1: f"`{sec}`", 2: f'"{sec}"', 3: f"url/{sec}?x=1"}[wrap])
+        elif kind == 7:  # keyword-style assignment
+            tokens.append(f"{rng.choice(['password', 'api_key', 'token'])}={_rand_base64(rng, 6, 30)}")
+        else:  # uppercase / digit noise
+            tokens.append(
+                "".join(rng.choice(string.ascii_uppercase + string.digits) for _ in range(rng.randint(1, 20)))
+            )
+    return tokens
+
+
+@pytest.mark.parametrize("seed", [1, 7, 42, 20260618, 999999])
+def test_prefilter_output_identical_to_unfiltered(seed, monkeypatch):
+    rng = random.Random(seed)
+    tokens = _build_tokens(rng, 4000)
+    # Pack tokens into lines of random width so line/token structure varies.
+    lines, i = [], 0
+    while i < len(tokens):
+        width = rng.randint(1, 12)
+        lines.append(" ".join(tokens[i : i + width]))
+        i += width
+    text = "\n".join(lines)
+
+    gated = redact_text(text)  # real _could_be_secret
+
+    monkeypatch.setattr(redact_mod, "_could_be_secret", lambda value: True)  # disable gate
+    ungated = redact_text(text)
+
+    assert gated == ungated
+
+
+def test_prefilter_skips_only_safe_tokens():
+    """Spot-check the gate's contract on boundary cases."""
+    # skipped (pure lowercase, <=22)
+    cap = redact_mod._PROSE_MAX_LEN
+    # skipped: pure ASCII-lowercase, length <= the cap
+    assert redact_mod._could_be_secret("the") is False
+    assert redact_mod._could_be_secret("a" * cap) is False
+    # NOT skipped: one char over the cap, or any uppercase / digit / special / non-ascii
+    assert redact_mod._could_be_secret("a" * (cap + 1)) is True
+    assert redact_mod._could_be_secret("Configuration") is True
+    assert redact_mod._could_be_secret("config1") is True
+    assert redact_mod._could_be_secret("api_key") is True
+    assert redact_mod._could_be_secret("café") is True

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from agent_scan.models import SkillServer
 from agent_scan.skill_client import inspect_commands_dir, inspect_skill
+from tests.unit._secret_fixtures import synthetic_secret
 
 
 def test_inspect_commands_dir_surfaces_flat_md_files(tmp_path):
@@ -150,3 +151,78 @@ def test_inspect_skill_body_horizontal_rules_not_parsed_as_frontmatter(tmp_path)
     sig = inspect_skill(SkillServer(path=str(cmd)))
 
     assert sig.metadata.serverInfo.name == "deploy"
+
+
+# A high-entropy fake credential used to assert that skill contents are redacted
+# at read time. Derived at runtime (see ``synthetic_secret``) rather than a
+# hardcoded literal so repo secret scanners don't flag a checked-in secret.
+_FAKE_SKILL_SECRET = synthetic_secret()
+
+
+def test_inspect_skill_redacts_secrets_in_command_file(tmp_path):
+    """inspect_skill must redact secrets in a single-file command before returning."""
+    cmd = tmp_path / "deploy.md"
+    cmd.write_text(f"# Deploy\nexport TOKEN={_FAKE_SKILL_SECRET}\n")
+
+    sig = inspect_skill(SkillServer(path=str(cmd)))
+
+    assert _FAKE_SKILL_SECRET not in sig.model_dump_json()
+
+
+def test_inspect_skill_redacts_secrets_across_skill_tree(tmp_path):
+    """inspect_skill redacts secrets in SKILL.md, the frontmatter description,
+    bundled scripts (tools), nested prompts and other resources -- the whole
+    signature, across every file type traverse_skill_tree surfaces and into
+    nested subdirectories."""
+    skill = tmp_path / "myskill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        f"---\nname: myskill\ndescription: uses {_FAKE_SKILL_SECRET}\n---\n# Heading\nkey={_FAKE_SKILL_SECRET}\n"
+    )
+    # Scripts -> tools (one per supported language extension).
+    (skill / "run.sh").write_text(f"export GH={_FAKE_SKILL_SECRET}\n")
+    (skill / "deploy.py").write_text(f"API_KEY = '{_FAKE_SKILL_SECRET}'\n")
+    (skill / "client.js").write_text(f"const token = '{_FAKE_SKILL_SECRET}';\n")
+    (skill / "client.ts").write_text(f"const token: string = '{_FAKE_SKILL_SECRET}';\n")
+    # Non-script, non-md files -> resources.
+    (skill / "notes.txt").write_text(f"remember the token {_FAKE_SKILL_SECRET}\n")
+    (skill / "config.json").write_text(f'{{"apiKey": "{_FAKE_SKILL_SECRET}"}}\n')
+    # Nested directory with a markdown prompt -> recursion.
+    nested = skill / "references"
+    nested.mkdir()
+    (nested / "guide.md").write_text(f"# Guide\nUse {_FAKE_SKILL_SECRET} to authenticate.\n")
+
+    sig = inspect_skill(SkillServer(path=str(skill)))
+
+    dump = sig.model_dump_json()
+    assert _FAKE_SKILL_SECRET not in dump
+    assert sig.metadata.serverInfo.name == "myskill"
+    # Non-secret structure (skill name, descriptions, headings, file names,
+    # prose) is preserved across every surfaced file and the nested prompt.
+    for retained in (
+        "myskill",
+        "description",
+        "uses",
+        "# Heading",
+        "run.sh",
+        "deploy.py",
+        "client.js",
+        "client.ts",
+        "notes.txt",
+        "remember the token",
+        "config.json",
+        "guide.md",
+        "# Guide",
+        "to authenticate",
+    ):
+        assert retained in dump
+
+
+def test_inspect_skill_preserves_clean_content(tmp_path):
+    """Redaction at read time must not mangle skills that contain no secrets."""
+    cmd = tmp_path / "deploy.md"
+    cmd.write_text("# Deploy\nDo the deploy.")
+
+    sig = inspect_skill(SkillServer(path=str(cmd)))
+
+    assert any("Do the deploy." in (p.description or "") for p in sig.prompts)

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -247,3 +247,32 @@ def test_inspect_skill_preserves_binary_file_hash(tmp_path):
     sig = inspect_skill(SkillServer(path=str(skill)))
 
     assert any((r.description or "") == expected for r in sig.resources)
+
+
+def test_binary_marker_prefix_owned_by_skill_client():
+    """The binary-marker prefix is defined in ``skill_client`` itself, and
+    ``redact``'s matcher accepts a marker built from it -- the two must not drift
+    apart."""
+    import agent_scan.skill_client as skill_client
+    from agent_scan.redact import _is_synthetic_binary_description
+
+    assert "BINARY_FILE_DESCRIPTION_PREFIX" in vars(skill_client)
+    digest = "a" * 64
+    assert _is_synthetic_binary_description(f"{skill_client.BINARY_FILE_DESCRIPTION_PREFIX}{digest}")
+
+
+def test_redact_and_skill_client_import_without_cycle():
+    """``redact`` imports the binary-marker prefix from ``skill_client`` lazily so
+    the two modules don't form an import cycle. Guard against a regression that
+    moves that import back to module scope: a fresh interpreter must import each
+    module first without error, in either order."""
+    import subprocess
+    import sys
+
+    for module in ("agent_scan.redact", "agent_scan.skill_client"):
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {module}"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"importing {module} first failed:\n{result.stderr}"

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -226,3 +226,24 @@ def test_inspect_skill_preserves_clean_content(tmp_path):
     sig = inspect_skill(SkillServer(path=str(cmd)))
 
     assert any("Do the deploy." in (p.description or "") for p in sig.prompts)
+
+
+def test_inspect_skill_preserves_binary_file_hash(tmp_path):
+    """A binary resource is surfaced as a synthetic 'Binary file. Hash: <sha256>'
+    description. That digest is self-generated and secret-free, so redaction at
+    read time must leave it intact -- otherwise the 64-char hash trips the hex
+    high-entropy detector and every binary collapses to an identical, useless
+    description. Also guards against the binary-marker prefix drifting between
+    skill_client (which writes it) and redact (which exempts it)."""
+    import hashlib
+
+    skill = tmp_path / "myskill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: myskill\ndescription: a skill\n---\n# Heading\n")
+    blob = b"\xff\xfe\x00\x01\x02 not utf-8 \x80\x81"
+    (skill / "logo.bin").write_bytes(blob)
+    expected = f"Binary file. Hash: {hashlib.sha256(blob).hexdigest()}"
+
+    sig = inspect_skill(SkillServer(path=str(skill)))
+
+    assert any((r.description or "") == expected for r in sig.resources)


### PR DESCRIPTION
## Overview

Redacts secrets from **skill file contents** before a `ServerSignature` leaves the machine. Previously `inspect_skill` embedded raw file bodies (SKILL.md, command markdown, bundled scripts, other resources) into the signature that is later uploaded, so a credential pasted into a skill could leak.

A single redaction point — `inspect_skill` wraps `_inspect_skill` in `redact_signature` — sanitizes `metadata.instructions` and every prompt/resource/tool `description`, so the later `redact_scan_result` passes find the signature already clean.

## How redaction works

Reuses the existing `detect-secrets` plugin set, line by line, in two passes:
- **Pass 1** — high-entropy detectors on the raw line; their `secret_value` is the complete secret, so it is spliced out by substring (handles quoted literals).
- **Pass 2** — whole-token detection so a format-detector hit (AWS key, GitHub token) replaces the entire token, since those detectors report only a prefix. When the whole token isn't flagged, it is also split on structural delimiters (URL path/query separators, dotted/colon-joined values) and each segment re-checked, so a secret embedded as e.g. a URL path segment (`https://host/<token>/more`) is still caught — only the matched segment is replaced, leaving the surrounding structure intact.

## Binary-file hashes

`traverse_skill_tree` represents a binary resource as `Binary file. Hash: <sha256>`. The 64-char hex digest tripped the hex high-entropy detector and collapsed every binary to an identical, useless marker. That description is self-generated and secret-free, so it is now exempt:
- `skill_client` and `redact` share one `BINARY_FILE_DESCRIPTION_PREFIX` constant (no drift between writer and exemption).
- The exemption is an anchored whole-string match (`^prefix[0-9a-f]{64}$`), so a description that merely *starts* like the marker but carries extra text is still redacted.
