### PR TITLE
chore: remove dead command-discovery code and tests

### DIFF
--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -401,11 +401,10 @@ class AgentDiscoverer(ABC):
     ) -> SkillsDirsResult:
         """Walk each base dir for ``subdir_name`` directories and inspect each hit.
 
-        Shared by the Claude Code plugin ``skills``/``commands`` walks and the
-        VSCode-family extension ``skills`` walk — all iterate identically:
-        ``_walk_under_depth`` for the named directory under each base (skipping
-        unreadable bases, see its docstring), then run ``inspect_fn``
-        (``inspect_skills_dir`` or ``inspect_commands_dir``) on each match.
+        Shared by the Claude Code plugin ``skills`` walk and the VSCode-family
+        extension ``skills`` walk — both iterate identically: ``_walk_under_depth``
+        for the named directory under each base (skipping unreadable bases, see its
+        docstring), then run ``inspect_fn`` (``inspect_skills_dir``) on each match.
         """
         result: SkillsDirsResult = {}
         for base in bases:

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -31,12 +31,6 @@ logger = logging.getLogger(__name__)
 # drift apart.
 BINARY_FILE_DESCRIPTION_PREFIX = "Binary file. Hash: "
 
-# Cap traversal depth when walking a commands dir, mirroring the value used by
-# the discoverer plugin/extension walks (``agents.base._MAX_PLUGIN_RGLOB_DEPTH``).
-# Kept as a separate constant here to avoid a circular import (agents.base
-# imports this module).
-_MAX_COMMANDS_WALK_DEPTH = 10
-
 
 def get_skill_md_path(path: str) -> str | None:
     for file in os.listdir(path):
@@ -45,56 +39,8 @@ def get_skill_md_path(path: str) -> str | None:
     return None
 
 
-def _inspect_skill_file(expanded_path: str) -> ServerSignature:
-    """Inspect a single-file skill/command (a flat ``*.md``).
-
-    Command files (``~/.claude/commands/*.md``) are markdown files with optional
-    YAML frontmatter, not ``<name>/SKILL.md`` directories. The name defaults to
-    the file stem; an optional frontmatter ``name``/``description`` overrides it.
-    """
-    with open(expanded_path, encoding="utf-8") as f:
-        content = f.read()
-
-    name = os.path.splitext(os.path.basename(expanded_path))[0]
-    description = ""
-    # Only treat the file as having YAML frontmatter when it actually *starts*
-    # with a ``---`` fence; otherwise ``---`` used as a markdown horizontal rule
-    # in the body would be misread as frontmatter.
-    content_chunks = content.split("---")
-    if content.lstrip().startswith("---") and len(content_chunks) > 2:
-        try:
-            yaml_data = yaml.safe_load(content_chunks[1].strip())
-        except YAMLError:
-            yaml_data = None
-        if isinstance(yaml_data, dict):
-            # Guard against non-string frontmatter values (e.g. a YAML list),
-            # which would otherwise fail Pydantic validation downstream.
-            if isinstance(yaml_data.get("name"), str):
-                name = yaml_data["name"]
-            if isinstance(yaml_data.get("description"), str):
-                description = yaml_data["description"]
-
-    # Name the single prompt after the command's resolved ``name`` (file stem, or
-    # a frontmatter ``name`` override) so it matches ``serverInfo`` below rather
-    # than carrying the raw ``<stem>.md`` filename.
-    base_prompt = Prompt(name=name, description=content)
-    return ServerSignature(
-        metadata=InitializeResult(
-            protocolVersion="built-in",
-            instructions=description,
-            capabilities=ServerCapabilities(tools=ToolsCapability(listChanged=False)),
-            prompts=PromptsCapability(listChanged=False),
-            resources=ResourcesCapability(listChanged=False),
-            serverInfo=Implementation(name=name, version="skills"),
-        ),
-        prompts=[base_prompt],
-        resources=[],
-        tools=[],
-    )
-
-
 def inspect_skill(config: SkillServer) -> ServerSignature:
-    """Read a skill (single file or ``<name>/SKILL.md`` directory) into a signature.
+    """Read a skill (``<name>/SKILL.md`` directory) into a signature.
 
     Secrets in the skill's contents are redacted in place here -- the single
     point where skill files are read -- so the signature is already sanitized by
@@ -105,9 +51,6 @@ def inspect_skill(config: SkillServer) -> ServerSignature:
 
 def _inspect_skill(config: SkillServer) -> ServerSignature:
     logger.info(f"Scanning skill at path: {config.path}")
-    expanded_path = os.path.expanduser(config.path)
-    if os.path.isfile(expanded_path):
-        return _inspect_skill_file(expanded_path)
     skill_md_path = get_skill_md_path(config.path)
     if skill_md_path is None:
         raise Exception(f"neither SKILL.md nor skill.md file found at path: {config.path}")
@@ -232,42 +175,3 @@ def inspect_skills_dir(path: str) -> list[tuple[str, SkillServer]]:
             skills_servers.append((candidate_skill_dir, SkillServer(path=candidate_skill_dir_full_path)))
     logger.info("Found %d skills servers", len(skills_servers))
     return skills_servers
-
-
-def inspect_commands_dir(path: str) -> list[tuple[str, SkillServer]]:
-    """List command files under ``path`` as skill entries.
-
-    Unlike :func:`inspect_skills_dir` (which expects ``<name>/SKILL.md``
-    subdirectories), command files are flat ``*.md`` files. Claude Code
-    namespaces nested command files by their relative path joined with ``:``
-    (e.g. ``commands/git/commit.md`` -> ``git:commit``). Each file becomes one
-    ``SkillServer`` pointing at the file itself.
-
-    Traversal is depth-bounded by :data:`_MAX_COMMANDS_WALK_DEPTH`, pruning the
-    walk once it would descend past the cap rather than walking the whole subtree
-    first. This mirrors the discoverer plugin/extension walks
-    (``agents.base._walk_under_depth``) so a pathologically deep tree under a
-    commands dir can't blow up the scan. A ``.md`` file is surfaced only when its
-    path relative to ``path`` is at most ``_MAX_COMMANDS_WALK_DEPTH`` components
-    deep.
-    """
-    logger.info("Scanning commands dir: %s", path)
-
-    expanded_path = os.path.expanduser(path)
-    commands: list[tuple[str, SkillServer]] = []
-    for root, dirs, files in os.walk(expanded_path):
-        relative_root = os.path.relpath(root, expanded_path)
-        dir_depth = 0 if relative_root == os.curdir else len(relative_root.split(os.sep))
-        for file in files:
-            if not file.endswith(".md"):
-                continue
-            full_path = os.path.join(root, file)
-            relative = os.path.relpath(full_path, expanded_path)
-            name = os.path.splitext(relative)[0].replace(os.path.sep, ":")
-            commands.append((name, SkillServer(path=full_path)))
-        # A file inside the current dir sits at depth+1; prune once that reaches
-        # the cap so we don't descend into deeper subdirectories.
-        if dir_depth + 1 >= _MAX_COMMANDS_WALK_DEPTH:
-            dirs.clear()
-    logger.info("Found %d command files", len(commands))
-    return commands

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -1,172 +1,15 @@
-"""Unit tests for command-file scanning in ``skill_client``.
-
-``inspect_skills_dir`` only handles ``<name>/SKILL.md`` subdirectories; Claude
-Code command files are flat ``*.md`` files, so they need their own scanner
-(``inspect_commands_dir``) and ``inspect_skill`` must also accept a single-file
-``SkillServer`` so the discovered commands can be inspected downstream.
+"""Unit tests for ``skill_client``: skill-tree inspection, secret redaction at
+read time, and the binary-marker contract shared with ``redact``.
 """
 
-from pathlib import Path
-
 from agent_scan.models import SkillServer
-from agent_scan.skill_client import inspect_commands_dir, inspect_skill
+from agent_scan.skill_client import inspect_skill
 from tests.unit._secret_fixtures import synthetic_secret
-
-
-def test_inspect_commands_dir_surfaces_flat_md_files(tmp_path):
-    commands = tmp_path / "commands"
-    commands.mkdir()
-    (commands / "deploy.md").write_text("# Deploy\nrun the deploy")
-    (commands / "release.md").write_text("# Release")
-
-    found = dict(inspect_commands_dir(str(commands)))
-
-    assert set(found) == {"deploy", "release"}
-    assert isinstance(found["deploy"], SkillServer)
-    # ``inspect_commands_dir`` builds paths with ``os.path.join`` (OS-native
-    # separators), so compare via ``Path`` rather than a hardcoded "/" suffix.
-    deploy_path = Path(found["deploy"].path)
-    assert deploy_path.name == "deploy.md"
-    assert deploy_path.parent.name == "commands"
-
-
-def test_inspect_commands_dir_namespaces_nested_files_with_colon(tmp_path):
-    commands = tmp_path / "commands"
-    (commands / "git").mkdir(parents=True)
-    (commands / "git" / "commit.md").write_text("# Commit")
-
-    names = {name for name, _ in inspect_commands_dir(str(commands))}
-
-    assert names == {"git:commit"}
-
-
-def test_inspect_commands_dir_ignores_non_md_files(tmp_path):
-    commands = tmp_path / "commands"
-    commands.mkdir()
-    (commands / "deploy.md").write_text("# Deploy")
-    (commands / "README.txt").write_text("not a command")
-    (commands / "helper.py").write_text("print('hi')")
-
-    names = {name for name, _ in inspect_commands_dir(str(commands))}
-
-    assert names == {"deploy"}
-
-
-def test_inspect_commands_dir_empty_dir_returns_empty(tmp_path):
-    commands = tmp_path / "commands"
-    commands.mkdir()
-
-    assert inspect_commands_dir(str(commands)) == []
-
-
-def test_inspect_commands_dir_respects_max_walk_depth(tmp_path, monkeypatch):
-    """A command file nested deeper than the depth cap is pruned — traversal stops
-    at the cap rather than walking the whole subtree, mirroring the depth-bounded
-    plugin/extension walks (``_walk_under_depth``) so a pathologically deep tree
-    can't blow up the scan.
-    """
-    import agent_scan.skill_client as skill_client
-
-    monkeypatch.setattr(skill_client, "_MAX_COMMANDS_WALK_DEPTH", 3)
-
-    commands = tmp_path / "commands"
-    commands.mkdir()
-    # Shallow file (relative parts = 1) — within the cap, must be found.
-    (commands / "deploy.md").write_text("# Deploy")
-    # Deep file (relative parts = 4: a/b/c/deep.md) — beyond cap 3, must be pruned.
-    deep = commands / "a" / "b" / "c"
-    deep.mkdir(parents=True)
-    (deep / "deep.md").write_text("# Deep")
-
-    names = {name for name, _ in skill_client.inspect_commands_dir(str(commands))}
-
-    assert "deploy" in names
-    assert "a:b:c:deep" not in names
-
-
-def test_inspect_skill_handles_single_md_file_without_frontmatter(tmp_path):
-    cmd = tmp_path / "deploy.md"
-    cmd.write_text("# Deploy\nDo the deploy.")
-
-    sig = inspect_skill(SkillServer(path=str(cmd)))
-
-    # Name falls back to the file stem when there is no YAML frontmatter.
-    assert sig.metadata.serverInfo.name == "deploy"
-    # The full file content is surfaced as a prompt.
-    assert any("Do the deploy." in (p.description or "") for p in sig.prompts)
-
-
-def test_inspect_skill_command_file_prompt_name_matches_server_name(tmp_path):
-    """The single prompt emitted for a command file carries the command's resolved
-    name (the file stem) — not the raw ``<stem>.md`` filename — so the prompt and
-    ``serverInfo`` agree on one name."""
-    cmd = tmp_path / "deploy.md"
-    cmd.write_text("# Deploy\nDo the deploy.")
-
-    sig = inspect_skill(SkillServer(path=str(cmd)))
-
-    assert sig.metadata.serverInfo.name == "deploy"
-    assert [p.name for p in sig.prompts] == ["deploy"]
-
-
-def test_inspect_skill_command_file_prompt_name_follows_frontmatter_name(tmp_path):
-    """A frontmatter ``name`` override applies to both ``serverInfo`` and the prompt,
-    keeping the two consistent."""
-    cmd = tmp_path / "deploy.md"
-    cmd.write_text("---\nname: ship-it\ndescription: d\n---\nbody")
-
-    sig = inspect_skill(SkillServer(path=str(cmd)))
-
-    assert sig.metadata.serverInfo.name == "ship-it"
-    assert [p.name for p in sig.prompts] == ["ship-it"]
-
-
-def test_inspect_skill_uses_frontmatter_description_for_command_file(tmp_path):
-    cmd = tmp_path / "release.md"
-    cmd.write_text("---\ndescription: Cut a release\n---\nSteps to release.")
-
-    sig = inspect_skill(SkillServer(path=str(cmd)))
-
-    assert sig.metadata.instructions == "Cut a release"
-
-
-def test_inspect_skill_non_string_frontmatter_does_not_crash(tmp_path):
-    """A command file whose frontmatter ``description`` is a YAML list (not a
-    string) must not raise — it should fall back to the file stem / empty desc."""
-    cmd = tmp_path / "weird.md"
-    cmd.write_text("---\ndescription:\n  - a\n  - b\n---\nbody")
-
-    sig = inspect_skill(SkillServer(path=str(cmd)))
-
-    assert sig.metadata.serverInfo.name == "weird"
-    assert isinstance(sig.metadata.instructions, str)
-
-
-def test_inspect_skill_body_horizontal_rules_not_parsed_as_frontmatter(tmp_path):
-    """A file that does NOT start with frontmatter but uses ``---`` as markdown
-    horizontal rules must keep the file stem as its name, not parse body text."""
-    cmd = tmp_path / "deploy.md"
-    cmd.write_text("Run build\n\n---\n\nname: hijacked\ndescription: nope\n\n---\n\ndone")
-
-    sig = inspect_skill(SkillServer(path=str(cmd)))
-
-    assert sig.metadata.serverInfo.name == "deploy"
-
 
 # A high-entropy fake credential used to assert that skill contents are redacted
 # at read time. Derived at runtime (see ``synthetic_secret``) rather than a
 # hardcoded literal so repo secret scanners don't flag a checked-in secret.
 _FAKE_SKILL_SECRET = synthetic_secret()
-
-
-def test_inspect_skill_redacts_secrets_in_command_file(tmp_path):
-    """inspect_skill must redact secrets in a single-file command before returning."""
-    cmd = tmp_path / "deploy.md"
-    cmd.write_text(f"# Deploy\nexport TOKEN={_FAKE_SKILL_SECRET}\n")
-
-    sig = inspect_skill(SkillServer(path=str(cmd)))
-
-    assert _FAKE_SKILL_SECRET not in sig.model_dump_json()
 
 
 def test_inspect_skill_redacts_secrets_across_skill_tree(tmp_path):
@@ -216,16 +59,6 @@ def test_inspect_skill_redacts_secrets_across_skill_tree(tmp_path):
         "to authenticate",
     ):
         assert retained in dump
-
-
-def test_inspect_skill_preserves_clean_content(tmp_path):
-    """Redaction at read time must not mangle skills that contain no secrets."""
-    cmd = tmp_path / "deploy.md"
-    cmd.write_text("# Deploy\nDo the deploy.")
-
-    sig = inspect_skill(SkillServer(path=str(cmd)))
-
-    assert any("Do the deploy." in (p.description or "") for p in sig.prompts)
 
 
 def test_inspect_skill_preserves_binary_file_hash(tmp_path):


### PR DESCRIPTION
## What

Removes the dead command-discovery code and its tests left behind after #375 (`refactor: remove commands discovery from ClaudeCodeDiscoverer`).

Once #375 dropped the three `_discover_*_commands` methods, `inspect_commands_dir` had **no live caller** in `src/`. And since `inspect_commands_dir` was the *only* producer of single-**file** `SkillServer`s, the single-`.md`-file branch of `inspect_skill` (`_inspect_skill_file`) also became unreachable. Commands are no longer detected on `main`.

## Changes

- **`skill_client.py`**: drop `inspect_commands_dir`, `_MAX_COMMANDS_WALK_DEPTH`, `_inspect_skill_file`, and the `os.path.isfile(...)` single-file branch in `_inspect_skill`.
- **`tests/unit/test_skill_client.py`**: drop the 13 command-path tests (5 `inspect_commands_dir` + 8 single-`.md`-file `inspect_skill`). Keep the 4 directory-skill-tree / binary-marker / import-cycle tests that cover the still-live path.
- **`agents/base.py`**: fix the `_discover_skill_and_command_dirs` docstring that still referenced the deleted `inspect_commands_dir` and a commands walk.

No behavior change — this is pure dead-code removal.

## Test plan

- `uv run pytest tests/unit/test_skill_client.py` → 4 passed.
- `uv run pytest tests/unit/test_inspect.py tests/unit/test_agent_discovery.py` → 403 passed (exercise the live `inspect_skill` directory path).
- `pre-commit run` on the changed files → clean (mypy/ruff/format).