### PR TITLE
feat: add --no-findings flag to hide security findings from output

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ These options are available for all commands:
 --verbose              Enable detailed logging output
 --print-errors         Show error details and tracebacks
 --json                 Output results in JSON format instead of rich text
+--no-findings          Hide security findings from the output while still listing discovered servers/skills
 --no-bootstrap         Disable the startup bootstrap call to the control server
 ```
 

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -914,9 +914,11 @@ async def print_scan_inspect(mode="scan", args=None):
         for r in result:
             dumped = r.model_dump(mode="json")
             if not show_findings:
-                # Empty the issues list on the serialized copy only; the live
-                # result object keeps its issues for --ci / control-server push.
+                # Empty findings (issues + their toxic-flow label scores) on the
+                # serialized copy only; the live result object keeps them for
+                # --ci / control-server push.
                 dumped["issues"] = []
+                dumped["labels"] = []
             result_dict[r.path] = dumped
         print(json.dumps(result_dict, indent=2))
     else:

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -216,6 +216,15 @@ def add_common_arguments(parser):
         action=argparse.BooleanOptionalAction,
         help="Scan skills beyond mcp servers (default: enabled). Use --no-skills to disable.",
     )
+    parser.add_argument(
+        "--findings",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help=(
+            "Print security findings (default: enabled). Use --no-findings to hide findings "
+            "while still showing discovered servers and skills."
+        ),
+    )
     add_bootstrap_argument(parser)
     parser.add_argument(
         "--scan-all-users",
@@ -448,6 +457,7 @@ def main():
             f"  {program_name} ~/custom/config.json # Scan a specific config file\n"
             f"  {program_name} inspect              # Just inspect tools without verification\n"
             f"  {program_name} --no-skills          # Scan only mcp servers, skip skills.\n"
+            f"  {program_name} --no-findings        # Hide security findings, still list discovered servers/skills\n"
             f"  {program_name} --verbose            # Enable detailed logging output\n"
             f"  {program_name} --print-errors       # Show error details and tracebacks\n"
             f"  {program_name} --json               # Output results in JSON format\n"
@@ -871,6 +881,9 @@ async def print_scan_inspect(mode="scan", args=None):
     full_description: bool = hasattr(args, "print_full_descriptions") and args.print_full_descriptions
     verbose: bool = hasattr(args, "verbose") and args.verbose
     ci_mode: bool = hasattr(args, "ci") and args.ci
+    # --no-findings hides findings from the output only; it never mutates the
+    # scan result, so --ci exit codes and control-server uploads are unaffected.
+    show_findings: bool = getattr(args, "findings", True)
     ignore_codes = _parse_ignore_codes(args, ci_mode)
 
     if json_output:
@@ -883,7 +896,14 @@ async def print_scan_inspect(mode="scan", args=None):
         _apply_ignore_codes(result, ignore_codes)
 
     if json_output:
-        result_dict = {r.path: r.model_dump(mode="json") for r in result}
+        result_dict = {}
+        for r in result:
+            dumped = r.model_dump(mode="json")
+            if not show_findings:
+                # Empty the issues list on the serialized copy only; the live
+                # result object keeps its issues for --ci / control-server push.
+                dumped["issues"] = []
+            result_dict[r.path] = dumped
         print(json.dumps(result_dict, indent=2))
     else:
         print_scan_result(
@@ -892,6 +912,7 @@ async def print_scan_inspect(mode="scan", args=None):
             inspect_mode=mode == "inspect",
             internal_issues=verbose,
             full_description=full_description,
+            show_findings=show_findings,
             args=args,
         )
 

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -855,7 +855,12 @@ def _apply_ignore_codes(result: list[ScanPathResult], ignore_codes: set[str]) ->
         scan_result.issues = [i for i in scan_result.issues if i.code not in ignore_codes]
 
 
-def _handle_ci_exit(result: list[ScanPathResult], json_output: bool, ignore_codes: set[str]) -> None:
+def _handle_ci_exit(
+    result: list[ScanPathResult],
+    json_output: bool,
+    ignore_codes: set[str],
+    show_findings: bool = True,
+) -> None:
     """In CI mode, exit with code 1 if any issues or unignored failures remain."""
     has_issues = any(scan_result.issues for scan_result in result)
     failure_codes = _collect_failure_codes(result) - ignore_codes
@@ -863,9 +868,18 @@ def _handle_ci_exit(result: list[ScanPathResult], json_output: bool, ignore_code
         return
 
     if not json_output:
-        issue_codes = {issue.code for scan_result in result for issue in scan_result.issues if issue.code}
+        # --no-findings hides security finding codes from the CI summary too; the
+        # non-zero exit (gating) is unaffected and scan-error codes stay visible.
+        issue_codes = (
+            {issue.code for scan_result in result for issue in scan_result.issues if issue.code}
+            if show_findings
+            else set()
+        )
         all_codes = sorted(issue_codes | failure_codes)
-        codes_part = ", ".join(all_codes) if all_codes else "none"
+        # When nothing remains to show, distinguish a genuinely clean run ("none")
+        # from one whose finding codes were withheld by --no-findings ("hidden").
+        empty_label = "none" if show_findings else "hidden"
+        codes_part = ", ".join(all_codes) if all_codes else empty_label
         rich.print(
             f"[bold red]CI (--ci): exiting with code 1 (issue codes: {codes_part}).[/bold red]",
             file=sys.stderr,
@@ -917,7 +931,7 @@ async def print_scan_inspect(mode="scan", args=None):
         )
 
     if ci_mode:
-        _handle_ci_exit(result, json_output, ignore_codes)
+        _handle_ci_exit(result, json_output, ignore_codes, show_findings)
 
 
 if __name__ == "__main__":

--- a/src/agent_scan/printer.py
+++ b/src/agent_scan/printer.py
@@ -300,6 +300,7 @@ def print_scan_path_result(
     print_errors: bool = False,
     inspect_mode: bool = False,
     full_description: bool = False,
+    show_findings: bool = True,
     args=None,
 ) -> None:
     issues = []
@@ -333,12 +334,19 @@ def print_scan_path_result(
     path_print_tree = Tree("│")
     server_tracebacks = []
     for server_idx, server in enumerate(result.servers or []):
-        server_issues = [issue for issue in result.issues if issue.reference == (server_idx, None)]
-        severities = [
-            get_severity(issue)
-            for issue in result.issues
-            if issue.reference is not None and issue.reference[0] == server_idx
-        ]
+        # When --no-findings is set, suppress the security findings (per-server
+        # summary, per-entity issue lines, and global issues below) while still
+        # showing the discovered servers/skills and any errors.
+        if show_findings:
+            server_issues = [issue for issue in result.issues if issue.reference == (server_idx, None)]
+            severities = [
+                get_severity(issue)
+                for issue in result.issues
+                if issue.reference is not None and issue.reference[0] == server_idx
+            ]
+        else:
+            server_issues = []
+            severities = []
         if server.error is not None:
             error_issue, traceback = format_error(server.error, server_idx)
             server_issues.append(error_issue)
@@ -347,7 +355,11 @@ def print_scan_path_result(
             severities.append("info")
         server_print = path_print_tree.add(format_servers_line(server.name or "", severities, server_issues))
         for entity_idx, entity in enumerate(server.entities):
-            issues = [issue for issue in result.issues if issue.reference == (server_idx, entity_idx)]
+            issues = (
+                [issue for issue in result.issues if issue.reference == (server_idx, entity_idx)]
+                if show_findings
+                else []
+            )
             server_print.add(
                 format_entity_line(
                     entity,
@@ -362,9 +374,10 @@ def print_scan_path_result(
         rich.print(path_print_tree)
 
     # print global issues
-    for issue in result.issues:
-        if issue.reference is None:
-            rich.print(format_global_issue(result, issue, True))
+    if show_findings:
+        for issue in result.issues:
+            if issue.reference is None:
+                rich.print(format_global_issue(result, issue, True))
 
     if print_errors and len(server_tracebacks) > 0:
         console = rich.console.Console()
@@ -381,6 +394,7 @@ def print_scan_result(
     inspect_mode: bool = False,
     internal_issues: bool = False,
     full_description: bool = False,
+    show_findings: bool = True,
     args=None,
 ) -> None:
     if not result:
@@ -390,7 +404,7 @@ def print_scan_result(
         for res in result:
             res.issues = [issue for issue in res.issues if issue.code not in ["W003", "W004", "W005", "W006"]]
     for i, path_result in enumerate(result):
-        print_scan_path_result(path_result, print_errors, inspect_mode, full_description, args)
+        print_scan_path_result(path_result, print_errors, inspect_mode, full_description, show_findings, args)
         if i < len(result) - 1:
             rich.print()
     print(end="", flush=True)

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -236,6 +236,31 @@ class TestSkillsFlag:
         assert self._parse(["--no-skills", "--skills"]) is True
 
 
+class TestFindingsFlag:
+    """--findings is on by default; --no-findings opts out; --findings is still accepted."""
+
+    def _parse(self, extra_argv: list[str]) -> bool:
+        import argparse
+
+        from agent_scan.cli import add_common_arguments
+
+        parser = argparse.ArgumentParser()
+        add_common_arguments(parser)
+        return parser.parse_args(extra_argv).findings
+
+    def test_findings_default_is_true(self):
+        assert self._parse([]) is True
+
+    def test_findings_flag_keeps_true(self):
+        assert self._parse(["--findings"]) is True
+
+    def test_no_findings_disables(self):
+        assert self._parse(["--no-findings"]) is False
+
+    def test_no_findings_then_findings_re_enables(self):
+        assert self._parse(["--no-findings", "--findings"]) is True
+
+
 class TestControlServerHeaderParsing:
     """Test suite for header parsing in control servers."""
 
@@ -619,6 +644,77 @@ class TestJSONOutput:
 
             parsed = json.loads(output)
             assert isinstance(parsed, dict)
+
+    @pytest.mark.asyncio
+    async def test_no_findings_strips_issues_from_json(self):
+        """--no-findings empties the issues list in JSON output without mutating the source result."""
+        import io
+        import json
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path.json",
+            issues=[Issue(code="E001", message="finding", reference=None)],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                findings=False,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+            )
+
+            captured_output = io.StringIO()
+            original_stdout = sys.stdout
+            try:
+                sys.stdout = captured_output
+                await print_scan_inspect(mode="scan", args=args)
+            finally:
+                sys.stdout = original_stdout
+
+            parsed = json.loads(captured_output.getvalue())
+            assert parsed["/test/path.json"]["issues"] == []
+            # the live result object is not mutated (guards --ci / push behavior)
+            assert [i.code for i in mock_result.issues] == ["E001"]
+
+    @pytest.mark.asyncio
+    async def test_findings_kept_in_json_by_default(self):
+        """Without --no-findings, JSON output keeps the issues."""
+        import io
+        import json
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path.json",
+            issues=[Issue(code="E001", message="finding", reference=None)],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=True,
+                findings=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+            )
+
+            captured_output = io.StringIO()
+            original_stdout = sys.stdout
+            try:
+                sys.stdout = captured_output
+                await print_scan_inspect(mode="scan", args=args)
+            finally:
+                sys.stdout = original_stdout
+
+            parsed = json.loads(captured_output.getvalue())
+            codes = [i["code"] for i in parsed["/test/path.json"]["issues"]]
+            assert "E001" in codes
 
 
 class TestIgnoreIssuesCodes:

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -6,7 +6,15 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from agent_scan.cli import MissingIdentifierError, parse_control_servers
-from agent_scan.models import ControlServer, Issue, RemoteServer, ScanError, ScanPathResult, ServerScanResult
+from agent_scan.models import (
+    ControlServer,
+    Issue,
+    RemoteServer,
+    ScalarToolLabels,
+    ScanError,
+    ScanPathResult,
+    ServerScanResult,
+)
 
 
 class TestControlServerParsing:
@@ -716,8 +724,8 @@ class TestJSONOutput:
             assert isinstance(parsed, dict)
 
     @pytest.mark.asyncio
-    async def test_no_findings_strips_issues_from_json(self):
-        """--no-findings empties the issues list in JSON output without mutating the source result."""
+    async def test_no_findings_strips_issues_and_labels_from_json(self):
+        """--no-findings empties issues and labels in JSON output without mutating the source result."""
         import io
         import json
         from argparse import Namespace
@@ -727,6 +735,7 @@ class TestJSONOutput:
         mock_result = ScanPathResult(
             path="/test/path.json",
             issues=[Issue(code="E001", message="finding", reference=None)],
+            labels=[[ScalarToolLabels(is_public_sink=1, destructive=0, untrusted_content=0, private_data=0)]],
         )
 
         with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
@@ -748,12 +757,14 @@ class TestJSONOutput:
 
             parsed = json.loads(captured_output.getvalue())
             assert parsed["/test/path.json"]["issues"] == []
+            assert parsed["/test/path.json"]["labels"] == []
             # the live result object is not mutated (guards --ci / push behavior)
             assert [i.code for i in mock_result.issues] == ["E001"]
+            assert len(mock_result.labels) == 1
 
     @pytest.mark.asyncio
-    async def test_findings_kept_in_json_by_default(self):
-        """Without --no-findings, JSON output keeps the issues."""
+    async def test_findings_and_labels_kept_in_json_by_default(self):
+        """Without --no-findings, JSON output keeps the issues and labels."""
         import io
         import json
         from argparse import Namespace
@@ -763,6 +774,7 @@ class TestJSONOutput:
         mock_result = ScanPathResult(
             path="/test/path.json",
             issues=[Issue(code="E001", message="finding", reference=None)],
+            labels=[[ScalarToolLabels(is_public_sink=1, destructive=0, untrusted_content=0, private_data=0)]],
         )
 
         with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
@@ -785,6 +797,7 @@ class TestJSONOutput:
             parsed = json.loads(captured_output.getvalue())
             codes = [i["code"] for i in parsed["/test/path.json"]["issues"]]
             assert "E001" in codes
+            assert len(parsed["/test/path.json"]["labels"]) == 1
 
 
 class TestIgnoreIssuesCodes:

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -566,6 +566,76 @@ class TestCIMode:
             await print_scan_inspect(mode="scan", args=args)
 
 
+class TestCIExitShowFindings:
+    """--no-findings keeps CI gating (exit 1) but hides finding codes from the CI summary line."""
+
+    def _result_with_finding(self) -> ScanPathResult:
+        return ScanPathResult(
+            path="/test/path",
+            issues=[Issue(code="E001", message="finding", reference=None)],
+        )
+
+    def test_ci_summary_shows_finding_codes_by_default(self, capsys):
+        from agent_scan.cli import _handle_ci_exit
+
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_ci_exit([self._result_with_finding()], json_output=False, ignore_codes=set())
+        assert exc_info.value.code == 1
+        assert "E001" in capsys.readouterr().err
+
+    def test_ci_summary_hides_finding_codes_when_no_findings(self, capsys):
+        from agent_scan.cli import _handle_ci_exit
+
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_ci_exit([self._result_with_finding()], json_output=False, ignore_codes=set(), show_findings=False)
+        # gating is preserved: still exits 1
+        assert exc_info.value.code == 1
+        # the finding code is not leaked to the CI summary
+        assert "E001" not in capsys.readouterr().err
+
+    def test_ci_keeps_error_codes_when_no_findings(self, capsys):
+        """Scan errors are not findings; their failure codes stay in the CI summary even with --no-findings."""
+        from agent_scan.cli import _handle_ci_exit
+
+        result = ScanPathResult(
+            path="/test/path",
+            issues=[Issue(code="E001", message="finding", reference=None)],
+            error=ScanError(message="parse failed", is_failure=True, category="parse_error"),
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_ci_exit([result], json_output=False, ignore_codes=set(), show_findings=False)
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "E001" not in err  # finding code hidden
+        assert "X005" in err  # parse_error failure code preserved
+
+    @pytest.mark.asyncio
+    async def test_no_findings_threads_through_to_ci_summary(self, capsys):
+        """--no-findings + --ci (rich) exits 1 without leaking finding codes to stdout or stderr."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+
+        mock_result = ScanPathResult(
+            path="/test/path",
+            issues=[Issue(code="E001", message="finding", reference=None)],
+        )
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[mock_result]):
+            args = Namespace(
+                json=False,
+                findings=False,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                await print_scan_inspect(mode="scan", args=args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "E001" not in (captured.out + captured.err)
+
+
 class TestJSONOutput:
     """Test suite for JSON output functionality."""
 

--- a/tests/unit/test_printer.py
+++ b/tests/unit/test_printer.py
@@ -1,6 +1,7 @@
-from mcp.types import Prompt, Tool
+from mcp.types import Implementation, InitializeResult, Prompt, ServerCapabilities, Tool
 
-from agent_scan.printer import format_entity_line, format_servers_line
+from agent_scan.models import Issue, ScanPathResult, ServerScanResult, ServerSignature, StdioServer
+from agent_scan.printer import format_entity_line, format_servers_line, print_scan_result
 
 
 class TestFormatServersLine:
@@ -79,3 +80,64 @@ class TestFormatEntityLine:
         result = format_entity_line(entity, issues=[], is_skill=True, full_description=True).plain
         assert "instruction SKILL.md" in result
         assert "instructionSKILL.md" not in result
+
+
+def _result_with_findings() -> ScanPathResult:
+    """A scan result with a server, one tool entity, and both an entity-level
+    and a server-level security finding."""
+    server = ServerScanResult(
+        name="github",
+        server=StdioServer(command="run"),
+        signature=ServerSignature(
+            metadata=InitializeResult(
+                protocolVersion="2024-11-05",
+                capabilities=ServerCapabilities(),
+                serverInfo=Implementation(name="github", version="1.0"),
+            ),
+            tools=[Tool(name="create_issue", description="dangerous tool", inputSchema={"type": "object"})],
+        ),
+    )
+    return ScanPathResult(
+        path="/test/path",
+        servers=[server],
+        issues=[
+            Issue(code="E001", message="entity finding", reference=(0, 0), extra_data={"severity": "high"}),
+            Issue(code="W001", message="server finding", reference=(0, None), extra_data={"severity": "medium"}),
+        ],
+    )
+
+
+class TestPrintScanResultShowFindings:
+    """--no-findings hides security findings while keeping the discovery tree."""
+
+    def test_findings_shown_by_default(self, capsys):
+        print_scan_result([_result_with_findings()])
+        out = capsys.readouterr().out
+        # discovery + findings both present
+        assert "github" in out
+        assert "create_issue" in out
+        assert "E001" in out
+        assert "entity finding" in out
+        assert "finding" in out  # severity summary line
+
+    def test_show_findings_true_prints_issue(self, capsys):
+        print_scan_result([_result_with_findings()], show_findings=True)
+        out = capsys.readouterr().out
+        assert "E001" in out
+        assert "entity finding" in out
+
+    def test_no_findings_hides_issues_keeps_discovery(self, capsys):
+        result = _result_with_findings()
+        print_scan_result([result], show_findings=False)
+        out = capsys.readouterr().out
+        # discovery is preserved
+        assert "github" in out
+        assert "create_issue" in out
+        # findings are suppressed
+        assert "E001" not in out
+        assert "W001" not in out
+        assert "entity finding" not in out
+        assert "server finding" not in out
+        assert "finding" not in out  # severity summary gone
+        # the live result object is not mutated (guards --ci / push behavior)
+        assert sorted(i.code for i in result.issues) == ["E001", "W001"]


### PR DESCRIPTION
## What

Adds a `--findings` / `--no-findings` flag (`BooleanOptionalAction`, on by default — mirroring `--skills`). When `--no-findings` is set, the scan still runs and reports *what was discovered*, but the security findings are hidden from the output.

## Behavior

- **Rich (terminal) output**: keeps the version banner, per-path `found N servers/skills` counts, the discovery tree of servers/skills and their entities, and errors. Hides per-server severity summaries, per-entity issue lines + descriptions, and global toxic-flow issues.
- **`--json` output**: each result's `issues` list is emptied (`[]`); `error` / `server.error` are preserved.
- **`--ci` summary**: the CI exit line no longer prints security finding codes when `--no-findings` is set. The non-zero exit (gating) is unchanged and non-finding scan-error codes stay visible. When only suppressed findings remain, the line reads `issue codes: hidden` instead of `none` so it never implies a clean run.
- **Invariant**: the flag is *purely presentational*. It never mutates `result.issues`, so `--ci` exit codes and what gets pushed to control servers are unaffected (JSON suppression operates on the serialized dict copy only; the CI summary recomputes codes for display without touching the live result).

### Example

```
# default
● Scanning ~/.cursor/mcp.json found 1 mcp server
│
└── github 2 findings (1 high, 1 medium)
    ● [W001 medium]: server finding here
    ├── tool        create_issue               ● [E001 high]: entity finding here
    │   Description:
    │   dangerous tool
    └── tool        list_repos

# --no-findings
● Scanning ~/.cursor/mcp.json found 1 mcp server
│
└── github
    ├── tool        create_issue
    └── tool        list_repos
```

## Tests

- `TestFindingsFlag` — flag parsing (default on, `--no-findings` opts out, re-enable works).
- `TestJSONOutput` — `--no-findings` empties `issues` in JSON and does **not** mutate the live result; default keeps issues.
- `TestPrintScanResultShowFindings` — rich output hides findings while keeping the discovery tree; default still prints findings.
- `TestCIExitShowFindings` — `--ci` summary hides finding codes under `--no-findings` while preserving exit code 1 and non-finding scan-error codes; integration test confirms the flag threads from `print_scan_inspect`.

Full `tests/unit` suite passes (8 pre-existing `test_verify_api.py` env-only failures confirmed unrelated — they also fail on a clean tree). `pre-commit run` clean on a freshly cleaned cache.

## Files

- `src/agent_scan/cli.py` — flag, epilog example, JSON serialization, `print_scan_result` threading, and `_handle_ci_exit` finding-code suppression.
- `src/agent_scan/printer.py` — `show_findings` param on `print_scan_result` / `print_scan_path_result`; three suppression points.
- `README.md` — documents the flag.
