### PR TITLE
Populate hooks script checksum

### DIFF
--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -325,7 +325,7 @@ def _install_hooks(
     old_push_key = existing_info.get("auth_value", "") if existing_info else ""
     push_key_changed = bool(old_push_key) and old_push_key != push_key
 
-    dest_path, script_existed, script_updated, current_checksum, new_checksum = _copy_hook_script(client, config_path)
+    dest_path, script_existed, script_updated, current_checksum, new_checksum = _copy_hook_script(config_path)
     command = _build_hook_command(push_key, url, dest_path, hook_client, tenant_id=tenant_id)
     prepared_config, prepared_content, hooks_diff, preserved = _prepare_client_config(client, command, config_path)
 

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import hashlib
 import json
 import os
 import re
@@ -324,7 +325,7 @@ def _install_hooks(
     old_push_key = existing_info.get("auth_value", "") if existing_info else ""
     push_key_changed = bool(old_push_key) and old_push_key != push_key
 
-    dest_path, script_existed, script_updated = _copy_hook_script(client, config_path)
+    dest_path, script_existed, script_updated, current_checksum, new_checksum = _copy_hook_script(client, config_path)
     command = _build_hook_command(push_key, url, dest_path, hook_client, tenant_id=tenant_id)
     prepared_config, prepared_content, hooks_diff, preserved = _prepare_client_config(client, command, config_path)
 
@@ -340,6 +341,8 @@ def _install_hooks(
         config_changed=config_changed,
         hooks_diff=hooks_diff,
         push_key_changed=push_key_changed,
+        current_checksum=current_checksum,
+        new_checksum=new_checksum,
     ):
         if not script_existed:
             dest_path.unlink(missing_ok=True)
@@ -909,6 +912,8 @@ def _send_test_event(
     config_changed: bool = False,
     hooks_diff: dict | None = None,
     push_key_changed: bool = False,
+    current_checksum: str | None = None,
+    new_checksum: str | None = None,
 ) -> bool:
     """Send a test hooksConfigured event by invoking the hook script. Returns True on success."""
     import subprocess
@@ -926,6 +931,13 @@ def _send_test_event(
             payload_dict["added"] = hooks_diff.get("added", {})
             payload_dict["modified"] = hooks_diff.get("modified", {})
             payload_dict["removed"] = hooks_diff.get("removed", {})
+    hooks_script: dict[str, str] = {}
+    if current_checksum is not None:
+        hooks_script["current_checksum"] = current_checksum
+    if new_checksum is not None:
+        hooks_script["new_checksum"] = new_checksum
+    if hooks_script:
+        payload_dict["hooks_script"] = hooks_script
     redact_push_keys_in_data(payload_dict)
     payload = json.dumps(payload_dict)
 
@@ -1203,10 +1215,11 @@ def _compact_events(events: list[str]) -> str:
     return f"({', '.join(events[:show])} + {len(events) - show} more)"
 
 
-def _copy_hook_script(client: str, config_path: Path) -> tuple[Path, bool, bool]:
+def _copy_hook_script(config_path: Path) -> tuple[Path, bool, bool, str | None, str]:
     """Copy bundled hook script to a hooks/ dir next to the config file.
 
-    Returns (path, already_existed, was_updated).
+    Returns (path, already_existed, was_updated, current_checksum, new_checksum).
+    current_checksum is None when the script did not exist before.
     """
     dest_dir = config_path.parent / "hooks"
 
@@ -1215,19 +1228,24 @@ def _copy_hook_script(client: str, config_path: Path) -> tuple[Path, bool, bool]
     dest = dest_dir / script_name
     existed = dest.exists()
 
+    current_checksum: str | None = None
+    if existed:
+        current_checksum = hashlib.sha256(dest.read_bytes()).hexdigest()
+
     from agent_scan.version import version_info
 
     hook_pkg = importlib_resources.files("agent_scan.hooks")
     source = hook_pkg.joinpath(script_name)
     new_content = source.read_bytes().replace(b"__AGENT_SCAN_VERSION__", version_info.encode())
+    new_checksum = hashlib.sha256(new_content).hexdigest()
 
-    if existed and dest.read_bytes() == new_content:
-        return dest, existed, False
+    if existed and current_checksum == new_checksum:
+        return dest, existed, False, current_checksum, new_checksum
 
     dest.write_bytes(new_content)
     dest.chmod(dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     rich.print(f"[green]\u2713[/green]  Copied hook script to [dim]{dest}[/dim]")
-    return dest, existed, True
+    return dest, existed, True, current_checksum, new_checksum
 
 
 def _remove_hook_script(client: str, config_path: Path) -> None:

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -1665,6 +1665,14 @@ class TestInstallHooksOrchestration:
         return [c.args[0] for c in ctx["rich"].print.call_args_list if c.args]
 
     # ---------------------------------------------------------------
+    # _copy_hook_script receives only config_path
+    # ---------------------------------------------------------------
+
+    def test_copy_hook_script_called_with_config_path_only(self, ctx, tmp_path):
+        config = self._call(tmp_path, client="claude", config_exists=True)
+        ctx["copy"].assert_called_once_with(config)
+
+    # ---------------------------------------------------------------
     # Client routing: each client calls its own prepare + write
     # ---------------------------------------------------------------
 

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -50,6 +50,7 @@ from agent_scan.guard import (
     _prepare_cursor_config,
     _print_client_status,
     _run_install,
+    _send_test_event,
     _shell_quote,
     _uninstall_claude,
     _uninstall_codex,
@@ -1600,6 +1601,9 @@ _DIFF_EMPTY: dict = {"added": {}, "modified": {}, "removed": {}}
 
 _PREPARED: dict[str, dict[str, list[object]]] = {"hooks": {"SessionStart": []}}
 
+_CURRENT_CHECKSUM = "a" * 64
+_NEW_CHECKSUM = "b" * 64
+
 
 class TestInstallHooksOrchestration:
     """Tests for _install_hooks: detect changes → send test event → write config."""
@@ -1613,7 +1617,7 @@ class TestInstallHooksOrchestration:
         """
         dest = MagicMock(name="dest_path")
         targets = {
-            "copy": (f"{_G}._copy_hook_script", (dest, True, False)),
+            "copy": (f"{_G}._copy_hook_script", (dest, True, False, _CURRENT_CHECKSUM, _NEW_CHECKSUM)),
             "build": (f"{_G}._build_hook_command", "test-cmd"),
             "prep_claude": (f"{_G}._prepare_claude_config", (_PREPARED, _DIFF_REMOVED, 0)),
             "prep_cursor": (f"{_G}._prepare_cursor_config", (_PREPARED, _DIFF_REMOVED, 0)),
@@ -1726,7 +1730,7 @@ class TestInstallHooksOrchestration:
 
     def test_test_event_sent_when_script_new(self, ctx, tmp_path):
         """first_install=True because script did not exist prior."""
-        ctx["copy"].return_value = (ctx["dest"], False, True)
+        ctx["copy"].return_value = (ctx["dest"], False, True, None, _NEW_CHECKSUM)
         self._call(tmp_path, config_exists=True)
         ctx["test_event"].assert_called_once()
         _, kwargs = ctx["test_event"].call_args
@@ -1746,7 +1750,7 @@ class TestInstallHooksOrchestration:
 
     def test_test_event_receives_diff(self, ctx, tmp_path):
         ctx["prep_claude"].return_value = (_PREPARED, _DIFF_REMOVED, 0)
-        ctx["copy"].return_value = (ctx["dest"], False, True)
+        ctx["copy"].return_value = (ctx["dest"], False, True, None, _NEW_CHECKSUM)
         self._call(tmp_path)
         ctx["test_event"].assert_called_once_with(
             "pk-test",
@@ -1757,11 +1761,13 @@ class TestInstallHooksOrchestration:
             config_changed=True,
             hooks_diff=_DIFF_REMOVED,
             push_key_changed=False,
+            current_checksum=None,
+            new_checksum=_NEW_CHECKSUM,
         )
 
     def test_test_event_receives_empty_diff(self, ctx, tmp_path):
         ctx["prep_claude"].return_value = (_PREPARED, _DIFF_EMPTY, 0)
-        ctx["copy"].return_value = (ctx["dest"], False, True)
+        ctx["copy"].return_value = (ctx["dest"], False, True, None, _NEW_CHECKSUM)
         self._call(tmp_path)
         ctx["test_event"].assert_called_once_with(
             "pk-test",
@@ -1772,6 +1778,8 @@ class TestInstallHooksOrchestration:
             config_changed=False,
             hooks_diff=_DIFF_EMPTY,
             push_key_changed=False,
+            current_checksum=None,
+            new_checksum=_NEW_CHECKSUM,
         )
 
     def test_test_event_not_first_install(self, ctx, tmp_path):
@@ -1786,11 +1794,13 @@ class TestInstallHooksOrchestration:
             config_changed=True,
             hooks_diff=_DIFF_REMOVED,
             push_key_changed=False,
+            current_checksum=_CURRENT_CHECKSUM,
+            new_checksum=_NEW_CHECKSUM,
         )
 
     def test_test_event_push_key_changed(self, ctx, tmp_path):
         ctx["detect_existing"].return_value = {"auth_value": "old-push-key"}
-        ctx["copy"].return_value = (ctx["dest"], False, True)
+        ctx["copy"].return_value = (ctx["dest"], False, True, None, _NEW_CHECKSUM)
         self._call(tmp_path)
         ctx["test_event"].assert_called_once_with(
             "pk-test",
@@ -1801,11 +1811,13 @@ class TestInstallHooksOrchestration:
             config_changed=True,
             hooks_diff=_DIFF_REMOVED,
             push_key_changed=True,
+            current_checksum=None,
+            new_checksum=_NEW_CHECKSUM,
         )
 
     def test_test_event_push_key_unchanged(self, ctx, tmp_path):
         ctx["detect_existing"].return_value = {"auth_value": "pk-test"}
-        ctx["copy"].return_value = (ctx["dest"], False, True)
+        ctx["copy"].return_value = (ctx["dest"], False, True, None, _NEW_CHECKSUM)
         self._call(tmp_path)
         ctx["test_event"].assert_called_once_with(
             "pk-test",
@@ -1816,7 +1828,28 @@ class TestInstallHooksOrchestration:
             config_changed=True,
             hooks_diff=_DIFF_REMOVED,
             push_key_changed=False,
+            current_checksum=None,
+            new_checksum=_NEW_CHECKSUM,
         )
+
+    # ---------------------------------------------------------------
+    # Test event: hooks_script checksums
+    # ---------------------------------------------------------------
+
+    def test_test_event_checksums_first_install(self, ctx, tmp_path):
+        """First install: current_checksum is None, new_checksum is populated."""
+        ctx["copy"].return_value = (ctx["dest"], False, True, None, _NEW_CHECKSUM)
+        self._call(tmp_path)
+        _, kwargs = ctx["test_event"].call_args
+        assert kwargs["current_checksum"] is None
+        assert kwargs["new_checksum"] == _NEW_CHECKSUM
+
+    def test_test_event_checksums_existing_install(self, ctx, tmp_path):
+        """Existing install: both checksums are populated."""
+        self._call(tmp_path, minted=True, config_exists=True)
+        _, kwargs = ctx["test_event"].call_args
+        assert kwargs["current_checksum"] == _CURRENT_CHECKSUM
+        assert kwargs["new_checksum"] == _NEW_CHECKSUM
 
     # ---------------------------------------------------------------
     # Test event failure: abort, cleanup, revoke
@@ -1839,21 +1872,21 @@ class TestInstallHooksOrchestration:
         )
 
     def test_test_event_failure_no_revoke_when_not_minted(self, ctx, tmp_path):
-        ctx["copy"].return_value = (ctx["dest"], False, True)
+        ctx["copy"].return_value = (ctx["dest"], False, True, None, _NEW_CHECKSUM)
         ctx["test_event"].return_value = False
         with pytest.raises(SystemExit):
             self._call(tmp_path, minted=False, config_exists=True)
         ctx["revoke"].assert_not_called()
 
     def test_test_event_failure_cleans_new_script(self, ctx, tmp_path):
-        ctx["copy"].return_value = (ctx["dest"], False, True)
+        ctx["copy"].return_value = (ctx["dest"], False, True, None, _NEW_CHECKSUM)
         ctx["test_event"].return_value = False
         with pytest.raises(SystemExit):
             self._call(tmp_path)
         ctx["dest"].unlink.assert_called_once_with(missing_ok=True)
 
     def test_test_event_failure_keeps_existing_script(self, ctx, tmp_path):
-        ctx["copy"].return_value = (ctx["dest"], True, False)
+        ctx["copy"].return_value = (ctx["dest"], True, False, _CURRENT_CHECKSUM, _NEW_CHECKSUM)
         ctx["test_event"].return_value = False
         with pytest.raises(SystemExit):
             self._call(tmp_path, minted=True, config_exists=True)
@@ -1911,7 +1944,7 @@ class TestInstallHooksOrchestration:
         assert any("hooks installed" in m for m in self._print_messages(ctx))
 
     def test_status_installed_when_script_updated(self, ctx, tmp_path):
-        ctx["copy"].return_value = (ctx["dest"], True, True)
+        ctx["copy"].return_value = (ctx["dest"], True, True, _CURRENT_CHECKSUM, _NEW_CHECKSUM)
         ctx["write_claude"].return_value = False
         self._call(tmp_path, config_exists=True)
         assert any("hooks installed" in m for m in self._print_messages(ctx))
@@ -1925,6 +1958,57 @@ class TestInstallHooksOrchestration:
         ctx["write_claude"].return_value = False
         self._call(tmp_path, minted=False, config_exists=True)
         assert any("up to date" in m for m in self._print_messages(ctx))
+
+
+# ===================================================================
+# _send_test_event: hooks_script payload
+# ===================================================================
+
+
+class TestSendTestEventHooksScript:
+    """Verify the hooks_script checksum fields in the test event payload."""
+
+    def _capture_payload(self, **kwargs):
+        """Call _send_test_event with a fake script, capture the JSON payload."""
+        import subprocess
+
+        captured = {}
+
+        def fake_run(cmd, *, input, **kw):
+            captured["payload"] = json.loads(input)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with patch("subprocess.run", side_effect=fake_run), patch(f"{_G}.rich"):
+            _send_test_event(
+                "pk-test",
+                "https://api.snyk.io",
+                "claude-code",
+                Path("/fake/script.sh"),
+                **kwargs,
+            )
+        return captured["payload"]
+
+    def test_first_install_only_new_checksum(self):
+        payload = self._capture_payload(
+            first_install=True,
+            new_checksum="abc123",
+        )
+        assert payload["hooks_script"] == {"new_checksum": "abc123"}
+
+    def test_existing_install_both_checksums(self):
+        payload = self._capture_payload(
+            first_install=False,
+            current_checksum="old111",
+            new_checksum="new222",
+        )
+        assert payload["hooks_script"] == {
+            "current_checksum": "old111",
+            "new_checksum": "new222",
+        }
+
+    def test_no_checksums_omits_hooks_script(self):
+        payload = self._capture_payload(first_install=True)
+        assert "hooks_script" not in payload
 
 
 # ===================================================================


### PR DESCRIPTION
To monitor the hooks script integrity on each machine, we have to store its checksum at each hookConfigured event. This PR introduces it on agent scan side.