### PR TITLE
chore: bump version to 0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,4 @@
 - `0.5.8` Reverting changes.
 - `0.5.9` Don't handshake (launch) stdio MCP servers by default. Add VSCode family discoverers (VSCode, Cursor, Windsurf, Kiro, Antigravity); only scan installed extensions and plugins. Upgrade aiohttp to fix CVEs.
 - `0.5.10` Add Codex discoverer for MCP servers and skills. Add Claude Desktop support. Attach config-file path to each MCP server on upload. Fix remote URL handling. Stop probing host tool versions and enumerating home directories during bootstrap.
+- `0.5.11` Discover Cursor's built-in/managed skills. Redact secrets from skill file contents. Extend guard hook change detection. Remove commands discovery from the Claude Code discoverer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snyk-agent-scan"
-version = "0.5.10"
+version = "0.5.11"
 description = "Agent supply chain security scanner."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -2059,7 +2059,7 @@ wheels = [
 
 [[package]]
 name = "snyk-agent-scan"
-version = "0.5.10"
+version = "0.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release version bump `0.5.10` → `0.5.11`.

- `pyproject.toml`: `version = "0.5.11"`
- `uv.lock`: project version synced to `0.5.11`
- `CHANGELOG.md`: new `0.5.11` entry

## Changelog entry

> Discover Cursor's built-in/managed skills. Redact secrets from skill file contents. Extend guard hook change detection. Remove commands discovery from the Claude Code discoverer.

## Changes since v0.5.10

- Discover Cursor's built-in/managed skills (#374)
- Redact secrets from skill file contents (#377)
- Extend guard hook change detection (#365)
- Remove commands discovery from the Claude Code discoverer (#375)

(Docs-only / CI-only changes #370, #371, #372 omitted from the changelog per convention.)