### PR TITLE
feat: discover installed Cursor plugins (~/.cursor/plugins)

### DIFF
--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -420,19 +420,14 @@ class AgentDiscoverer(ABC):
         filenames: tuple[str, ...],
         parse_fn: Callable[[Path], McpScanResult],
     ) -> McpConfigsResult:
-        """Walk each base dir for plugin MCP config files named in ``filenames`` and
-        parse each hit via ``parse_fn``, keyed by absolute file path.
+        """Walk each base dir for plugin MCP files named in ``filenames``, parse
+        each hit via ``parse_fn``, keyed by absolute path.
 
         The MCP counterpart of :meth:`_discover_skill_and_command_dirs`, shared by
-        the Claude Code, Codex, and Cursor installed-plugin walks — all iterate
-        identically: ``_walk_under_depth`` for each filename under each base
-        (skipping unreadable bases, see its docstring), then ``parse_fn`` per hit.
-        Each agent supplies its own ``filenames`` (``.mcp.json`` for Claude Code &
-        Codex; both ``mcp.json`` and ``.mcp.json`` for Cursor) and its own
-        ``parse_fn`` (which encodes that agent's format union / snake-case handling
-        / ``skip_unrecognized`` policy), so per-agent parsing stays in the subclass
-        while the walk skeleton is shared. A falsy parse result — ``None``
-        (missing/empty/unrecognized) or an empty server list — is skipped; a truthy
+        the Claude Code, Codex, and Cursor plugin walks. Each agent supplies its own
+        ``filenames`` and ``parse_fn`` (format union / snake-case / ``skip_unrecognized``
+        policy), so per-agent parsing stays in the subclass while the walk is shared.
+        A falsy result (``None`` or empty list) is skipped; a truthy
         ``CouldNotParseMCPConfig`` is recorded.
         """
         result: McpConfigsResult = {}

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -54,9 +54,16 @@ _MAX_PLUGIN_RGLOB_DEPTH = 10
 _MAX_CONFIG_FILE_BYTES = 20 * 1024 * 1024  # 20 MiB
 
 
-def _walk_under_depth(base: Path, name: str, max_path_depth: int, *, want_file: bool) -> Iterator[Path]:
-    """Yield paths named ``name`` under ``base``, pruning traversal so each yielded
-    path's relative parts count is at most ``max_path_depth``.
+def _walk_under_depth(
+    base: Path, name: str | tuple[str, ...], max_path_depth: int, *, want_file: bool
+) -> Iterator[Path]:
+    """Yield paths whose final component is ``name`` — or any entry of ``name`` when
+    it is a tuple — under ``base``, pruning traversal so each yielded path's relative
+    parts count is at most ``max_path_depth``.
+
+    Passing a tuple matches every name in a single traversal (e.g. a plugin tree
+    carrying both ``mcp.json`` and ``.mcp.json``), so the tree is walked once rather
+    than once per name.
 
     Unlike ``Path.rglob`` + post-hoc filtering, traversal stops at the cap rather
     than walking the full subtree first — so a pathologically deep plugin layout
@@ -75,6 +82,7 @@ def _walk_under_depth(base: Path, name: str, max_path_depth: int, *, want_file: 
     leading ``exists()`` probe. Mirrors the tolerance ``_load_json_file`` and
     ``profiles_dir.iterdir`` already apply.
     """
+    names = (name,) if isinstance(name, str) else name
     try:
         if not base.exists():
             return
@@ -83,8 +91,9 @@ def _walk_under_depth(base: Path, name: str, max_path_depth: int, *, want_file: 
             root = Path(root_str)
             dir_depth = len(root.relative_to(base).parts)
             candidates = files if want_file else dirs
-            if name in candidates:
-                hits.append(root / name)
+            for n in names:
+                if n in candidates:
+                    hits.append(root / n)
             # The dir we're in is at depth `dir_depth`; an entry inside it sits at
             # depth+1. Prune once depth+1 reaches the cap so we don't descend further.
             if dir_depth + 1 >= max_path_depth:
@@ -427,19 +436,20 @@ class AgentDiscoverer(ABC):
         the Claude Code, Codex, and Cursor plugin walks. Each agent supplies its own
         ``filenames`` and ``parse_fn`` (format union / snake-case / ``skip_unrecognized``
         policy), so per-agent parsing stays in the subclass while the walk is shared.
-        A falsy result (``None`` or empty list) is skipped; a truthy
-        ``CouldNotParseMCPConfig`` is recorded.
+        All ``filenames`` are matched in a single traversal per base, so a tree
+        carrying both ``mcp.json`` and ``.mcp.json`` is walked once. A falsy result
+        (``None`` or empty list) is skipped; a truthy ``CouldNotParseMCPConfig`` is
+        recorded.
         """
         result: McpConfigsResult = {}
         for base in bases:
-            for name in filenames:
-                for mcp_file in _walk_under_depth(base, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
-                    if not mcp_file.is_file():
-                        continue
-                    parsed = parse_fn(mcp_file)
-                    if not parsed:
-                        continue
-                    result[mcp_file.as_posix()] = parsed
+            for mcp_file in _walk_under_depth(base, filenames, _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
+                if not mcp_file.is_file():
+                    continue
+                parsed = parse_fn(mcp_file)
+                if not parsed:
+                    continue
+                result[mcp_file.as_posix()] = parsed
         return result
 
     # --- shared project-folder enumeration (used by both Claude Code and the VSCode family) ---

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -54,16 +54,9 @@ _MAX_PLUGIN_RGLOB_DEPTH = 10
 _MAX_CONFIG_FILE_BYTES = 20 * 1024 * 1024  # 20 MiB
 
 
-def _walk_under_depth(
-    base: Path, name: str | tuple[str, ...], max_path_depth: int, *, want_file: bool
-) -> Iterator[Path]:
-    """Yield paths whose final component is ``name`` — or any entry of ``name`` when
-    it is a tuple — under ``base``, pruning traversal so each yielded path's relative
-    parts count is at most ``max_path_depth``.
-
-    Passing a tuple matches every name in a single traversal (e.g. a plugin tree
-    carrying both ``mcp.json`` and ``.mcp.json``), so the tree is walked once rather
-    than once per name.
+def _walk_under_depth(base: Path, name: str, max_path_depth: int, *, want_file: bool) -> Iterator[Path]:
+    """Yield paths named ``name`` under ``base``, pruning traversal so each yielded
+    path's relative parts count is at most ``max_path_depth``.
 
     Unlike ``Path.rglob`` + post-hoc filtering, traversal stops at the cap rather
     than walking the full subtree first — so a pathologically deep plugin layout
@@ -82,7 +75,6 @@ def _walk_under_depth(
     leading ``exists()`` probe. Mirrors the tolerance ``_load_json_file`` and
     ``profiles_dir.iterdir`` already apply.
     """
-    names = (name,) if isinstance(name, str) else name
     try:
         if not base.exists():
             return
@@ -91,9 +83,8 @@ def _walk_under_depth(
             root = Path(root_str)
             dir_depth = len(root.relative_to(base).parts)
             candidates = files if want_file else dirs
-            for n in names:
-                if n in candidates:
-                    hits.append(root / n)
+            if name in candidates:
+                hits.append(root / name)
             # The dir we're in is at depth `dir_depth`; an entry inside it sits at
             # depth+1. Prune once depth+1 reaches the cap so we don't descend further.
             if dir_depth + 1 >= max_path_depth:
@@ -436,20 +427,19 @@ class AgentDiscoverer(ABC):
         the Claude Code, Codex, and Cursor plugin walks. Each agent supplies its own
         ``filenames`` and ``parse_fn`` (format union / snake-case / ``skip_unrecognized``
         policy), so per-agent parsing stays in the subclass while the walk is shared.
-        All ``filenames`` are matched in a single traversal per base, so a tree
-        carrying both ``mcp.json`` and ``.mcp.json`` is walked once. A falsy result
-        (``None`` or empty list) is skipped; a truthy ``CouldNotParseMCPConfig`` is
-        recorded.
+        A falsy result (``None`` or empty list) is skipped; a truthy
+        ``CouldNotParseMCPConfig`` is recorded.
         """
         result: McpConfigsResult = {}
         for base in bases:
-            for mcp_file in _walk_under_depth(base, filenames, _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
-                if not mcp_file.is_file():
-                    continue
-                parsed = parse_fn(mcp_file)
-                if not parsed:
-                    continue
-                result[mcp_file.as_posix()] = parsed
+            for name in filenames:
+                for mcp_file in _walk_under_depth(base, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
+                    if not mcp_file.is_file():
+                        continue
+                    parsed = parse_fn(mcp_file)
+                    if not parsed:
+                        continue
+                    result[mcp_file.as_posix()] = parsed
         return result
 
     # --- shared project-folder enumeration (used by both Claude Code and the VSCode family) ---

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -414,6 +414,39 @@ class AgentDiscoverer(ABC):
                     result[found.as_posix()] = inspect_fn(str(found))
         return result
 
+    def _discover_plugin_mcp_files(
+        self,
+        bases: list[Path],
+        filenames: tuple[str, ...],
+        parse_fn: Callable[[Path], McpScanResult],
+    ) -> McpConfigsResult:
+        """Walk each base dir for plugin MCP config files named in ``filenames`` and
+        parse each hit via ``parse_fn``, keyed by absolute file path.
+
+        The MCP counterpart of :meth:`_discover_skill_and_command_dirs`, shared by
+        the Claude Code, Codex, and Cursor installed-plugin walks — all iterate
+        identically: ``_walk_under_depth`` for each filename under each base
+        (skipping unreadable bases, see its docstring), then ``parse_fn`` per hit.
+        Each agent supplies its own ``filenames`` (``.mcp.json`` for Claude Code &
+        Codex; both ``mcp.json`` and ``.mcp.json`` for Cursor) and its own
+        ``parse_fn`` (which encodes that agent's format union / snake-case handling
+        / ``skip_unrecognized`` policy), so per-agent parsing stays in the subclass
+        while the walk skeleton is shared. A falsy parse result — ``None``
+        (missing/empty/unrecognized) or an empty server list — is skipped; a truthy
+        ``CouldNotParseMCPConfig`` is recorded.
+        """
+        result: McpConfigsResult = {}
+        for base in bases:
+            for name in filenames:
+                for mcp_file in _walk_under_depth(base, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
+                    if not mcp_file.is_file():
+                        continue
+                    parsed = parse_fn(mcp_file)
+                    if not parsed:
+                        continue
+                    result[mcp_file.as_posix()] = parsed
+        return result
+
     # --- shared project-folder enumeration (used by both Claude Code and the VSCode family) ---
 
     def _discover_project_folders(self) -> list[Path]:

--- a/src/agent_scan/agents/claude_code.py
+++ b/src/agent_scan/agents/claude_code.py
@@ -297,13 +297,9 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
         return [root / sub for root in self._plugin_root_dirs() for sub in self._plugin_subdirs]
 
     def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
-        """Scan plugin ``.mcp.json`` files under every plugin base dir.
-
-        Plugin ``.mcp.json`` files use the flat ``{name: serverConfig}`` format
-        (no ``mcpServers`` wrapper). A top-level ``mcpServers`` key is also
-        tolerated for plugins that ship the wrapped format. Walk skeleton is the
-        shared :meth:`_discover_plugin_mcp_files`; only the format union is
-        Claude-Code-specific.
+        """Scan plugin ``.mcp.json`` files (flat ``{name: serverConfig}`` or wrapped
+        ``mcpServers``) via the shared :meth:`_discover_plugin_mcp_files`; only the
+        format union is Claude-Code-specific.
         """
         return self._discover_plugin_mcp_files(
             self._plugin_base_dirs(),

--- a/src/agent_scan/agents/claude_code.py
+++ b/src/agent_scan/agents/claude_code.py
@@ -301,20 +301,15 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
 
         Plugin ``.mcp.json`` files use the flat ``{name: serverConfig}`` format
         (no ``mcpServers`` wrapper). A top-level ``mcpServers`` key is also
-        tolerated for plugins that ship the wrapped format.
+        tolerated for plugins that ship the wrapped format. Walk skeleton is the
+        shared :meth:`_discover_plugin_mcp_files`; only the format union is
+        Claude-Code-specific.
         """
-        result: McpConfigsResult = {}
-        for base in self._plugin_base_dirs():
-            for mcp_file in _walk_under_depth(base, ".mcp.json", _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
-                if not mcp_file.is_file():
-                    continue
-                parsed = self._parse_mcp_file(mcp_file, formats=_CLAUDE_MCP_FORMATS)
-                # Skip on None (missing/empty file) or an empty server list; a parse
-                # failure is a truthy ``CouldNotParseMCPConfig`` and is still recorded.
-                if not parsed:
-                    continue
-                result[mcp_file.as_posix()] = parsed
-        return result
+        return self._discover_plugin_mcp_files(
+            self._plugin_base_dirs(),
+            (".mcp.json",),
+            lambda f: self._parse_mcp_file(f, formats=_CLAUDE_MCP_FORMATS),
+        )
 
     def _discover_plugin_skills(self) -> SkillsDirsResult:
         """Scan ``skills/`` subdirs under every plugin base dir."""

--- a/src/agent_scan/agents/codex.py
+++ b/src/agent_scan/agents/codex.py
@@ -184,17 +184,10 @@ class CodexDiscoverer(AgentDiscoverer):
         return [self._codex_home() / "plugins"]
 
     def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
-        """Scan every plugin tree for ``.mcp.json`` files."""
-        result: McpConfigsResult = {}
-        for base in self._plugin_base_dirs():
-            for mcp_file in _walk_under_depth(base, ".mcp.json", _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
-                if not mcp_file.is_file():
-                    continue
-                parsed = self._parse_plugin_mcp_json(mcp_file)
-                if not parsed:
-                    continue
-                result[mcp_file.as_posix()] = parsed
-        return result
+        """Scan every plugin tree for ``.mcp.json`` files via the shared
+        :meth:`_discover_plugin_mcp_files` walk; ``_parse_plugin_mcp_json`` carries
+        Codex's snake-case/camelCase/flat handling."""
+        return self._discover_plugin_mcp_files(self._plugin_base_dirs(), (".mcp.json",), self._parse_plugin_mcp_json)
 
     def _discover_plugin_skills(self) -> SkillsDirsResult:
         """Scan ``skills/`` subdirs under every plugin tree (the default location). A

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -827,12 +827,12 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
 
     def _discover_extension_mcp_servers(self) -> McpConfigsResult:
         """Scan ``mcp.json`` under each *installed* extension (no leading dot — the
-        VSCode-family file-name convention). Mirrors
-        :meth:`ClaudeCodeDiscoverer._discover_plugin_mcp_servers` but uses
-        :attr:`_VSCODE_FAMILY_FORMATS` so wrapped, VSCode-flat ``servers``, and
-        fully flat shapes all parse. Roots are install-manifest gated (see
-        :meth:`_extension_scan_roots`) so uninstalled extensions left on disk are
-        not scanned.
+        VSCode-family file-name convention) via the shared
+        :meth:`_discover_plugin_mcp_files`, the same opportunistic walk the Claude
+        Code / Codex / Cursor plugin trees use. Roots are install-manifest gated
+        (see :meth:`_extension_scan_roots`) so uninstalled extensions left on disk
+        are not scanned. Uses :attr:`_VSCODE_FAMILY_FORMATS` so wrapped, VSCode-flat
+        ``servers``, and fully flat shapes all parse.
 
         ``skip_unrecognized=True``: this walk matches every file merely *named*
         ``mcp.json``, and extensions ship unrelated files under that name (JSON
@@ -840,16 +840,11 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         ``CouldNotParseMCPConfig`` false positives; a file with a real MCP shape
         that fails to validate is still reported as malformed.
         """
-        result: McpConfigsResult = {}
-        for root in self._extension_scan_roots():
-            for mcp_file in _walk_under_depth(root, "mcp.json", _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
-                if not mcp_file.is_file():
-                    continue
-                parsed = self._parse_mcp_file(mcp_file, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True)
-                if parsed is None:
-                    continue
-                result[mcp_file.as_posix()] = parsed
-        return result
+        return self._discover_plugin_mcp_files(
+            self._extension_scan_roots(),
+            ("mcp.json",),
+            lambda f: self._parse_mcp_file(f, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True),
+        )
 
     def _discover_extension_skills(self) -> SkillsDirsResult:
         """Scan ``skills/`` subdirs under each *installed* extension (roots are

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -80,7 +80,7 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
     # wrapped ``mcp.json`` / ``.mcp.json`` and a ``skills/`` dir, like Claude
     # Code's plugins. Cursor's docs cover the ``mcp.json`` format but not these
     # install paths — verified empirically (Jun 2026).
-    _plugin_root_path = "~/.cursor/plugins"
+    _plugin_root_path: ClassVar[str] = "~/.cursor/plugins"
     # Installed-plugin subtrees only: ``cache`` (marketplace-installed) and
     # ``local`` (locally-installed). The ``plugins`` root is never walked
     # wholesale, so a marketplace *catalog* clone (a ``marketplaces`` sibling, as

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -75,21 +75,16 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
     # not twice. No other VSCode-family fork ships such a dir. See
     # cursor.com/docs/skills.
     _builtin_skills_dir_paths: ClassVar[tuple[str, ...]] = ("~/.cursor/skills-cursor",)
-    # Cursor's plugin install tree, distinct from ``~/.cursor/extensions``: an
-    # installed plugin lives under ``~/.cursor/plugins/<subdir>/…/<plugin>`` and
-    # ships a flat ``{name: cfg}`` or wrapped ``{"mcpServers": …}`` ``mcp.json`` /
-    # ``.mcp.json`` plus a ``skills/`` dir, mirroring Claude Code's plugin layout.
-    # Cursor's docs document only the ``mcp.json`` *format*, not these on-disk
-    # install paths — verified empirically (Jun 2026), tagged like the other
-    # verified-vs-inferred paths in this family.
+    # Cursor's plugin tree, distinct from ``~/.cursor/extensions``: an installed
+    # plugin lives at ``~/.cursor/plugins/<subdir>/…/<plugin>`` with a flat or
+    # wrapped ``mcp.json`` / ``.mcp.json`` and a ``skills/`` dir, like Claude
+    # Code's plugins. Cursor's docs cover the ``mcp.json`` format but not these
+    # install paths — verified empirically (Jun 2026).
     _plugin_root_path = "~/.cursor/plugins"
-    # Only the *installed*-plugin subtrees are scanned: ``cache`` holds plugins
-    # installed from a marketplace (grouped by marketplace name) and ``local``
-    # holds locally-installed ones. The ``plugins`` root is never walked wholesale,
-    # so a future marketplace *catalog* clone (a ``marketplaces`` sibling, as in
-    # Claude Code) is excluded by construction — only plugins the user actually
-    # installed are surfaced. Mirrors ``ClaudeCodeDiscoverer._plugin_subdirs``
-    # deliberately skipping ``marketplaces``.
+    # Installed-plugin subtrees only: ``cache`` (marketplace-installed) and
+    # ``local`` (locally-installed). The ``plugins`` root is never walked
+    # wholesale, so a marketplace *catalog* clone (a ``marketplaces`` sibling, as
+    # in Claude Code) is excluded by construction.
     _plugin_subdirs: ClassVar[tuple[str, ...]] = ("cache", "local")
 
     def _builtin_skills_dirs(self) -> list[Path]:
@@ -119,24 +114,17 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
     # --- private: installed-plugin walks (~/.cursor/plugins, parity with Claude Code) ---
 
     def _plugin_base_dirs(self) -> list[Path]:
-        """Each installed-plugin subtree to walk: ``~/.cursor/plugins/<subdir>`` for
-        every entry in :attr:`_plugin_subdirs` (``cache``/``local``). Enumerating the
-        named subdirs — rather than walking the ``plugins`` root — keeps the scan to
-        *installed* plugins and excludes any marketplace catalog sibling."""
+        """Installed-plugin subtrees to walk: ``~/.cursor/plugins/<subdir>`` per
+        :attr:`_plugin_subdirs`. Enumerating named subdirs (not the ``plugins``
+        root) keeps the scan to installed plugins, excluding any catalog sibling."""
         root = expand_path(Path(self._plugin_root_path), self.home_directory)
         return [root / sub for sub in self._plugin_subdirs]
 
     def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
         """Scan ``mcp.json`` / ``.mcp.json`` under each installed plugin via the
-        shared :meth:`_discover_plugin_mcp_files` walk.
-
-        Cursor plugins ship MCP config under either filename and in either the flat
-        ``{name: serverConfig}`` or wrapped ``{"mcpServers": {...}}`` shape, so both
-        names are walked and parsed via :attr:`_VSCODE_FAMILY_FORMATS`.
-        ``skip_unrecognized=True`` drops stray files merely *named* ``mcp.json`` (a
-        plugin may ship a JSON schema / fixture) rather than surfacing them as
-        ``CouldNotParseMCPConfig`` false positives; a genuinely-malformed MCP file
-        is still reported."""
+        shared :meth:`_discover_plugin_mcp_files`. Cursor plugins use either
+        filename and the flat or wrapped shape; ``skip_unrecognized=True`` drops
+        stray files merely *named* ``mcp.json`` instead of flagging them malformed."""
         return self._discover_plugin_mcp_files(
             self._plugin_base_dirs(),
             ("mcp.json", ".mcp.json"),
@@ -144,7 +132,6 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
         )
 
     def _discover_plugin_skills(self) -> SkillsDirsResult:
-        """Scan ``skills/`` subdirs under each installed plugin via the shared
-        :meth:`_discover_skill_and_command_dirs` walk (parity with the Claude Code /
-        Codex plugin-skill walks)."""
+        """Scan ``skills/`` under each installed plugin via the shared
+        :meth:`_discover_skill_and_command_dirs`."""
         return self._discover_skill_and_command_dirs(self._plugin_base_dirs(), "skills", inspect_skills_dir)

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -3,7 +3,17 @@
 from pathlib import Path
 from typing import ClassVar
 
-from agent_scan.agents.vscode.base import SkillsDirsResult, VSCodeFamilyDiscoverer
+from agent_scan.agents.base import (
+    _MAX_PLUGIN_RGLOB_DEPTH,
+    McpConfigsResult,
+    _walk_under_depth,
+)
+from agent_scan.agents.vscode.base import (
+    _VSCODE_FAMILY_FORMATS,
+    SkillsDirsResult,
+    VSCodeFamilyDiscoverer,
+)
+from agent_scan.skill_client import inspect_skills_dir
 from agent_scan.well_known_clients import expand_path
 
 
@@ -69,6 +79,22 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
     # not twice. No other VSCode-family fork ships such a dir. See
     # cursor.com/docs/skills.
     _builtin_skills_dir_paths: ClassVar[tuple[str, ...]] = ("~/.cursor/skills-cursor",)
+    # Cursor's plugin install tree, distinct from ``~/.cursor/extensions``: an
+    # installed plugin lives under ``~/.cursor/plugins/<subdir>/…/<plugin>`` and
+    # ships a flat ``{name: cfg}`` or wrapped ``{"mcpServers": …}`` ``mcp.json`` /
+    # ``.mcp.json`` plus a ``skills/`` dir, mirroring Claude Code's plugin layout.
+    # Cursor's docs document only the ``mcp.json`` *format*, not these on-disk
+    # install paths — verified empirically (Jun 2026), tagged like the other
+    # verified-vs-inferred paths in this family.
+    _plugin_root_path = "~/.cursor/plugins"
+    # Only the *installed*-plugin subtrees are scanned: ``cache`` holds plugins
+    # installed from a marketplace (grouped by marketplace name) and ``local``
+    # holds locally-installed ones. The ``plugins`` root is never walked wholesale,
+    # so a future marketplace *catalog* clone (a ``marketplaces`` sibling, as in
+    # Claude Code) is excluded by construction — only plugins the user actually
+    # installed are surfaced. Mirrors ``ClaudeCodeDiscoverer._plugin_subdirs``
+    # deliberately skipping ``marketplaces``.
+    _plugin_subdirs: ClassVar[tuple[str, ...]] = ("cache", "local")
 
     def _builtin_skills_dirs(self) -> list[Path]:
         """Resolve the home-relative built-in / managed skills directories."""
@@ -86,4 +112,53 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
     def discover_skills(self) -> SkillsDirsResult:
         result = super().discover_skills()
         result.update(self._discover_builtin_skills())
+        result.update(self._discover_plugin_skills())
+        return result
+
+    def discover_mcp_servers(self) -> McpConfigsResult:
+        result = super().discover_mcp_servers()
+        result.update(self._discover_plugin_mcp_servers())
+        return result
+
+    # --- private: installed-plugin walks (~/.cursor/plugins, parity with Claude Code) ---
+
+    def _plugin_base_dirs(self) -> list[Path]:
+        """Each installed-plugin subtree to walk: ``~/.cursor/plugins/<subdir>`` for
+        every entry in :attr:`_plugin_subdirs` (``cache``/``local``). Enumerating the
+        named subdirs — rather than walking the ``plugins`` root — keeps the scan to
+        *installed* plugins and excludes any marketplace catalog sibling."""
+        root = expand_path(Path(self._plugin_root_path), self.home_directory)
+        return [root / sub for sub in self._plugin_subdirs]
+
+    def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
+        """Scan ``mcp.json`` / ``.mcp.json`` under each installed plugin.
+
+        Cursor plugins ship MCP config under either filename and in either the flat
+        ``{name: serverConfig}`` or wrapped ``{"mcpServers": {...}}`` shape, so both
+        names are walked and parsed via :attr:`_VSCODE_FAMILY_FORMATS`.
+        ``skip_unrecognized=True`` drops stray files merely *named* ``mcp.json`` (a
+        plugin may ship a JSON schema / fixture) rather than surfacing them as
+        ``CouldNotParseMCPConfig`` false positives; a genuinely-malformed MCP file
+        is still reported. Mirrors
+        :meth:`ClaudeCodeDiscoverer._discover_plugin_mcp_servers`."""
+        result: McpConfigsResult = {}
+        for base in self._plugin_base_dirs():
+            for name in ("mcp.json", ".mcp.json"):
+                for mcp_file in _walk_under_depth(base, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
+                    if not mcp_file.is_file():
+                        continue
+                    parsed = self._parse_mcp_file(mcp_file, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True)
+                    if parsed is None:
+                        continue
+                    result[mcp_file.as_posix()] = parsed
+        return result
+
+    def _discover_plugin_skills(self) -> SkillsDirsResult:
+        """Scan ``skills/`` subdirs under each installed plugin (parity with
+        :meth:`VSCodeFamilyDiscoverer._discover_extension_skills`)."""
+        result: SkillsDirsResult = {}
+        for base in self._plugin_base_dirs():
+            for skills_dir in _walk_under_depth(base, "skills", _MAX_PLUGIN_RGLOB_DEPTH, want_file=False):
+                if skills_dir.is_dir():
+                    result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
         return result

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -3,11 +3,7 @@
 from pathlib import Path
 from typing import ClassVar
 
-from agent_scan.agents.base import (
-    _MAX_PLUGIN_RGLOB_DEPTH,
-    McpConfigsResult,
-    _walk_under_depth,
-)
+from agent_scan.agents.base import McpConfigsResult
 from agent_scan.agents.vscode.base import (
     _VSCODE_FAMILY_FORMATS,
     SkillsDirsResult,
@@ -131,7 +127,8 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
         return [root / sub for sub in self._plugin_subdirs]
 
     def _discover_plugin_mcp_servers(self) -> McpConfigsResult:
-        """Scan ``mcp.json`` / ``.mcp.json`` under each installed plugin.
+        """Scan ``mcp.json`` / ``.mcp.json`` under each installed plugin via the
+        shared :meth:`_discover_plugin_mcp_files` walk.
 
         Cursor plugins ship MCP config under either filename and in either the flat
         ``{name: serverConfig}`` or wrapped ``{"mcpServers": {...}}`` shape, so both
@@ -139,26 +136,15 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
         ``skip_unrecognized=True`` drops stray files merely *named* ``mcp.json`` (a
         plugin may ship a JSON schema / fixture) rather than surfacing them as
         ``CouldNotParseMCPConfig`` false positives; a genuinely-malformed MCP file
-        is still reported. Mirrors
-        :meth:`ClaudeCodeDiscoverer._discover_plugin_mcp_servers`."""
-        result: McpConfigsResult = {}
-        for base in self._plugin_base_dirs():
-            for name in ("mcp.json", ".mcp.json"):
-                for mcp_file in _walk_under_depth(base, name, _MAX_PLUGIN_RGLOB_DEPTH, want_file=True):
-                    if not mcp_file.is_file():
-                        continue
-                    parsed = self._parse_mcp_file(mcp_file, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True)
-                    if parsed is None:
-                        continue
-                    result[mcp_file.as_posix()] = parsed
-        return result
+        is still reported."""
+        return self._discover_plugin_mcp_files(
+            self._plugin_base_dirs(),
+            ("mcp.json", ".mcp.json"),
+            lambda f: self._parse_mcp_file(f, formats=_VSCODE_FAMILY_FORMATS, skip_unrecognized=True),
+        )
 
     def _discover_plugin_skills(self) -> SkillsDirsResult:
-        """Scan ``skills/`` subdirs under each installed plugin (parity with
-        :meth:`VSCodeFamilyDiscoverer._discover_extension_skills`)."""
-        result: SkillsDirsResult = {}
-        for base in self._plugin_base_dirs():
-            for skills_dir in _walk_under_depth(base, "skills", _MAX_PLUGIN_RGLOB_DEPTH, want_file=False):
-                if skills_dir.is_dir():
-                    result[skills_dir.as_posix()] = inspect_skills_dir(str(skills_dir))
-        return result
+        """Scan ``skills/`` subdirs under each installed plugin via the shared
+        :meth:`_discover_skill_and_command_dirs` walk (parity with the Claude Code /
+        Codex plugin-skill walks)."""
+        return self._discover_skill_and_command_dirs(self._plugin_base_dirs(), "skills", inspect_skills_dir)

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -5926,27 +5926,6 @@ def test_walk_under_depth_yields_hits_for_readable_tree(tmp_path):
     assert hits[0] == target / "mcp.json"
 
 
-def test_walk_under_depth_matches_multiple_names_in_one_pass(tmp_path):
-    """A tuple of names is matched in a single traversal: a tree carrying both
-    ``mcp.json`` and ``.mcp.json`` yields every match without walking once per
-    name. Guards the single-pass plugin-MCP walk."""
-    from agent_scan.agents.base import _walk_under_depth
-
-    (tmp_path / "p1").mkdir()
-    (tmp_path / "p1" / "mcp.json").write_text("{}")
-    (tmp_path / "p1" / ".mcp.json").write_text("{}")
-    (tmp_path / "p2").mkdir()
-    (tmp_path / "p2" / "mcp.json").write_text("{}")
-
-    hits = list(_walk_under_depth(tmp_path, ("mcp.json", ".mcp.json"), 10, want_file=True))
-
-    assert sorted(h.relative_to(tmp_path).as_posix() for h in hits) == [
-        "p1/.mcp.json",
-        "p1/mcp.json",
-        "p2/mcp.json",
-    ]
-
-
 def test_vscode_extension_walks_unreadable_do_not_abort_discovery(tmp_path, monkeypatch):
     """An unreadable ``~/.vscode/extensions`` base (shared by the extension-MCP and
     extension-skills walks) must degrade gracefully, not abort the whole discoverer.

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3491,6 +3491,25 @@ def test_windsurf_extension_mcp_discovers_mcp_json(tmp_path):
     assert name == "ws-ext-srv"
 
 
+def test_vscode_extension_empty_mcpservers_map_skipped(tmp_path, monkeypatch):
+    """An installed extension's ``mcp.json`` with an empty ``mcpServers`` map yields
+    no servers and is omitted rather than recorded as an empty entry. The extension
+    walk drops empty-but-valid configs via the shared ``if not parsed`` skip, the
+    same as the plugin walks (cf. ``test_claude_mcp_formats_empty_mcpservers_map_skipped``)."""
+    from agent_scan.agents import VSCodeDiscoverer
+
+    monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
+    exts = tmp_path / ".vscode" / "extensions"
+    ext_dir = exts / "pub.empty-1.0.0"
+    ext_dir.mkdir(parents=True)
+    (ext_dir / "mcp.json").write_text('{"mcpServers": {}}')
+    (exts / "extensions.json").write_text('[{"relativeLocation": "pub.empty-1.0.0"}]')
+
+    mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert [k for k in mcp_configs if k.endswith("/pub.empty-1.0.0/mcp.json")] == []
+
+
 def test_vscode_extension_walk_respects_max_depth_cap(tmp_path, monkeypatch):
     """An extension nested deeper than the depth cap is not scanned.
 
@@ -5893,6 +5912,27 @@ def test_walk_under_depth_yields_hits_for_readable_tree(tmp_path):
 
     assert [h.name for h in hits] == ["mcp.json"]
     assert hits[0] == target / "mcp.json"
+
+
+def test_walk_under_depth_matches_multiple_names_in_one_pass(tmp_path):
+    """A tuple of names is matched in a single traversal: a tree carrying both
+    ``mcp.json`` and ``.mcp.json`` yields every match without walking once per
+    name. Guards the single-pass plugin-MCP walk."""
+    from agent_scan.agents.base import _walk_under_depth
+
+    (tmp_path / "p1").mkdir()
+    (tmp_path / "p1" / "mcp.json").write_text("{}")
+    (tmp_path / "p1" / ".mcp.json").write_text("{}")
+    (tmp_path / "p2").mkdir()
+    (tmp_path / "p2" / "mcp.json").write_text("{}")
+
+    hits = list(_walk_under_depth(tmp_path, ("mcp.json", ".mcp.json"), 10, want_file=True))
+
+    assert sorted(h.relative_to(tmp_path).as_posix() for h in hits) == [
+        "p1/.mcp.json",
+        "p1/mcp.json",
+        "p2/mcp.json",
+    ]
 
 
 def test_vscode_extension_walks_unreadable_do_not_abort_discovery(tmp_path, monkeypatch):

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3498,11 +3498,12 @@ def test_vscode_extension_walk_respects_max_depth_cap(tmp_path, monkeypatch):
     pathologically deep trees blowing up the walk.
     """
     from agent_scan.agents import VSCodeDiscoverer
-    from agent_scan.agents.vscode import base as vscode_base
+    from agent_scan.agents import base as agent_base
 
-    # The extension walk reads ``_MAX_PLUGIN_RGLOB_DEPTH`` from its own module
-    # (agents.vscode.base), so patch the cap there.
-    monkeypatch.setattr(vscode_base, "_MAX_PLUGIN_RGLOB_DEPTH", 3)
+    # The extension MCP walk delegates to ``AgentDiscoverer._discover_plugin_mcp_files``
+    # (agents.base), which reads ``_MAX_PLUGIN_RGLOB_DEPTH`` from that module, so patch
+    # the cap there.
+    monkeypatch.setattr(agent_base, "_MAX_PLUGIN_RGLOB_DEPTH", 3)
 
     # Scan the tree as a built-in (manifest-less) root so it is walked wholesale
     # and depth *pruning* — not manifest gating — is what's under test; depth is

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3382,6 +3382,92 @@ def test_cursor_extension_skills_discovers_skills_dir(tmp_path):
     assert len(matching) == 1
 
 
+def test_cursor_plugin_mcp_discovers_mcp_json_flat(tmp_path):
+    """Installed Cursor plugins under ``~/.cursor/plugins/cache`` are scanned for a
+    flat ``{name: serverConfig}`` ``mcp.json`` (the Linear-plugin shape)."""
+    from agent_scan.agents import CursorDiscoverer
+
+    plugin_dir = tmp_path / ".cursor" / "plugins" / "cache" / "cursor-public" / "linear" / "abc123"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "mcp.json").write_text('{"linear": {"command": "linear-mcp"}}')
+
+    mcp_configs = CursorDiscoverer(tmp_path).discover_mcp_servers()
+
+    matching = [k for k in mcp_configs if k.endswith("/cursor-public/linear/abc123/mcp.json")]
+    assert len(matching) == 1
+    entries = mcp_configs[matching[0]]
+    assert isinstance(entries, list)
+    name, _ = entries[0]
+    assert name == "linear"
+
+
+def test_cursor_plugin_mcp_discovers_dot_mcp_json_wrapped(tmp_path):
+    """Installed Cursor plugins are scanned for a wrapped ``{"mcpServers": ...}``
+    ``.mcp.json`` carrying a remote server (the Atlassian-plugin shape)."""
+    from agent_scan.agents import CursorDiscoverer
+
+    plugin_dir = tmp_path / ".cursor" / "plugins" / "cache" / "cursor-public" / "atlassian" / "def456"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".mcp.json").write_text(
+        '{"mcpServers": {"atlassian": {"type": "http", "url": "https://mcp.atlassian.com/v1/mcp"}}}'
+    )
+
+    mcp_configs = CursorDiscoverer(tmp_path).discover_mcp_servers()
+
+    matching = [k for k in mcp_configs if k.endswith("/atlassian/def456/.mcp.json")]
+    assert len(matching) == 1
+    entries = mcp_configs[matching[0]]
+    assert isinstance(entries, list)
+    name, _ = entries[0]
+    assert name == "atlassian"
+
+
+def test_cursor_plugin_skills_discovers_skills_dir(tmp_path):
+    """Installed Cursor plugins can ship a ``skills/`` directory."""
+    from agent_scan.agents import CursorDiscoverer
+
+    skill_dir = (
+        tmp_path / ".cursor" / "plugins" / "cache" / "cursor-public" / "datadog" / "fed789" / "skills" / "ddsetup"
+    )
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: ddsetup\ndescription: d\n---\n\nbody.\n")
+
+    skills_dirs = CursorDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/datadog/fed789/skills")]
+    assert len(matching) == 1
+
+
+def test_cursor_plugin_local_dir_scanned(tmp_path):
+    """Locally-installed Cursor plugins under ``~/.cursor/plugins/local`` are scanned too."""
+    from agent_scan.agents import CursorDiscoverer
+
+    plugin_dir = tmp_path / ".cursor" / "plugins" / "local" / "my-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "mcp.json").write_text('{"mcpServers": {"local-srv": {"command": "l"}}}')
+
+    mcp_configs = CursorDiscoverer(tmp_path).discover_mcp_servers()
+
+    matching = [k for k in mcp_configs if k.endswith("/plugins/local/my-plugin/mcp.json")]
+    assert len(matching) == 1
+    name, _ = mcp_configs[matching[0]][0]
+    assert name == "local-srv"
+
+
+def test_cursor_plugins_marketplaces_not_scanned(tmp_path):
+    """Only *installed* plugins (``cache``/``local``) are scanned; a marketplace
+    catalog clone under ``~/.cursor/plugins/marketplaces`` is NOT walked."""
+    from agent_scan.agents import CursorDiscoverer
+
+    catalog_dir = tmp_path / ".cursor" / "plugins" / "marketplaces" / "cursor-public" / "uninstalled" / "xyz"
+    catalog_dir.mkdir(parents=True)
+    (catalog_dir / "mcp.json").write_text('{"mcpServers": {"uninstalled-srv": {"command": "u"}}}')
+
+    mcp_configs = CursorDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert not any("/marketplaces/" in k for k in mcp_configs)
+
+
 def test_windsurf_extension_mcp_discovers_mcp_json(tmp_path):
     """Windsurf is a VSCode fork. Its Codeium *engine* state lives under
     ``~/.codeium/windsurf`` (the MCP/skill paths), but its VSCode-fork *user data*

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -3493,20 +3493,32 @@ def test_windsurf_extension_mcp_discovers_mcp_json(tmp_path):
 
 def test_vscode_extension_empty_mcpservers_map_skipped(tmp_path, monkeypatch):
     """An installed extension's ``mcp.json`` with an empty ``mcpServers`` map yields
-    no servers and is omitted rather than recorded as an empty entry. The extension
-    walk drops empty-but-valid configs via the shared ``if not parsed`` skip, the
-    same as the plugin walks (cf. ``test_claude_mcp_formats_empty_mcpservers_map_skipped``)."""
+    no servers and is omitted rather than recorded as an empty entry, while a
+    populated sibling under the same manifest IS recorded — so the absence is the
+    empty-config drop (the shared ``if not parsed`` skip), not the extension going
+    unscanned. Cf. ``test_claude_mcp_formats_empty_mcpservers_map_skipped``."""
     from agent_scan.agents import VSCodeDiscoverer
 
     monkeypatch.setattr(VSCodeDiscoverer, "_builtin_extension_dirs", lambda self: [])
     exts = tmp_path / ".vscode" / "extensions"
-    ext_dir = exts / "pub.empty-1.0.0"
-    ext_dir.mkdir(parents=True)
-    (ext_dir / "mcp.json").write_text('{"mcpServers": {}}')
-    (exts / "extensions.json").write_text('[{"relativeLocation": "pub.empty-1.0.0"}]')
+    empty = exts / "pub.empty-1.0.0"
+    populated = exts / "pub.populated-1.0.0"
+    empty.mkdir(parents=True)
+    populated.mkdir(parents=True)
+    (empty / "mcp.json").write_text('{"mcpServers": {}}')
+    (populated / "mcp.json").write_text('{"mcpServers": {"real-srv": {"command": "r"}}}')
+    (exts / "extensions.json").write_text(
+        '[{"relativeLocation": "pub.empty-1.0.0"}, {"relativeLocation": "pub.populated-1.0.0"}]'
+    )
 
     mcp_configs = VSCodeDiscoverer(tmp_path).discover_mcp_servers()
 
+    # Positive control: the populated sibling IS scanned and recorded...
+    populated_keys = [k for k in mcp_configs if k.endswith("/pub.populated-1.0.0/mcp.json")]
+    assert len(populated_keys) == 1
+    name, _ = mcp_configs[populated_keys[0]][0]
+    assert name == "real-srv"
+    # ...so the empty config's absence is the drop, not an unscanned dir.
     assert [k for k in mcp_configs if k.endswith("/pub.empty-1.0.0/mcp.json")] == []
 
 


### PR DESCRIPTION
## Why

A customer-reported gap — *"not detecting plugins within the Cursor ecosystem"* — was confirmed real on disk. `CursorDiscoverer` only walked `~/.cursor/extensions`; it never touched `~/.cursor/plugins`. On a real install this hid three **live remote MCP servers** (Linear `mcp.linear.app`, Atlassian `mcp.atlassian.com`, Datadog — including `DD_API_KEY` / `DD_APPLICATION_KEY` headers) plus their skills — all invisible to a scan.

## What

Two parts: the Cursor feature, plus a shared-walk refactor it builds on.

### 1. Discover installed Cursor plugins (`~/.cursor/plugins`)

Scan the **installed**-plugin subtrees for bundled MCP servers and skills, with the same fidelity as Claude Code's plugin walk:

- Walk `cache/` (marketplace-installed) and `local/` (locally-installed) for `mcp.json` **and** `.mcp.json`, parsed via the VSCode-family format union so both flat `{name: cfg}` and wrapped `{"mcpServers": …}` shapes resolve. `skip_unrecognized=True` drops stray files merely *named* `mcp.json` (schemas, fixtures) rather than flagging them malformed — matching the existing extension walk.
- Walk `skills/` dirs the same way as installed extensions.
- `CursorDiscoverer.discover_mcp_servers` / `discover_skills` now layer the plugin results on top of `super()`'s.

**Installed-only by construction.** The `plugins` root is **never** walked wholesale — only the named `cache`/`local` subdirs are enumerated, so a future marketplace *catalog* clone (a `marketplaces/` sibling, as in Claude Code) is excluded by design. Mirrors `ClaudeCodeDiscoverer._plugin_subdirs` deliberately skipping `marketplaces`.

### 2. Share the opportunistic MCP walk

The Claude Code, Codex, and Cursor plugin walks — plus the VSCode-family **extension** walk — were four copies of the same loop. Extracted into `AgentDiscoverer._discover_plugin_mcp_files(bases, filenames, parse_fn)`, the MCP counterpart of the existing `_discover_skill_and_command_dirs`:

- The **walk** (depth-capped `_walk_under_depth`, `is_file` guard, skip-falsy / record-`CouldNotParseMCPConfig`) lives once in the base.
- The **parsing** stays per-agent via the injected `parse_fn`: Claude Code keeps its format union, Codex its snake-case/camelCase/flat handling, Cursor + the extension walk the VSCode-family union + `skip_unrecognized`.
- Claude Code and Codex are rewired onto the helper with **no behavior change**. The extension walk is rewired too: it was the lone walk recording empty-but-valid configs (`if parsed is None`) where the plugin walks drop them (`if not parsed`); it now drops them uniformly. These are all *opportunistic* walks (match any file named `mcp.json`, `skip_unrecognized=True`), so a zero-server config is noise — consistent with the plugin walks, distinct from the explicit user-config walks that still record empty configs.

> Note: Cursor's docs document the `mcp.json` *format* but not these on-disk install paths; the layout is verified empirically (Jun 2026) and tagged as such in code.

## Files

- `agents/base.py` — new shared `_discover_plugin_mcp_files`.
- `agents/claude_code.py`, `agents/codex.py` — plugin walks rewired onto it (behavior-preserving).
- `agents/vscode/base.py` — extension MCP walk rewired onto it.
- `agents/vscode/cursor.py` — `~/.cursor/plugins` MCP + skills discovery.
- `tests/unit/test_agent_discovery.py` — 5 new tests; extension depth-cap test repointed to the shared helper's module.

## Tests

5 new tests in `tests/unit/test_agent_discovery.py`: flat `mcp.json`, wrapped `.mcp.json` remote server, plugin `skills/`, `local/` tree, and a `marketplaces/`-not-scanned guard. The existing Claude Code / Codex plugin tests and the full VSCode-family extension-walk tests still pass, confirming the consolidation is behavior-preserving. **Full suite: 383 passed.** `pre-commit` (mypy + pinned ruff + ruff-format) clean on all changed files.

Real-machine smoke test confirms all 3 plugin servers + 2 plugin skills dirs are now discovered, with zero `marketplaces/` leakage.
