### PR TITLE
feat: discover installed opencode agents (~/.config/opencode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Agent Scan auto-discovers agents and their capabilities (MCP servers or skills) 
 | OpenClaw | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
 | Amp | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
 | Kiro | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| OpenCode | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| OpenCode | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Antigravity | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Codex | ✓ | ✓ | ✓ | ✓ | — | — |
 | Amazon Q | ✓ | ✗ | ✓ | ✗ | ✓ (WSL) | ✗ |
@@ -101,7 +101,7 @@ Legend: **✓** detected · **✗** the agent supports this but Agent Scan does 
 | OpenClaw | N/A | N/A | ✓ | ✗ | ✓ † | N/A | ✗ | ✗ |
 | Amp | N/A | ✗ | ✓ | ✗ | ✗ ‡ | ✗ | ✗ | ✗ |
 | Kiro | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| OpenCode | N/A | ✗ | ✗ | ✗ | ✗ | ✗ | N/A | N/A |
+| OpenCode | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | N/A | N/A |
 | Antigravity | N/A | N/A | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Amazon Q | N/A | N/A | N/A | ✓ | N/A | ✗ | N/A | N/A |

--- a/src/agent_scan/agents/__init__.py
+++ b/src/agent_scan/agents/__init__.py
@@ -12,6 +12,7 @@ from agent_scan.agents.base import AgentDiscoverer
 from agent_scan.agents.claude_code import ClaudeCodeDiscoverer
 from agent_scan.agents.claude_desktop import ClaudeDesktopDiscoverer
 from agent_scan.agents.codex import CodexDiscoverer
+from agent_scan.agents.opencode import OpenCodeDiscoverer
 from agent_scan.agents.vscode import (
     AntigravityDiscoverer,
     CursorDiscoverer,
@@ -32,6 +33,7 @@ DISCOVERERS: dict[str, type[AgentDiscoverer]] = {
     KiroDiscoverer.name: KiroDiscoverer,
     AntigravityDiscoverer.name: AntigravityDiscoverer,
     CodexDiscoverer.name: CodexDiscoverer,
+    OpenCodeDiscoverer.name: OpenCodeDiscoverer,
 }
 
 
@@ -66,6 +68,7 @@ __all__ = [
     "CodexDiscoverer",
     "CursorDiscoverer",
     "KiroDiscoverer",
+    "OpenCodeDiscoverer",
     "VSCodeDiscoverer",
     "VSCodeFamilyDiscoverer",
     "WindsurfDiscoverer",

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -514,15 +514,23 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             paths: Schema.optional(Schema.Array(Schema.String))
                 .annotate({ description: "Additional paths to skill folders" })
 
-        The opencode loader (``packages/opencode/src/skill/index.ts:211-220``)
-        expands each entry — ``~/...`` against the user's home, relative paths
-        against the *containing config file's directory*. We mirror those
-        expansion rules and scan each resolved directory via ``_scan_skills_dir``.
+        The opencode loader (``packages/opencode/src/skill/index.ts:211-214``)
+        merges all config scopes into one config and resolves each entry —
+        ``~/...`` against the user's home, absolute as-is, and **relative entries
+        against the instance/project directory** (the cwd within the worktree),
+        *not* the declaring config file's directory. Since this scanner is
+        session-less, we resolve relative entries against every opened-project
+        worktree (see :meth:`_resolve_skills_path_entry`) and scan each resolved
+        directory via ``_scan_skills_dir``.
 
         Malformed config files (already reported by MCP discovery) are skipped
         here — we only consume the ``skills.paths`` array on success.
         """
         result: SkillsDirsResult = {}
+        # opencode's instance dirs (the db ``worktree`` leaves); computed once so
+        # the relative-entry resolution below doesn't re-read the SQLite db per
+        # candidate config file.
+        worktrees = self._discover_project_folders()
         for config_path in self._iter_candidate_config_files():
             data = self._load_json_file(config_path)
             if not isinstance(data, dict):
@@ -536,23 +544,28 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             for entry in paths:
                 if not isinstance(entry, str) or not entry:
                     continue
-                resolved = self._resolve_skills_path_entry(entry, config_path)
-                self._record_skills_at(result, resolved)
+                for resolved in self._resolve_skills_path_entry(entry, worktrees):
+                    self._record_skills_at(result, resolved)
         return result
 
-    def _resolve_skills_path_entry(self, entry: str, config_path: Path) -> Path:
+    def _resolve_skills_path_entry(self, entry: str, worktrees: list[Path]) -> list[Path]:
         """Expand a single ``skills.paths`` entry the way opencode does.
 
-        - ``~/...`` -> joined to ``self.home_directory``.
-        - Absolute -> as-is.
-        - Relative -> joined to the *containing config file's directory*.
+        - ``~`` / ``~/...`` -> the scanned user's home (one path).
+        - Absolute -> as-is (one path).
+        - Relative -> opencode joins it to the *instance/project directory* (the
+          cwd within the worktree), not the declaring config file's dir, so we
+          resolve it against every opened-project ``worktree`` (one path each).
+          With no opened projects there is no anchor and the entry resolves to
+          nothing — matching that opencode would never load it from the config
+          dir.
         """
-        if entry.startswith("~/") or entry == "~":
-            return expand_path(Path(entry), self.home_directory)
+        if entry == "~" or entry.startswith("~/"):
+            return [expand_path(Path(entry), self.home_directory)]
         candidate = Path(entry)
         if candidate.is_absolute():
-            return candidate
-        return config_path.parent / candidate
+            return [candidate]
+        return [worktree / candidate for worktree in worktrees]
 
     # --- URL-pulled skills cache (Gap C) ---
 

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -200,7 +200,7 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     def _global_config_dirs(self) -> list[Path]:
         """Every global config dir to sweep for MCP/skills.
 
-        Includes (in priority order):
+        Includes (all scanned additively):
 
         - ``$XDG_CONFIG_HOME/opencode`` when set on an own-home scan — opencode
           reads its config from there instead of ``~/.config/opencode`` per
@@ -313,8 +313,11 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             #      silently drop every project for that user.
             #   2. The cost is tolerated torn reads if opencode happens to
             #      be writing the ``project`` table mid-scan: a corrupt
-            #      worktree string just yields a ``Path`` that probes
-            #      nothing downstream. The ``project`` table only grows
+            #      worktree string yields a ``Path`` whose ancestor walk
+            #      makes a bounded handful of stat calls (one
+            #      ``opencode.json`` / ``.opencode/skills`` probe per
+            #      ancestor up to the filesystem root), all of which miss
+            #      on a non-existent path. The ``project`` table only grows
             #      when a user opens a new project, so the window is small
             #      in practice.
             # ``as_uri()`` produces the canonical ``file:///`` form on every

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -96,11 +96,15 @@ class OpenCodeDiscoverer(AgentDiscoverer):
       skills-dir root.
 
     Project enumeration is unusual: opencode persists the absolute paths of
-    opened projects in a SQLite database at
-    ``~/.local/share/opencode/opencode.db`` (Drizzle ``project`` table,
-    ``worktree`` column). :meth:`_discover_project_folders` reads it read-only;
-    any failure (missing file, lock contention, schema drift) yields an empty
-    list rather than aborting discovery.
+    opened projects in a SQLite database under ``~/.local/share/opencode``
+    (Drizzle ``project`` table, ``worktree`` column). The db filename varies by
+    install channel — ``opencode.db`` on ``latest``/``beta``/``prod`` builds,
+    ``opencode-<channel>.db`` otherwise — and ``$OPENCODE_DB`` may relocate it on
+    own-home scans, so :meth:`_discover_project_folders` globs ``opencode*.db``
+    per data dir and additionally honors ``$OPENCODE_DB`` (see
+    :meth:`_candidate_db_paths`). Each db is read read-only; any failure (missing
+    file, lock contention, schema drift) yields an empty list rather than
+    aborting discovery.
     """
 
     name = "opencode"
@@ -118,7 +122,16 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     # ``<cache>/skills/<bun-hash-of-base-url>/<skill-name>/SKILL.md``. We walk
     # the ``<hash>`` level so each hash dir is treated like a skills dir root.
     _cache_path = "~/.cache/opencode"
-    _db_filename = "opencode.db"
+    # opencode's db filename varies by install channel
+    # (packages/core/src/database/database.ts ``path()``): ``opencode.db`` for
+    # ``latest``/``beta``/``prod`` builds (or when ``OPENCODE_DISABLE_CHANNEL_DB``
+    # is set), and ``opencode-<channel>.db`` for every other channel — e.g. the
+    # build-time default ``local`` (``opencode-local.db``) or a dev/preview build
+    # named after its git branch. We glob this pattern per data dir so projects
+    # from any channel are enumerated. ``opencode*.db`` is start-anchored and
+    # matches the ``.db`` suffix, so the ``-wal``/``-shm`` sidecars (which end in
+    # ``-wal``/``-shm``) are excluded.
+    _DB_GLOB = "opencode*.db"
     # Both spellings are documented; ``skills/`` is canonical, ``skill/`` is the
     # backwards-compat alias. We scan both so a user who created either gets
     # picked up; downstream keys by absolute path so a single existing dir
@@ -254,7 +267,7 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         return dirs
 
     def _data_dirs(self) -> list[Path]:
-        """Every data dir to consult for the opencode SQLite db.
+        """Every data dir to consult for opencode SQLite db files.
 
         Includes ``$XDG_DATA_HOME/opencode`` on own-home scans (where opencode
         actually persists projects when XDG is set) plus the home-relative
@@ -306,22 +319,92 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         # ``client_path`` (see ``_xdg_env_dir``).
         return Path(override).absolute()
 
+    def _opencode_db_value(self) -> str | None:
+        """Raw ``$OPENCODE_DB`` value on an own-home scan, else ``None``.
+
+        Mirrors :meth:`_opencode_config_env_path`'s own-home gate (the env var
+        reflects the *scanning process's* environment, not another user's under
+        ``--scan-all-users``). The raw string is returned because resolution
+        differs by shape — ``:memory:`` has no backing file, an absolute path is
+        used as-is, and a relative path is joined to the data dir — which
+        :meth:`_resolve_db_env_paths` handles. An empty value is treated as unset,
+        matching the ``OPENCODE_CONFIG``/``OPENCODE_CONFIG_DIR`` handling.
+        """
+        if not self._scans_own_home():
+            return None
+        return os.environ.get("OPENCODE_DB") or None
+
+    def _resolve_db_env_paths(self) -> list[Path]:
+        """Resolve ``$OPENCODE_DB`` (own-home only) to concrete db file paths.
+
+        Per ``packages/core/src/database/database.ts`` ``path()``: ``:memory:``
+        has no backing file (skipped — nothing to scan); an absolute path is used
+        as-is; a relative value is joined to ``Global.Path.data``. opencode joins
+        a relative value to whichever data dir is active, and this session-less
+        scanner can't know which, so it resolves against *every* data dir (an
+        additive superset — a join that doesn't exist on disk is filtered by the
+        ``is_file()`` guard in :meth:`_discover_project_folders`).
+
+        ``.absolute()`` (never ``.resolve()``) keeps keys absolute for a relative
+        env value while preserving the ``is_file()`` symlink-follow semantics the
+        FIFO hang-defense relies on (see :meth:`_xdg_env_dir`).
+        """
+        value = self._opencode_db_value()
+        if value is None or value == ":memory:":
+            return []
+        candidate = Path(value)
+        if candidate.is_absolute():
+            return [candidate.absolute()]
+        return [(data_dir / candidate).absolute() for data_dir in self._data_dirs()]
+
     # --- project enumeration (SQLite db) ---
+
+    def _candidate_db_paths(self) -> list[Path]:
+        """Every opencode SQLite db file to consult for opened projects.
+
+        The ``$OPENCODE_DB`` override paths (own-home only, see
+        :meth:`_resolve_db_env_paths`) come first, followed by every
+        ``opencode*.db`` glob hit in each data dir from :meth:`_data_dirs`. Paths
+        are deduplicated by ``.as_posix()`` so a relative ``$OPENCODE_DB`` that
+        coincides with a globbed file is opened — and warned about — only once.
+        Globbing tolerates a per-dir ``PermissionError``/``OSError`` (the
+        ``sorted(dir.glob(...))`` idiom used across the discoverers).
+        """
+        seen: set[str] = set()
+        candidates: list[Path] = []
+
+        def add(path: Path) -> None:
+            key = path.as_posix()
+            if key not in seen:
+                seen.add(key)
+                candidates.append(path)
+
+        for path in self._resolve_db_env_paths():
+            add(path)
+        for data_dir in self._data_dirs():
+            try:
+                matches = sorted(data_dir.glob(self._DB_GLOB))
+            except (PermissionError, OSError):
+                continue
+            for path in matches:
+                add(path)
+        return candidates
 
     def _discover_project_folders(self) -> list[Path]:
         """Project paths from opencode's SQLite db (``project.worktree`` column).
 
-        Reads ``opencode.db`` from every data dir in :meth:`_data_dirs` (XDG +
-        default), deduplicating worktree paths. :meth:`_read_worktrees` opens
-        each db read-only (preferring a WAL-aware ``mode=ro`` read, falling back
-        to an ``immutable=1`` snapshot when that open is denied); per-db sqlite
-        errors (missing file, schema drift, permission denied) are tolerated
-        rather than aborting the whole discoverer.
+        Reads every candidate db from :meth:`_candidate_db_paths` (the
+        ``opencode*.db`` glob across the data dirs in :meth:`_data_dirs` plus any
+        ``$OPENCODE_DB`` override on own-home scans), deduplicating worktree
+        paths. :meth:`_read_worktrees` opens each db read-only (preferring a
+        WAL-aware ``mode=ro`` read, falling back to an ``immutable=1`` snapshot
+        when that open is denied); per-db sqlite errors (missing file, schema
+        drift, permission denied) are tolerated rather than aborting the whole
+        discoverer.
         """
         seen: set[str] = set()
         result: list[Path] = []
-        for data_dir in self._data_dirs():
-            db_path = data_dir / self._db_filename
+        for db_path in self._candidate_db_paths():
             try:
                 # ``is_file()`` (not ``exists()``) so a non-regular file planted
                 # at this path — a FIFO/socket/device, the classic

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -1,0 +1,224 @@
+"""opencode discoverer: ``~/.config/opencode/opencode.{json,jsonc}`` + skills +
+per-project ``opencode.json`` + per-OS managed configs + ``$OPENCODE_CONFIG`` override."""
+
+import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+from agent_scan.agents.base import (
+    AgentDiscoverer,
+    McpConfigsResult,
+    SkillsDirsResult,
+)
+from agent_scan.models import MCPConfig, OpenCodeConfigFile
+from agent_scan.well_known_clients import expand_path
+
+logger = logging.getLogger(__name__)
+
+# Format union for opencode MCP files. Only one format today; declared as a
+# tuple to plug into ``_parse_mcp_file`` uniformly with the other discoverers.
+_OPENCODE_MCP_FORMATS: tuple[type[MCPConfig], ...] = (OpenCodeConfigFile,)
+# opencode accepts either extension; per https://opencode.ai/docs/config the
+# layered-config loader tries each when reading global and project scopes.
+_CONFIG_FILENAMES: tuple[str, ...] = ("opencode.json", "opencode.jsonc")
+
+
+class OpenCodeDiscoverer(AgentDiscoverer):
+    """opencode discovery across global, project, managed, and ``$OPENCODE_CONFIG`` scopes.
+
+    Scope sources:
+
+    * Global — ``~/.config/opencode/opencode.{json,jsonc}`` (mcp) and
+      ``~/.config/opencode/skills`` (skills). ``~/.config/opencode`` is XDG-style
+      on every OS opencode supports, including Windows (verified empirically).
+    * Project — for every project root in ``_project_paths_with_ancestors`` (and
+      its ancestors): ``<root>/opencode.{json,jsonc}`` plus ``<root>/.opencode/skills``.
+    * Managed — per-OS system-wide ``opencode.{json,jsonc}`` (and ``skills/``)
+      under ``/Library/Application Support/opencode`` (macOS), ``/etc/opencode``
+      (Linux), or ``%ProgramData%\\opencode`` (Windows).
+    * Env override — ``$OPENCODE_CONFIG`` names an alternate config file; honored
+      only on an own-home scan (the env var reflects the *scanning process's*
+      environment, so it must not be applied to other users under
+      ``--scan-all-users``).
+
+    Project enumeration is unusual: opencode persists the absolute paths of
+    opened projects in a SQLite database at
+    ``~/.local/share/opencode/opencode.db`` (Drizzle ``project`` table,
+    ``worktree`` column). :meth:`_discover_project_folders` reads it read-only;
+    any failure (missing file, lock contention, schema drift) yields an empty
+    list rather than aborting discovery.
+    """
+
+    name = "opencode"
+
+    _install_path = "~/.config/opencode"
+    _data_path = "~/.local/share/opencode"
+    _db_filename = "opencode.db"
+    _skills_subdir = "skills"
+    # Project-scoped skill dirs scanned at every opened project root and its
+    # ancestors. ``.opencode/skills`` is opencode's canonical project skills
+    # location per https://opencode.ai/docs/skills.
+    _project_skills_relative: tuple[str, ...] = (".opencode/skills",)
+
+    # --- public (override AgentDiscoverer abstracts) ---
+
+    def client_exists(self) -> str | None:
+        path = self._global_config_dir()
+        try:
+            if path.exists():
+                return path.as_posix()
+        except PermissionError:
+            logger.warning("Permission error for path %s", path.as_posix())
+        return None
+
+    def discover_mcp_servers(self) -> McpConfigsResult:
+        result: McpConfigsResult = {}
+        result.update(self._discover_global_mcp_servers())
+        result.update(self._discover_project_mcp_servers())
+        result.update(self._discover_managed_mcp_servers())
+        result.update(self._discover_env_override_mcp_servers())
+        return result
+
+    def discover_skills(self) -> SkillsDirsResult:
+        result: SkillsDirsResult = {}
+        result.update(self._discover_global_skills())
+        result.update(self._discover_project_skills())
+        result.update(self._discover_managed_skills())
+        return result
+
+    # --- folder resolution ---
+
+    def _global_config_dir(self) -> Path:
+        return expand_path(Path(self._install_path), self.home_directory)
+
+    def _data_dir(self) -> Path:
+        return expand_path(Path(self._data_path), self.home_directory)
+
+    def _managed_config_dir(self) -> Path | None:
+        """System-wide opencode config directory, or ``None`` on unsupported OSes."""
+        if sys.platform == "darwin":
+            return Path("/Library/Application Support/opencode")
+        if sys.platform in ("linux", "linux2"):
+            return Path("/etc/opencode")
+        if sys.platform == "win32":
+            program_data = os.environ.get("PROGRAMDATA") or r"C:\ProgramData"
+            return Path(program_data) / "opencode"
+        return None
+
+    def _opencode_config_env_path(self) -> Path | None:
+        """Resolved ``$OPENCODE_CONFIG`` path on an own-home scan, else ``None``."""
+        if not self._scans_own_home():
+            return None
+        override = os.environ.get("OPENCODE_CONFIG")
+        if not override:
+            return None
+        return Path(override)
+
+    # --- project enumeration (SQLite db) ---
+
+    def _discover_project_folders(self) -> list[Path]:
+        """Project paths from opencode's SQLite db (``project.worktree`` column).
+
+        Opened with ``mode=ro&immutable=1`` so a concurrently-running opencode
+        cannot block us on the WAL/SHM lock; any sqlite error (missing file,
+        schema drift, permission denied) yields ``[]`` rather than aborting the
+        whole discoverer.
+        """
+        db_path = self._data_dir() / self._db_filename
+        try:
+            if not db_path.exists():
+                return []
+        except (PermissionError, OSError):
+            return []
+        # ``immutable=1`` is what lets us co-exist with a live opencode: it tells
+        # SQLite the file will not change, so no WAL/SHM is consulted and no lock
+        # is taken. Safe for a read-only inspection.
+        uri = f"file:{db_path.as_posix()}?mode=ro&immutable=1"
+        try:
+            con = sqlite3.connect(uri, uri=True)
+            try:
+                cur = con.execute("SELECT worktree FROM project WHERE worktree IS NOT NULL")
+                rows = cur.fetchall()
+            finally:
+                con.close()
+        except sqlite3.Error as e:
+            logger.warning("Could not read opencode project table from %s: %s", db_path.as_posix(), e)
+            return []
+        return [Path(row[0]) for row in rows if isinstance(row[0], str) and row[0]]
+
+    # --- MCP discovery ---
+
+    def _scan_config_dir(self, base: Path) -> McpConfigsResult:
+        """Try every ``_CONFIG_FILENAMES`` entry under ``base``; record any hits."""
+        result: McpConfigsResult = {}
+        for filename in _CONFIG_FILENAMES:
+            path = base / filename
+            # ``skip_unrecognized=True`` so a file lacking an ``mcp`` block (e.g.
+            # an opencode config that only sets ``permission`` / ``theme``) is
+            # skipped quietly rather than reported as malformed. The
+            # ``_looks_like_mcp_payload`` gate covers wrapper-key detection.
+            parsed = self._parse_mcp_file(path, formats=_OPENCODE_MCP_FORMATS, skip_unrecognized=True)
+            if not parsed:
+                continue
+            result[path.as_posix()] = parsed
+        return result
+
+    def _discover_global_mcp_servers(self) -> McpConfigsResult:
+        return self._scan_config_dir(self._global_config_dir())
+
+    def _discover_project_mcp_servers(self) -> McpConfigsResult:
+        result: McpConfigsResult = {}
+        for project in self._project_paths_with_ancestors():
+            result.update(self._scan_config_dir(project))
+        return result
+
+    def _discover_managed_mcp_servers(self) -> McpConfigsResult:
+        managed_dir = self._managed_config_dir()
+        if managed_dir is None:
+            return {}
+        return self._scan_config_dir(managed_dir)
+
+    def _discover_env_override_mcp_servers(self) -> McpConfigsResult:
+        path = self._opencode_config_env_path()
+        if path is None:
+            return {}
+        # An explicitly-named config — do NOT use ``skip_unrecognized``: if the
+        # user pointed ``$OPENCODE_CONFIG`` at a file that fails to parse, that's
+        # a real signal worth surfacing rather than silently dropping.
+        parsed = self._parse_mcp_file(path, formats=_OPENCODE_MCP_FORMATS)
+        if not parsed:
+            return {}
+        return {path.as_posix(): parsed}
+
+    # --- skills discovery ---
+
+    def _discover_global_skills(self) -> SkillsDirsResult:
+        result: SkillsDirsResult = {}
+        skills_dir = self._global_config_dir() / self._skills_subdir
+        entries = self._scan_skills_dir(skills_dir)
+        if entries is not None:
+            result[skills_dir.as_posix()] = entries
+        return result
+
+    def _discover_project_skills(self) -> SkillsDirsResult:
+        result: SkillsDirsResult = {}
+        for project in self._project_paths_with_ancestors():
+            for rel in self._project_skills_relative:
+                skills_dir = project / rel
+                entries = self._scan_skills_dir(skills_dir)
+                if entries is not None:
+                    result[skills_dir.as_posix()] = entries
+        return result
+
+    def _discover_managed_skills(self) -> SkillsDirsResult:
+        managed_dir = self._managed_config_dir()
+        if managed_dir is None:
+            return {}
+        result: SkillsDirsResult = {}
+        skills_dir = managed_dir / self._skills_subdir
+        entries = self._scan_skills_dir(skills_dir)
+        if entries is not None:
+            result[skills_dir.as_posix()] = entries
+        return result

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -45,15 +45,20 @@ class OpenCodeDiscoverer(AgentDiscoverer):
       (Linux), or ``%ProgramData%\\opencode`` (Windows). See follow-up note in
       :meth:`_managed_config_dir` for the macOS MDM plist scope, which is
       intentionally NOT scanned here.
-    * Env overrides — both are honored only on an own-home scan (the env vars
+    * Env overrides — all are honored only on an own-home scan (the env vars
       reflect the *scanning process's* environment, so they must not be applied
-      to other users under ``--scan-all-users``):
+      to other users under ``--scan-all-users``). All are applied *additively*
+      to the home-relative defaults so the scanner never misses configs
+      regardless of whether opencode treats them as relocation or addition.
 
       - ``$OPENCODE_CONFIG`` names an alternate config file (mcp only).
-      - ``$OPENCODE_CONFIG_DIR`` names an alternate global config *directory*;
-        treated additively (the default ``~/.config/opencode`` is still scanned
-        too) so the scanner never misses configs regardless of whether opencode
-        treats this as replacement or addition.
+      - ``$OPENCODE_CONFIG_DIR`` names an alternate global config *directory*.
+      - ``$XDG_CONFIG_HOME``, ``$XDG_DATA_HOME``, ``$XDG_CACHE_HOME`` — opencode
+        uses the ``xdg-basedir`` package for every ``Global.Path`` location
+        (``packages/core/src/global.ts``), so when these are set opencode reads
+        from ``<XDG>/opencode/`` instead of the conventional home-relative paths
+        for config, data (SQLite db), and cache (URL-pulled skills),
+        respectively.
 
     * Claude-Code compat — opencode's skill discovery
       (https://opencode.ai/docs/skills) lists four extra paths it loads
@@ -137,12 +142,20 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     # --- public (override AgentDiscoverer abstracts) ---
 
     def client_exists(self) -> str | None:
-        path = self._global_config_dir()
-        try:
-            if path.exists():
-                return path.as_posix()
-        except PermissionError:
-            logger.warning("Permission error for path %s", path.as_posix())
+        """Detect an opencode install at any of the known global config dirs.
+
+        Walks every candidate in :meth:`_global_config_dirs` (XDG override,
+        ``$OPENCODE_CONFIG_DIR``, ``~/.config/opencode``, ``~/.opencode``) and
+        returns the first one that exists. A user with ``$XDG_CONFIG_HOME``
+        relocating their config out of ``~/.config`` would otherwise read as
+        "not installed" and skip the whole discoverer.
+        """
+        for path in self._global_config_dirs():
+            try:
+                if path.exists():
+                    return path.as_posix()
+            except PermissionError:
+                logger.warning("Permission error for path %s", path.as_posix())
         return None
 
     def discover_mcp_servers(self) -> McpConfigsResult:
@@ -177,15 +190,32 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         """
         return self._default_global_config_dir()
 
+    def _xdg_env_dir(self, env_var: str) -> Path | None:
+        """Return ``<env>/opencode`` if ``env_var`` is set on an own-home scan.
+
+        opencode resolves every ``Global.Path`` via ``xdg-basedir``
+        (``packages/core/src/global.ts``), which honors the standard ``XDG_*``
+        env vars. When the scanning process has one set, that's where opencode
+        is reading from; the scanner must look there too. Other users under
+        ``--scan-all-users`` get the home-relative defaults only.
+        """
+        if not self._scans_own_home():
+            return None
+        value = os.environ.get(env_var)
+        if not value:
+            return None
+        return Path(value) / "opencode"
+
     def _global_config_dirs(self) -> list[Path]:
         """Every global config dir to sweep for MCP/skills.
 
         Includes (in priority order):
 
-        - ``$OPENCODE_CONFIG_DIR`` when set on an own-home scan — kept additive
-          (not a replacement) so the scanner never misses configs regardless of
-          whether opencode treats the env var as relocation or as an additional
-          search root.
+        - ``$XDG_CONFIG_HOME/opencode`` when set on an own-home scan — opencode
+          reads its config from there instead of ``~/.config/opencode`` per
+          ``xdg-basedir`` resolution. Additive: defaults are still scanned.
+        - ``$OPENCODE_CONFIG_DIR`` when set on an own-home scan — opencode's
+          alternate config dir.
         - ``~/.config/opencode`` — the XDG default.
         - ``~/.opencode`` — opencode's ``ConfigPaths.directories`` also walks
           ``Global.Path.home`` for ``.opencode``, so a user with skills or an
@@ -195,6 +225,9 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         appears multiple ways collapses to one entry.
         """
         dirs: list[Path] = []
+        xdg = self._xdg_env_dir("XDG_CONFIG_HOME")
+        if xdg is not None:
+            dirs.append(xdg)
         if self._scans_own_home():
             override = os.environ.get("OPENCODE_CONFIG_DIR")
             if override:
@@ -203,11 +236,32 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         dirs.append(expand_path(Path(self._install_path_alt), self.home_directory))
         return dirs
 
-    def _data_dir(self) -> Path:
-        return expand_path(Path(self._data_path), self.home_directory)
+    def _data_dirs(self) -> list[Path]:
+        """Every data dir to consult for the opencode SQLite db.
 
-    def _cache_dir(self) -> Path:
-        return expand_path(Path(self._cache_path), self.home_directory)
+        Includes ``$XDG_DATA_HOME/opencode`` on own-home scans (where opencode
+        actually persists projects when XDG is set) plus the home-relative
+        default ``~/.local/share/opencode``.
+        """
+        dirs: list[Path] = []
+        xdg = self._xdg_env_dir("XDG_DATA_HOME")
+        if xdg is not None:
+            dirs.append(xdg)
+        dirs.append(expand_path(Path(self._data_path), self.home_directory))
+        return dirs
+
+    def _cache_dirs(self) -> list[Path]:
+        """Every cache dir to consult for URL-pulled skills.
+
+        Includes ``$XDG_CACHE_HOME/opencode`` on own-home scans plus the
+        home-relative default ``~/.cache/opencode``.
+        """
+        dirs: list[Path] = []
+        xdg = self._xdg_env_dir("XDG_CACHE_HOME")
+        if xdg is not None:
+            dirs.append(xdg)
+        dirs.append(expand_path(Path(self._cache_path), self.home_directory))
+        return dirs
 
     def _managed_config_dir(self) -> Path | None:
         """System-wide opencode config directory, or ``None`` on unsupported OSes.
@@ -242,32 +296,42 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     def _discover_project_folders(self) -> list[Path]:
         """Project paths from opencode's SQLite db (``project.worktree`` column).
 
-        Opened with ``mode=ro&immutable=1`` so a concurrently-running opencode
-        cannot block us on the WAL/SHM lock; any sqlite error (missing file,
-        schema drift, permission denied) yields ``[]`` rather than aborting the
-        whole discoverer.
+        Reads ``opencode.db`` from every data dir in :meth:`_data_dirs` (XDG +
+        default), deduplicating worktree paths. Opened with
+        ``mode=ro&immutable=1`` so a concurrently-running opencode cannot block
+        us on the WAL/SHM lock; per-db sqlite errors (missing file, schema
+        drift, permission denied) are tolerated rather than aborting the whole
+        discoverer.
         """
-        db_path = self._data_dir() / self._db_filename
-        try:
-            if not db_path.exists():
-                return []
-        except (PermissionError, OSError):
-            return []
-        # ``immutable=1`` is what lets us co-exist with a live opencode: it tells
-        # SQLite the file will not change, so no WAL/SHM is consulted and no lock
-        # is taken. Safe for a read-only inspection.
-        uri = f"file:{db_path.as_posix()}?mode=ro&immutable=1"
-        try:
-            con = sqlite3.connect(uri, uri=True)
+        seen: set[str] = set()
+        result: list[Path] = []
+        for data_dir in self._data_dirs():
+            db_path = data_dir / self._db_filename
             try:
-                cur = con.execute("SELECT worktree FROM project WHERE worktree IS NOT NULL")
-                rows = cur.fetchall()
-            finally:
-                con.close()
-        except sqlite3.Error as e:
-            logger.warning("Could not read opencode project table from %s: %s", db_path.as_posix(), e)
-            return []
-        return [Path(row[0]) for row in rows if isinstance(row[0], str) and row[0]]
+                if not db_path.exists():
+                    continue
+            except (PermissionError, OSError):
+                continue
+            # ``immutable=1`` tells SQLite the file will not change, so no
+            # WAL/SHM is consulted and no lock is taken — safe co-existence
+            # with a live opencode.
+            uri = f"file:{db_path.as_posix()}?mode=ro&immutable=1"
+            try:
+                con = sqlite3.connect(uri, uri=True)
+                try:
+                    cur = con.execute("SELECT worktree FROM project WHERE worktree IS NOT NULL")
+                    rows = cur.fetchall()
+                finally:
+                    con.close()
+            except sqlite3.Error as e:
+                logger.warning("Could not read opencode project table from %s: %s", db_path.as_posix(), e)
+                continue
+            for row in rows:
+                if not isinstance(row[0], str) or not row[0] or row[0] in seen:
+                    continue
+                seen.add(row[0])
+                result.append(Path(row[0]))
+        return result
 
     # --- MCP discovery ---
 
@@ -436,25 +500,26 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     # --- URL-pulled skills cache (Gap C) ---
 
     def _discover_cached_url_skills(self) -> SkillsDirsResult:
-        """Scan ``~/.cache/opencode/skills/<hash>/`` for skills pulled from
-        ``cfg.skills.urls`` URLs.
+        """Scan ``<cache>/opencode/skills/<hash>/`` for URL-pulled skills.
 
-        Per ``packages/core/src/skill/discovery.ts:107`` the layout is
-        ``<cache>/skills/<Bun.hash(base-url)>/<skill-name>/SKILL.md``. Each
-        ``<hash>`` directory is structurally identical to a normal skills dir
-        root, so we list one level beneath ``skills/`` and feed each match
+        Iterates every cache dir in :meth:`_cache_dirs` (XDG override +
+        default). Per ``packages/core/src/skill/discovery.ts:107`` the layout
+        under each cache root is ``skills/<Bun.hash(base-url)>/<skill-name>/SKILL.md``.
+        Each ``<hash>`` directory is structurally identical to a normal skills
+        dir root, so we list one level beneath ``skills/`` and feed each match
         through ``_scan_skills_dir``.
         """
-        cache_skills = self._cache_dir() / "skills"
         result: SkillsDirsResult = {}
-        try:
-            if not cache_skills.is_dir():
-                return result
-            hash_dirs = sorted(cache_skills.iterdir())
-        except (PermissionError, OSError):
-            return result
-        for hash_dir in hash_dirs:
-            if not hash_dir.is_dir():
+        for cache_dir in self._cache_dirs():
+            cache_skills = cache_dir / "skills"
+            try:
+                if not cache_skills.is_dir():
+                    continue
+                hash_dirs = sorted(cache_skills.iterdir())
+            except (PermissionError, OSError):
                 continue
-            self._record_skills_at(result, hash_dir)
+            for hash_dir in hash_dirs:
+                if not hash_dir.is_dir():
+                    continue
+                self._record_skills_at(result, hash_dir)
         return result

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -204,7 +204,11 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         value = os.environ.get(env_var)
         if not value:
             return None
-        return Path(value) / "opencode"
+        # ``.absolute()`` so a relative env value (xdg-basedir/Node don't reject
+        # one) still yields an absolute path — the result dicts are keyed by
+        # ``.as_posix()`` and downstream dedup/attribution assumes absolute keys.
+        # Matches the ``.absolute()`` guard on the SQLite db path below.
+        return (Path(value) / "opencode").absolute()
 
     def _global_config_dirs(self) -> list[Path]:
         """Every global config dir to sweep for MCP/skills.
@@ -231,7 +235,9 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         if self._scans_own_home():
             override = os.environ.get("OPENCODE_CONFIG_DIR")
             if override:
-                dirs.append(Path(override))
+                # ``.absolute()`` keeps keys absolute even for a relative env
+                # value (see ``_xdg_env_dir``).
+                dirs.append(Path(override).absolute())
         dirs.append(self._default_global_config_dir())
         dirs.append(expand_path(Path(self._install_path_alt), self.home_directory))
         return dirs
@@ -285,7 +291,9 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         override = os.environ.get("OPENCODE_CONFIG")
         if not override:
             return None
-        return Path(override)
+        # ``.absolute()`` so a relative env value yields an absolute key /
+        # ``client_path`` (see ``_xdg_env_dir``).
+        return Path(override).absolute()
 
     # --- project enumeration (SQLite db) ---
 

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -317,7 +317,17 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         for data_dir in self._data_dirs():
             db_path = data_dir / self._db_filename
             try:
-                if not db_path.exists():
+                # ``is_file()`` (not ``exists()``) so a non-regular file planted
+                # at this path — a FIFO/socket/device, the classic
+                # ``--scan-all-users`` hostile-home case — is skipped before
+                # ``sqlite3.connect`` can block on open()/first-read waiting for
+                # a writer and hang the scan. Mirrors the ``is_file()`` guard the
+                # plugin/extension MCP walks use for the same defense. Follows
+                # symlinks, so a symlink to a real db still works; a symlink to a
+                # FIFO is rejected. Like ``exists()``, ``is_file()`` re-raises
+                # OSErrors outside the ENOENT/ENOTDIR ignore set (ESTALE, EIO),
+                # so the per-candidate tolerance below is still needed.
+                if not db_path.is_file():
                     continue
             except (PermissionError, OSError):
                 continue

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -26,22 +26,47 @@ _CONFIG_FILENAMES: tuple[str, ...] = ("opencode.json", "opencode.jsonc")
 
 
 class OpenCodeDiscoverer(AgentDiscoverer):
-    """opencode discovery across global, project, managed, and ``$OPENCODE_CONFIG`` scopes.
+    """opencode discovery across global, project, managed, env-override, and
+    Claude-compatibility scopes.
 
     Scope sources:
 
     * Global — ``~/.config/opencode/opencode.{json,jsonc}`` (mcp) and
-      ``~/.config/opencode/skills`` (skills). ``~/.config/opencode`` is XDG-style
-      on every OS opencode supports, including Windows (verified empirically).
-    * Project — for every project root in ``_project_paths_with_ancestors`` (and
-      its ancestors): ``<root>/opencode.{json,jsonc}`` plus ``<root>/.opencode/skills``.
-    * Managed — per-OS system-wide ``opencode.{json,jsonc}`` (and ``skills/``)
+      ``~/.config/opencode/{skills,skill}`` (skills). ``~/.config/opencode`` is
+      XDG-style on every OS opencode supports, including Windows (verified
+      empirically). Singular ``skill/`` is opencode's documented
+      backwards-compat spelling (https://opencode.ai/docs/config: "Singular
+      names (e.g., ``agent/``) are also supported for backwards compatibility").
+    * Project — for every project root in ``_project_paths_with_ancestors``
+      (and its ancestors): ``<root>/opencode.{json,jsonc}`` plus
+      ``<root>/.opencode/{skills,skill}``.
+    * Managed — per-OS system-wide ``opencode.{json,jsonc}`` (and skill dirs)
       under ``/Library/Application Support/opencode`` (macOS), ``/etc/opencode``
-      (Linux), or ``%ProgramData%\\opencode`` (Windows).
-    * Env override — ``$OPENCODE_CONFIG`` names an alternate config file; honored
-      only on an own-home scan (the env var reflects the *scanning process's*
-      environment, so it must not be applied to other users under
-      ``--scan-all-users``).
+      (Linux), or ``%ProgramData%\\opencode`` (Windows). See follow-up note in
+      :meth:`_managed_config_dir` for the macOS MDM plist scope, which is
+      intentionally NOT scanned here.
+    * Env overrides — both are honored only on an own-home scan (the env vars
+      reflect the *scanning process's* environment, so they must not be applied
+      to other users under ``--scan-all-users``):
+
+      - ``$OPENCODE_CONFIG`` names an alternate config file (mcp only).
+      - ``$OPENCODE_CONFIG_DIR`` names an alternate global config *directory*;
+        treated additively (the default ``~/.config/opencode`` is still scanned
+        too) so the scanner never misses configs regardless of whether opencode
+        treats this as replacement or addition.
+
+    * Claude-Code compat — opencode's skill discovery
+      (https://opencode.ai/docs/skills) lists four extra paths it loads
+      alongside its own ``skills/`` dirs:
+
+      - Project: ``<root>/.claude/skills``, ``<root>/.agents/skills``
+      - Global: ``~/.claude/skills``, ``~/.agents/skills``
+
+      These are scanned even when Claude Code itself is not installed (an
+      opencode-only user may still have authored skills under one of these
+      directories — opencode will load them, so the scanner must see them).
+      Cross-discoverer overlap when Claude Code *is* also installed is harmless:
+      the pipeline keys results by absolute path and dedupes.
 
     Project enumeration is unusual: opencode persists the absolute paths of
     opened projects in a SQLite database at
@@ -56,11 +81,29 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     _install_path = "~/.config/opencode"
     _data_path = "~/.local/share/opencode"
     _db_filename = "opencode.db"
-    _skills_subdir = "skills"
+    # Both spellings are documented; ``skills/`` is canonical, ``skill/`` is the
+    # backwards-compat alias. We scan both so a user who created either gets
+    # picked up; downstream keys by absolute path so a single existing dir
+    # appears once.
+    _skills_subdirs: tuple[str, ...] = ("skills", "skill")
     # Project-scoped skill dirs scanned at every opened project root and its
-    # ancestors. ``.opencode/skills`` is opencode's canonical project skills
-    # location per https://opencode.ai/docs/skills.
-    _project_skills_relative: tuple[str, ...] = (".opencode/skills",)
+    # ancestors. The ``.opencode/`` entries are opencode-native (both spellings
+    # per the backwards-compat note above); the ``.claude/`` and ``.agents/``
+    # entries are the Claude-Code/cross-agent compat paths opencode also loads
+    # per https://opencode.ai/docs/skills.
+    _project_skills_relative: tuple[str, ...] = (
+        ".opencode/skills",
+        ".opencode/skill",
+        ".claude/skills",
+        ".agents/skills",
+    )
+    # Global Claude-compat skill dirs scanned in addition to
+    # ``~/.config/opencode/{skills,skill}``. Same compat list as above but
+    # rooted at the user's home.
+    _global_compat_skill_dirs: tuple[str, ...] = (
+        "~/.claude/skills",
+        "~/.agents/skills",
+    )
 
     # --- public (override AgentDiscoverer abstracts) ---
 
@@ -90,14 +133,50 @@ class OpenCodeDiscoverer(AgentDiscoverer):
 
     # --- folder resolution ---
 
-    def _global_config_dir(self) -> Path:
+    def _default_global_config_dir(self) -> Path:
+        """The XDG-style default global config dir, ignoring ``OPENCODE_CONFIG_DIR``."""
         return expand_path(Path(self._install_path), self.home_directory)
+
+    def _global_config_dir(self) -> Path:
+        """The single global config dir reported as the install path.
+
+        Kept as the canonical install path for ``client_exists``; the discovery
+        sweeps consult :meth:`_global_config_dirs` instead so they cover the
+        ``OPENCODE_CONFIG_DIR`` override too.
+        """
+        return self._default_global_config_dir()
+
+    def _global_config_dirs(self) -> list[Path]:
+        """Every global config dir to sweep for MCP/skills.
+
+        Always includes the XDG default (``~/.config/opencode``). When
+        ``$OPENCODE_CONFIG_DIR`` is set on an own-home scan, prepend it — kept
+        additive (not a replacement) so the scanner never misses configs
+        regardless of whether opencode treats the env var as relocation or as
+        an additional search root. Results are downstream-keyed by absolute
+        path, so a single dir that appears both ways collapses to one entry.
+        """
+        dirs: list[Path] = []
+        if self._scans_own_home():
+            override = os.environ.get("OPENCODE_CONFIG_DIR")
+            if override:
+                dirs.append(Path(override))
+        dirs.append(self._default_global_config_dir())
+        return dirs
 
     def _data_dir(self) -> Path:
         return expand_path(Path(self._data_path), self.home_directory)
 
     def _managed_config_dir(self) -> Path | None:
-        """System-wide opencode config directory, or ``None`` on unsupported OSes."""
+        """System-wide opencode config directory, or ``None`` on unsupported OSes.
+
+        macOS MDM scope NOT scanned here: opencode also exposes managed
+        preferences as a plist at ``/Library/Managed Preferences/<user>/
+        ai.opencode.managed.plist`` (bundle id ``ai.opencode.managed``). That
+        path uses Apple's binary-or-XML plist format, not JSON, and its mcp
+        schema is not yet documented end-to-end. Adding plist parsing for a
+        speculative schema would be premature; documented in TODO(ADS-MDM).
+        """
         if sys.platform == "darwin":
             return Path("/Library/Application Support/opencode")
         if sys.platform in ("linux", "linux2"):
@@ -166,7 +245,10 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         return result
 
     def _discover_global_mcp_servers(self) -> McpConfigsResult:
-        return self._scan_config_dir(self._global_config_dir())
+        result: McpConfigsResult = {}
+        for base in self._global_config_dirs():
+            result.update(self._scan_config_dir(base))
+        return result
 
     def _discover_project_mcp_servers(self) -> McpConfigsResult:
         result: McpConfigsResult = {}
@@ -194,22 +276,33 @@ class OpenCodeDiscoverer(AgentDiscoverer):
 
     # --- skills discovery ---
 
-    def _discover_global_skills(self) -> SkillsDirsResult:
-        result: SkillsDirsResult = {}
-        skills_dir = self._global_config_dir() / self._skills_subdir
-        entries = self._scan_skills_dir(skills_dir)
+    def _record_skills_at(self, result: SkillsDirsResult, path: Path) -> None:
+        """If ``path`` is an existing skills dir, record its entries under ``result``.
+
+        Centralized so every skill scope (global, global-compat, project,
+        managed) uses the same is-dir / PermissionError tolerance via
+        ``_scan_skills_dir``.
+        """
+        entries = self._scan_skills_dir(path)
         if entries is not None:
-            result[skills_dir.as_posix()] = entries
+            result[path.as_posix()] = entries
+
+    def _discover_global_skills(self) -> SkillsDirsResult:
+        """Scan every ``{base}/{skills,skill}`` across the global config dirs
+        (default + ``$OPENCODE_CONFIG_DIR``) and the Claude-compat globals."""
+        result: SkillsDirsResult = {}
+        for base in self._global_config_dirs():
+            for sub in self._skills_subdirs:
+                self._record_skills_at(result, base / sub)
+        for rel in self._global_compat_skill_dirs:
+            self._record_skills_at(result, expand_path(Path(rel), self.home_directory))
         return result
 
     def _discover_project_skills(self) -> SkillsDirsResult:
         result: SkillsDirsResult = {}
         for project in self._project_paths_with_ancestors():
             for rel in self._project_skills_relative:
-                skills_dir = project / rel
-                entries = self._scan_skills_dir(skills_dir)
-                if entries is not None:
-                    result[skills_dir.as_posix()] = entries
+                self._record_skills_at(result, project / rel)
         return result
 
     def _discover_managed_skills(self) -> SkillsDirsResult:
@@ -217,8 +310,6 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         if managed_dir is None:
             return {}
         result: SkillsDirsResult = {}
-        skills_dir = managed_dir / self._skills_subdir
-        entries = self._scan_skills_dir(skills_dir)
-        if entries is not None:
-            result[skills_dir.as_posix()] = entries
+        for sub in self._skills_subdirs:
+            self._record_skills_at(result, managed_dir / sub)
         return result

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -163,8 +163,13 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             try:
                 if path.exists():
                     return path.as_posix()
-            except PermissionError:
-                logger.warning("Permission error for path %s", path.as_posix())
+            except (PermissionError, OSError) as e:
+                # ``Path.exists()`` re-raises OSErrors other than
+                # ENOENT/ENOTDIR/EBADF/ELOOP (e.g. ESTALE on a stale NFS mount,
+                # EIO). Tolerate per candidate and keep probing the rest rather
+                # than letting one bad path drop the whole discoverer. Matches
+                # the ``(PermissionError, OSError)`` guard on the db probe below.
+                logger.warning("Error checking opencode candidate path %s: %s", path.as_posix(), e)
         return None
 
     def discover_mcp_servers(self) -> McpConfigsResult:

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -306,11 +306,11 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         """Project paths from opencode's SQLite db (``project.worktree`` column).
 
         Reads ``opencode.db`` from every data dir in :meth:`_data_dirs` (XDG +
-        default), deduplicating worktree paths. Opened with
-        ``mode=ro&immutable=1`` so a concurrently-running opencode cannot block
-        us on the WAL/SHM lock; per-db sqlite errors (missing file, schema
-        drift, permission denied) are tolerated rather than aborting the whole
-        discoverer.
+        default), deduplicating worktree paths. :meth:`_read_worktrees` opens
+        each db read-only (preferring a WAL-aware ``mode=ro`` read, falling back
+        to an ``immutable=1`` snapshot when that open is denied); per-db sqlite
+        errors (missing file, schema drift, permission denied) are tolerated
+        rather than aborting the whole discoverer.
         """
         seen: set[str] = set()
         result: list[Path] = []
@@ -331,39 +331,8 @@ class OpenCodeDiscoverer(AgentDiscoverer):
                     continue
             except (PermissionError, OSError):
                 continue
-            # ``immutable=1`` tells SQLite to bypass the WAL/SHM machinery
-            # entirely (no lock taken, no ``-shm`` file consulted). This is
-            # the right trade-off here for two reasons:
-            #   1. Under ``--scan-all-users`` the scanner reads other users'
-            #      dbs and may not have permission to create or read the
-            #      ``-shm`` file a normal WAL reader needs — without
-            #      ``immutable=1`` those scans would fail outright and
-            #      silently drop every project for that user.
-            #   2. The cost is tolerated torn reads if opencode happens to
-            #      be writing the ``project`` table mid-scan: a corrupt
-            #      worktree string yields a ``Path`` whose ancestor walk
-            #      makes a bounded handful of stat calls (one
-            #      ``opencode.json`` / ``.opencode/skills`` probe per
-            #      ancestor up to the filesystem root), all of which miss
-            #      on a non-existent path. The ``project`` table only grows
-            #      when a user opens a new project, so the window is small
-            #      in practice.
-            # ``as_uri()`` produces the canonical ``file:///`` form on every
-            # OS (Windows needs the third slash so ``C:`` isn't parsed as URI
-            # authority) and percent-encodes any ``?``/``#``/whitespace in
-            # the path so they don't corrupt the query string. ``.absolute()``
-            # guards a relative ``$XDG_DATA_HOME`` — ``as_uri`` raises
-            # ValueError on relative paths.
-            uri = f"{db_path.absolute().as_uri()}?mode=ro&immutable=1"
-            try:
-                con = sqlite3.connect(uri, uri=True)
-                try:
-                    cur = con.execute("SELECT worktree FROM project WHERE worktree IS NOT NULL")
-                    rows = cur.fetchall()
-                finally:
-                    con.close()
-            except sqlite3.Error as e:
-                logger.warning("Could not read opencode project table from %s: %s", db_path.as_posix(), e)
+            rows = self._read_worktrees(db_path)
+            if rows is None:
                 continue
             for row in rows:
                 if not isinstance(row[0], str) or not row[0] or row[0] in seen:
@@ -371,6 +340,52 @@ class OpenCodeDiscoverer(AgentDiscoverer):
                 seen.add(row[0])
                 result.append(Path(row[0]))
         return result
+
+    def _read_worktrees(self, db_path: Path) -> list[tuple[object, ...]] | None:
+        """Read the ``project.worktree`` column read-only, preferring a live
+        (WAL-aware) read and falling back to an immutable snapshot. ``None`` on
+        any sqlite failure (missing table, corruption, denied open).
+
+        ``mode=ro`` reads the latest *committed* state, including rows still in
+        the ``-wal`` that opencode hasn't checkpointed into the main db yet —
+        where its most-recently-opened projects live, since it keeps a
+        long-lived WAL connection and checkpoints lazily. But a plain read-only
+        open of a WAL db must read/build the ``-shm`` wal-index, which an
+        unprivileged scanner reading *another* user's home under
+        ``--scan-all-users`` may lack permission to write; that open fails
+        outright. So we fall back to ``immutable=1``, which tells SQLite the
+        file never changes and to read the main db file directly with no
+        ``-wal``/``-shm`` consulted and no lock taken: the open always succeeds,
+        at the cost of missing un-checkpointed rows (and tolerating a torn read
+        of an in-flight write — a bogus worktree string just yields a Path whose
+        ancestor walk misses on a handful of stats). Best case (own-home / root
+        scan) we get freshness; worst case we still get every checkpointed
+        project instead of dropping the user entirely.
+
+        ``no such table`` (schema drift) also raises ``OperationalError``, so a
+        drifted db is probed in both modes before the warning — rare and cheap
+        (no rows, fast fail), and preferable to matching on error-message text.
+
+        ``as_uri()`` produces the canonical ``file:///`` form on every OS
+        (Windows needs the third slash so ``C:`` isn't parsed as URI authority)
+        and percent-encodes any ``?``/``#``/whitespace in the path so they don't
+        corrupt the query string. ``.absolute()`` guards a relative
+        ``$XDG_DATA_HOME`` — ``as_uri`` raises ValueError on relative paths.
+        """
+        base = db_path.absolute().as_uri()
+        last_error: sqlite3.Error | None = None
+        for suffix in ("?mode=ro", "?mode=ro&immutable=1"):
+            try:
+                con = sqlite3.connect(f"{base}{suffix}", uri=True)
+                try:
+                    return con.execute("SELECT worktree FROM project WHERE worktree IS NOT NULL").fetchall()
+                finally:
+                    con.close()
+            except sqlite3.Error as e:
+                last_error = e
+                continue
+        logger.warning("Could not read opencode project table from %s: %s", db_path.as_posix(), last_error)
+        return None
 
     # --- MCP discovery ---
 

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -312,14 +312,26 @@ class OpenCodeDiscoverer(AgentDiscoverer):
                     continue
             except (PermissionError, OSError):
                 continue
-            # ``immutable=1`` tells SQLite the file will not change, so no
-            # WAL/SHM is consulted and no lock is taken — safe co-existence
-            # with a live opencode. ``as_uri()`` produces the canonical
-            # ``file:///`` form on every OS (Windows needs the third slash so
-            # ``C:`` isn't parsed as URI authority) and percent-encodes any
-            # ``?``/``#``/whitespace in the path so they don't corrupt the
-            # query string. ``.absolute()`` guards a relative ``$XDG_DATA_HOME``
-            # — ``as_uri`` raises ValueError on relative paths.
+            # ``immutable=1`` tells SQLite to bypass the WAL/SHM machinery
+            # entirely (no lock taken, no ``-shm`` file consulted). This is
+            # the right trade-off here for two reasons:
+            #   1. Under ``--scan-all-users`` the scanner reads other users'
+            #      dbs and may not have permission to create or read the
+            #      ``-shm`` file a normal WAL reader needs — without
+            #      ``immutable=1`` those scans would fail outright and
+            #      silently drop every project for that user.
+            #   2. The cost is tolerated torn reads if opencode happens to
+            #      be writing the ``project`` table mid-scan: a corrupt
+            #      worktree string just yields a ``Path`` that probes
+            #      nothing downstream. The ``project`` table only grows
+            #      when a user opens a new project, so the window is small
+            #      in practice.
+            # ``as_uri()`` produces the canonical ``file:///`` form on every
+            # OS (Windows needs the third slash so ``C:`` isn't parsed as URI
+            # authority) and percent-encodes any ``?``/``#``/whitespace in
+            # the path so they don't corrupt the query string. ``.absolute()``
+            # guards a relative ``$XDG_DATA_HOME`` — ``as_uri`` raises
+            # ValueError on relative paths.
             uri = f"{db_path.absolute().as_uri()}?mode=ro&immutable=1"
             try:
                 con = sqlite3.connect(uri, uri=True)

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -314,8 +314,13 @@ class OpenCodeDiscoverer(AgentDiscoverer):
                 continue
             # ``immutable=1`` tells SQLite the file will not change, so no
             # WAL/SHM is consulted and no lock is taken — safe co-existence
-            # with a live opencode.
-            uri = f"file:{db_path.as_posix()}?mode=ro&immutable=1"
+            # with a live opencode. ``as_uri()`` produces the canonical
+            # ``file:///`` form on every OS (Windows needs the third slash so
+            # ``C:`` isn't parsed as URI authority) and percent-encodes any
+            # ``?``/``#``/whitespace in the path so they don't corrupt the
+            # query string. ``.absolute()`` guards a relative ``$XDG_DATA_HOME``
+            # — ``as_uri`` raises ValueError on relative paths.
+            uri = f"{db_path.absolute().as_uri()}?mode=ro&immutable=1"
             try:
                 con = sqlite3.connect(uri, uri=True)
                 try:

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -42,9 +42,7 @@ class OpenCodeDiscoverer(AgentDiscoverer):
       ``<root>/.opencode/{skills,skill}``.
     * Managed — per-OS system-wide ``opencode.{json,jsonc}`` (and skill dirs)
       under ``/Library/Application Support/opencode`` (macOS), ``/etc/opencode``
-      (Linux), or ``%ProgramData%\\opencode`` (Windows). See follow-up note in
-      :meth:`_managed_config_dir` for the macOS MDM plist scope, which is
-      intentionally NOT scanned here.
+      (Linux), or ``%ProgramData%\\opencode`` (Windows).
     * Env overrides — all are honored only on an own-home scan (the env vars
       reflect the *scanning process's* environment, so they must not be applied
       to other users under ``--scan-all-users``). All are applied *additively*
@@ -268,12 +266,8 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     def _managed_config_dir(self) -> Path | None:
         """System-wide opencode config directory, or ``None`` on unsupported OSes.
 
-        macOS MDM scope NOT scanned here: opencode also exposes managed
-        preferences as a plist at ``/Library/Managed Preferences/<user>/
-        ai.opencode.managed.plist`` (bundle id ``ai.opencode.managed``). That
-        path uses Apple's binary-or-XML plist format, not JSON, and its mcp
-        schema is not yet documented end-to-end. Adding plist parsing for a
-        speculative schema would be premature; documented in TODO(ADS-MDM).
+        ``/Library/Application Support/opencode`` (macOS), ``/etc/opencode``
+        (Linux), or ``%ProgramData%\\opencode`` (Windows).
         """
         if sys.platform == "darwin":
             return Path("/Library/Application Support/opencode")
@@ -478,11 +472,8 @@ class OpenCodeDiscoverer(AgentDiscoverer):
 
         The opencode loader (``packages/opencode/src/skill/index.ts:211-220``)
         expands each entry — ``~/...`` against the user's home, relative paths
-        against the *containing config file's directory* — then globs
-        ``**/SKILL.md`` recursively. We mirror the expansion rules; the
-        recursive ``**/SKILL.md`` is handled by ``_scan_skills_dir`` only at
-        the top level for now (nested skills are a separate follow-up, since
-        ``inspect_skills_dir`` is shared infrastructure).
+        against the *containing config file's directory*. We mirror those
+        expansion rules and scan each resolved directory via ``_scan_skills_dir``.
 
         Malformed config files (already reported by MCP discovery) are skipped
         here — we only consume the ``skills.paths`` array on success.

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -68,6 +68,24 @@ class OpenCodeDiscoverer(AgentDiscoverer):
       Cross-discoverer overlap when Claude Code *is* also installed is harmless:
       the pipeline keys results by absolute path and dedupes.
 
+    * Second global dir — opencode's own ``ConfigPaths.directories`` also walks
+      ``~/.opencode`` (``packages/opencode/src/config/paths.ts``), so that
+      location is treated as a second global config root.
+
+    * User-declared skill folders — opencode's config schema
+      (``packages/core/src/v1/config/skills.ts``) exposes
+      ``skills.paths: string[]`` for "additional paths to skill folders". Every
+      ``opencode.json`` we already parse is rechecked for this array, and each
+      entry is expanded the way opencode does: ``~/...`` against
+      ``home_directory``, relative against the *containing config file's
+      directory*.
+
+    * URL-pulled skill cache — opencode's config also exposes
+      ``skills.urls: string[]``; the runtime puller writes downloaded skills
+      under ``~/.cache/opencode/skills/<Bun.hash(base-url)>/<skill-name>/SKILL.md``
+      (``packages/core/src/skill/discovery.ts``). Each hash dir is scanned as a
+      skills-dir root.
+
     Project enumeration is unusual: opencode persists the absolute paths of
     opened projects in a SQLite database at
     ``~/.local/share/opencode/opencode.db`` (Drizzle ``project`` table,
@@ -79,7 +97,18 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     name = "opencode"
 
     _install_path = "~/.config/opencode"
+    # opencode's own ``ConfigPaths.directories`` walks ``Global.Path.home`` for
+    # a ``.opencode`` dir (packages/opencode/src/config/paths.ts:34-38), so
+    # ``~/.opencode`` is a real second global config location alongside
+    # ``~/.config/opencode``. Scanned for both ``opencode.{json,jsonc}`` and
+    # ``{skills,skill}`` subdirs.
+    _install_path_alt = "~/.opencode"
     _data_path = "~/.local/share/opencode"
+    # opencode caches URL-pulled skills here. Per
+    # packages/core/src/skill/discovery.ts:107 the layout is
+    # ``<cache>/skills/<bun-hash-of-base-url>/<skill-name>/SKILL.md``. We walk
+    # the ``<hash>`` level so each hash dir is treated like a skills dir root.
+    _cache_path = "~/.cache/opencode"
     _db_filename = "opencode.db"
     # Both spellings are documented; ``skills/`` is canonical, ``skill/`` is the
     # backwards-compat alias. We scan both so a user who created either gets
@@ -129,6 +158,8 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         result.update(self._discover_global_skills())
         result.update(self._discover_project_skills())
         result.update(self._discover_managed_skills())
+        result.update(self._discover_config_skills_paths())
+        result.update(self._discover_cached_url_skills())
         return result
 
     # --- folder resolution ---
@@ -149,12 +180,19 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     def _global_config_dirs(self) -> list[Path]:
         """Every global config dir to sweep for MCP/skills.
 
-        Always includes the XDG default (``~/.config/opencode``). When
-        ``$OPENCODE_CONFIG_DIR`` is set on an own-home scan, prepend it — kept
-        additive (not a replacement) so the scanner never misses configs
-        regardless of whether opencode treats the env var as relocation or as
-        an additional search root. Results are downstream-keyed by absolute
-        path, so a single dir that appears both ways collapses to one entry.
+        Includes (in priority order):
+
+        - ``$OPENCODE_CONFIG_DIR`` when set on an own-home scan — kept additive
+          (not a replacement) so the scanner never misses configs regardless of
+          whether opencode treats the env var as relocation or as an additional
+          search root.
+        - ``~/.config/opencode`` — the XDG default.
+        - ``~/.opencode`` — opencode's ``ConfigPaths.directories`` also walks
+          ``Global.Path.home`` for ``.opencode``, so a user with skills or an
+          ``opencode.json`` directly under their home dir gets discovered too.
+
+        Results are downstream-keyed by absolute path, so a single dir that
+        appears multiple ways collapses to one entry.
         """
         dirs: list[Path] = []
         if self._scans_own_home():
@@ -162,10 +200,14 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             if override:
                 dirs.append(Path(override))
         dirs.append(self._default_global_config_dir())
+        dirs.append(expand_path(Path(self._install_path_alt), self.home_directory))
         return dirs
 
     def _data_dir(self) -> Path:
         return expand_path(Path(self._data_path), self.home_directory)
+
+    def _cache_dir(self) -> Path:
+        return expand_path(Path(self._cache_path), self.home_directory)
 
     def _managed_config_dir(self) -> Path | None:
         """System-wide opencode config directory, or ``None`` on unsupported OSes.
@@ -312,4 +354,107 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         result: SkillsDirsResult = {}
         for sub in self._skills_subdirs:
             self._record_skills_at(result, managed_dir / sub)
+        return result
+
+    # --- skills.paths from user opencode.json (Gap B) ---
+
+    def _iter_candidate_config_files(self) -> list[Path]:
+        """Every opencode config file we'd consider for ``skills.paths`` extraction.
+
+        Covers the same scopes as MCP discovery (global, project, managed,
+        ``$OPENCODE_CONFIG`` env file) so a ``skills.paths`` declared anywhere
+        opencode honors it is picked up. The file may or may not exist;
+        ``_load_json_file`` handles missing/unreadable files quietly.
+        """
+        candidates: list[Path] = []
+        for base in self._global_config_dirs():
+            for filename in _CONFIG_FILENAMES:
+                candidates.append(base / filename)
+        for project in self._project_paths_with_ancestors():
+            for filename in _CONFIG_FILENAMES:
+                candidates.append(project / filename)
+        managed = self._managed_config_dir()
+        if managed is not None:
+            for filename in _CONFIG_FILENAMES:
+                candidates.append(managed / filename)
+        env_path = self._opencode_config_env_path()
+        if env_path is not None:
+            candidates.append(env_path)
+        return candidates
+
+    def _discover_config_skills_paths(self) -> SkillsDirsResult:
+        """Scan every ``skills.paths`` entry referenced from any opencode.json.
+
+        Per ``packages/core/src/v1/config/skills.ts``:
+
+            paths: Schema.optional(Schema.Array(Schema.String))
+                .annotate({ description: "Additional paths to skill folders" })
+
+        The opencode loader (``packages/opencode/src/skill/index.ts:211-220``)
+        expands each entry — ``~/...`` against the user's home, relative paths
+        against the *containing config file's directory* — then globs
+        ``**/SKILL.md`` recursively. We mirror the expansion rules; the
+        recursive ``**/SKILL.md`` is handled by ``_scan_skills_dir`` only at
+        the top level for now (nested skills are a separate follow-up, since
+        ``inspect_skills_dir`` is shared infrastructure).
+
+        Malformed config files (already reported by MCP discovery) are skipped
+        here — we only consume the ``skills.paths`` array on success.
+        """
+        result: SkillsDirsResult = {}
+        for config_path in self._iter_candidate_config_files():
+            data = self._load_json_file(config_path)
+            if not isinstance(data, dict):
+                continue
+            skills = data.get("skills")
+            if not isinstance(skills, dict):
+                continue
+            paths = skills.get("paths")
+            if not isinstance(paths, list):
+                continue
+            for entry in paths:
+                if not isinstance(entry, str) or not entry:
+                    continue
+                resolved = self._resolve_skills_path_entry(entry, config_path)
+                self._record_skills_at(result, resolved)
+        return result
+
+    def _resolve_skills_path_entry(self, entry: str, config_path: Path) -> Path:
+        """Expand a single ``skills.paths`` entry the way opencode does.
+
+        - ``~/...`` -> joined to ``self.home_directory``.
+        - Absolute -> as-is.
+        - Relative -> joined to the *containing config file's directory*.
+        """
+        if entry.startswith("~/") or entry == "~":
+            return expand_path(Path(entry), self.home_directory)
+        candidate = Path(entry)
+        if candidate.is_absolute():
+            return candidate
+        return config_path.parent / candidate
+
+    # --- URL-pulled skills cache (Gap C) ---
+
+    def _discover_cached_url_skills(self) -> SkillsDirsResult:
+        """Scan ``~/.cache/opencode/skills/<hash>/`` for skills pulled from
+        ``cfg.skills.urls`` URLs.
+
+        Per ``packages/core/src/skill/discovery.ts:107`` the layout is
+        ``<cache>/skills/<Bun.hash(base-url)>/<skill-name>/SKILL.md``. Each
+        ``<hash>`` directory is structurally identical to a normal skills dir
+        root, so we list one level beneath ``skills/`` and feed each match
+        through ``_scan_skills_dir``.
+        """
+        cache_skills = self._cache_dir() / "skills"
+        result: SkillsDirsResult = {}
+        try:
+            if not cache_skills.is_dir():
+                return result
+            hash_dirs = sorted(cache_skills.iterdir())
+        except (PermissionError, OSError):
+            return result
+        for hash_dir in hash_dirs:
+            if not hash_dir.is_dir():
+                continue
+            self._record_skills_at(result, hash_dir)
         return result

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -142,15 +142,26 @@ class OpenCodeDiscoverer(AgentDiscoverer):
     # --- public (override AgentDiscoverer abstracts) ---
 
     def client_exists(self) -> str | None:
-        """Detect an opencode install at any of the known global config dirs.
+        """Detect an opencode install at any known global config dir or the
+        ``$OPENCODE_CONFIG`` file.
 
         Walks every candidate in :meth:`_global_config_dirs` (XDG override,
         ``$OPENCODE_CONFIG_DIR``, ``~/.config/opencode``, ``~/.opencode``) and
         returns the first one that exists. A user with ``$XDG_CONFIG_HOME``
         relocating their config out of ``~/.config`` would otherwise read as
         "not installed" and skip the whole discoverer.
+
+        The ``$OPENCODE_CONFIG`` file (own-home scans only, via
+        :meth:`_opencode_config_env_path`) is checked last: a user who relocates
+        their entire config to a file outside any standard dir would otherwise
+        read as "not installed", so ``discover`` would bail before
+        :meth:`_discover_env_override_mcp_servers` could surface it.
         """
-        for path in self._global_config_dirs():
+        candidates = list(self._global_config_dirs())
+        env_config = self._opencode_config_env_path()
+        if env_config is not None:
+            candidates.append(env_config)
+        for path in candidates:
             try:
                 if path.exists():
                     return path.as_posix()

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -68,8 +68,14 @@ class OpenCodeDiscoverer(AgentDiscoverer):
       These are scanned even when Claude Code itself is not installed (an
       opencode-only user may still have authored skills under one of these
       directories — opencode will load them, so the scanner must see them).
-      Cross-discoverer overlap when Claude Code *is* also installed is harmless:
-      the pipeline keys results by absolute path and dedupes.
+      Cross-discoverer overlap when Claude Code *is* also installed is expected,
+      not deduped away. The pipeline dedupes only *within* one agent: it keys
+      ``ClientToInspect`` by ``(name, username)`` and unions each one's
+      path-keyed ``skills_dirs`` (see ``pipelines.discover_clients_to_inspect``).
+      ``opencode`` and ``claude code`` are distinct names, so each reports
+      ``~/.claude/skills`` under its own name and it is inspected/attributed
+      twice. That is correct rather than redundant — both agents really do load
+      those skills, so each should be labeled with them.
 
     * Second global dir — opencode's own ``ConfigPaths.directories`` also walks
       ``~/.opencode`` (``packages/opencode/src/config/paths.ts``), so that

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -181,15 +181,6 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         """The XDG-style default global config dir, ignoring ``OPENCODE_CONFIG_DIR``."""
         return expand_path(Path(self._install_path), self.home_directory)
 
-    def _global_config_dir(self) -> Path:
-        """The single global config dir reported as the install path.
-
-        Kept as the canonical install path for ``client_exists``; the discovery
-        sweeps consult :meth:`_global_config_dirs` instead so they cover the
-        ``OPENCODE_CONFIG_DIR`` override too.
-        """
-        return self._default_global_config_dir()
-
     def _xdg_env_dir(self, env_var: str) -> Path | None:
         """Return ``<env>/opencode`` if ``env_var`` is set on an own-home scan.
 
@@ -532,6 +523,10 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             try:
                 if not cache_skills.is_dir():
                     continue
+                # Sort for deterministic ordering in tests/output; opencode's
+                # runtime doesn't impose any order on the bun-hash directories
+                # (each maps to a distinct base URL via Bun.hash, so iteration
+                # order is FS-dependent).
                 hash_dirs = sorted(cache_skills.iterdir())
             except (PermissionError, OSError):
                 continue

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -298,6 +298,70 @@ class PluginMCPConfigFile(MCPConfig):
         self.servers = servers
 
 
+class OpenCodeConfigFile(MCPConfig):
+    """opencode's ``opencode.json`` ``mcp`` block: ``{"mcp": {name: {type:"local"|"remote", ...}}}``.
+
+    Translates opencode's per-entry shape into the canonical
+    ``StdioServer`` / ``RemoteServer`` types via a ``before`` model validator,
+    which lets this model slot into ``_parse_mcp_file``'s format union like the
+    other file-format models. Per-entry rules:
+
+    * ``type: "local"`` -> ``StdioServer`` (``command`` is a single array combining
+      executable + args; ``environment`` maps onto ``env``).
+    * ``type: "remote"`` -> ``RemoteServer`` (``url`` matches; ``type`` is folded
+      onto ``"http"`` since opencode does not distinguish sse vs streamable-http).
+    * Entries whose ``enabled`` field is exactly ``False`` are dropped before
+      typed validation runs — opencode treats unset/``true`` as enabled.
+    """
+
+    model_config = ConfigDict()
+    servers: dict[str, StdioServer | RemoteServer]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _extract_mcp_block(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            raise ValueError("opencode config must be a JSON object")
+        mcp = data.get("mcp")
+        if not isinstance(mcp, dict) or not mcp:
+            raise ValueError("opencode config has no non-empty 'mcp' block")
+        servers: dict[str, dict[str, Any]] = {}
+        for name, entry in mcp.items():
+            if not isinstance(entry, dict):
+                raise ValueError(f"opencode mcp entry {name!r} must be an object")
+            if entry.get("enabled") is False:
+                continue
+            entry_type = entry.get("type")
+            if entry_type == "local":
+                command = entry.get("command")
+                if not isinstance(command, list) or not command or not all(isinstance(c, str) for c in command):
+                    raise ValueError(f"opencode mcp entry {name!r} 'command' must be a non-empty string array")
+                servers[name] = {
+                    "command": command[0],
+                    "args": list(command[1:]),
+                    "env": entry.get("environment"),
+                    "type": "stdio",
+                }
+            elif entry_type == "remote":
+                url = entry.get("url")
+                if not isinstance(url, str) or not url:
+                    raise ValueError(f"opencode mcp entry {name!r} 'url' must be a non-empty string")
+                servers[name] = {
+                    "url": url,
+                    "type": "http",
+                    "headers": entry.get("headers") or {},
+                }
+            else:
+                raise ValueError(f"opencode mcp entry {name!r} has unknown type {entry_type!r}")
+        return {"servers": servers}
+
+    def get_servers(self) -> dict[str, StdioServer | RemoteServer]:
+        return self.servers
+
+    def set_servers(self, servers: dict[str, StdioServer | RemoteServer]) -> None:
+        self.servers = servers
+
+
 class UnknownMCPConfig(MCPConfig):
     """
     Represents an MCP configuration the scanner cannot interpret.

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -323,8 +323,8 @@ class OpenCodeConfigFile(MCPConfig):
         if not isinstance(data, dict):
             raise ValueError("opencode config must be a JSON object")
         mcp = data.get("mcp")
-        if not isinstance(mcp, dict) or not mcp:
-            raise ValueError("opencode config has no non-empty 'mcp' block")
+        if not isinstance(mcp, dict):
+            raise ValueError("opencode config has no 'mcp' block")
         servers: dict[str, dict[str, Any]] = {}
         for name, entry in mcp.items():
             if not isinstance(entry, dict):

--- a/src/agent_scan/models.py
+++ b/src/agent_scan/models.py
@@ -352,7 +352,21 @@ class OpenCodeConfigFile(MCPConfig):
                     "headers": entry.get("headers") or {},
                 }
             else:
-                raise ValueError(f"opencode mcp entry {name!r} has unknown type {entry_type!r}")
+                # Unknown ``type`` (e.g. a transport added in a future opencode
+                # release). Skip the single entry rather than sinking the whole
+                # file: dropping parseable siblings on the floor would silently
+                # hide every other MCP server in the same config. The warning
+                # is the audit trail — operators who see it can file a ticket to
+                # add the new transport. Malformed *known* entries (e.g.
+                # ``local`` with no ``command``) still raise above; the
+                # tolerance applies only to entirely unrecognized types.
+                logger.warning(
+                    "opencode mcp entry %r has unrecognized type %r; skipping entry "
+                    "(file an issue if opencode added a new transport)",
+                    name,
+                    entry_type,
+                )
+                continue
         return {"servers": servers}
 
     def get_servers(self) -> dict[str, StdioServer | RemoteServer]:

--- a/src/agent_scan/well_known_clients.py
+++ b/src/agent_scan/well_known_clients.py
@@ -84,14 +84,8 @@ MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
     CandidateClient(
         name="opencode",
         client_exists_paths=["~/.config/opencode"],
-        mcp_config_paths=[
-            "~/.config/opencode/opencode.json",
-            "~/.config/opencode/opencode.jsonc",
-        ],
-        skills_dir_paths=[
-            "~/.config/opencode/skills",
-            ".opencode/skills",
-        ],
+        mcp_config_paths=[],
+        skills_dir_paths=[],
     ),
     CandidateClient(
         name="antigravity",
@@ -180,14 +174,8 @@ LINUX_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
     CandidateClient(
         name="opencode",
         client_exists_paths=["~/.config/opencode"],
-        mcp_config_paths=[
-            "~/.config/opencode/opencode.json",
-            "~/.config/opencode/opencode.jsonc",
-        ],
-        skills_dir_paths=[
-            "~/.config/opencode/skills",
-            ".opencode/skills",
-        ],
+        mcp_config_paths=[],
+        skills_dir_paths=[],
     ),
     CandidateClient(
         name="antigravity",
@@ -283,14 +271,8 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
     CandidateClient(
         name="opencode",
         client_exists_paths=["~/.config/opencode"],
-        mcp_config_paths=[
-            "~/.config/opencode/opencode.json",
-            "~/.config/opencode/opencode.jsonc",
-        ],
-        skills_dir_paths=[
-            "~/.config/opencode/skills",
-            ".opencode/skills",
-        ],
+        mcp_config_paths=[],
+        skills_dir_paths=[],
     ),
     CandidateClient(
         name="antigravity",

--- a/src/agent_scan/well_known_clients.py
+++ b/src/agent_scan/well_known_clients.py
@@ -84,8 +84,14 @@ MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
     CandidateClient(
         name="opencode",
         client_exists_paths=["~/.config/opencode"],
-        mcp_config_paths=[],
-        skills_dir_paths=[],
+        mcp_config_paths=[
+            "~/.config/opencode/opencode.json",
+            "~/.config/opencode/opencode.jsonc",
+        ],
+        skills_dir_paths=[
+            "~/.config/opencode/skills",
+            ".opencode/skills",
+        ],
     ),
     CandidateClient(
         name="antigravity",
@@ -174,8 +180,14 @@ LINUX_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
     CandidateClient(
         name="opencode",
         client_exists_paths=["~/.config/opencode"],
-        mcp_config_paths=[],
-        skills_dir_paths=[],
+        mcp_config_paths=[
+            "~/.config/opencode/opencode.json",
+            "~/.config/opencode/opencode.jsonc",
+        ],
+        skills_dir_paths=[
+            "~/.config/opencode/skills",
+            ".opencode/skills",
+        ],
     ),
     CandidateClient(
         name="antigravity",
@@ -271,8 +283,14 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
     CandidateClient(
         name="opencode",
         client_exists_paths=["~/.config/opencode"],
-        mcp_config_paths=[],
-        skills_dir_paths=[],
+        mcp_config_paths=[
+            "~/.config/opencode/opencode.json",
+            "~/.config/opencode/opencode.jsonc",
+        ],
+        skills_dir_paths=[
+            "~/.config/opencode/skills",
+            ".opencode/skills",
+        ],
     ),
     CandidateClient(
         name="antigravity",

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7809,6 +7809,45 @@ def test_opencode_discoverer_project_folders_empty_on_schema_drift(tmp_path):
     assert OpenCodeDiscoverer(tmp_path)._discover_project_folders() == []
 
 
+def test_opencode_discoverer_project_folders_skips_fifo_db_without_hanging(tmp_path):
+    """A non-regular file at the ``opencode.db`` path — e.g. a FIFO planted in a
+    hostile home under ``--scan-all-users`` — must be skipped via the
+    ``is_file()`` guard, never handed to ``sqlite3.connect``. Opening a FIFO
+    blocks on open()/first-read until a writer appears, which would hang the
+    whole scan. Runs in a worker thread with a join timeout so a regression
+    (the guard reverting to ``exists()``) surfaces as a fast failure rather than
+    a hung suite."""
+    import os
+    import threading
+
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("os.mkfifo not available on this platform")
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    db_path.parent.mkdir(parents=True)
+    os.mkfifo(db_path)
+
+    result: list = []
+    error: list = []
+
+    def run():
+        try:
+            result.append(OpenCodeDiscoverer(tmp_path)._discover_project_folders())
+        except BaseException as e:  # pragma: no cover - only on regression
+            error.append(e)
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive(), "discoverer hung opening a FIFO opencode.db (missing is_file guard)"
+    assert not error, f"discoverer raised on FIFO db: {error}"
+    assert result[0] == []
+
+
 def test_opencode_discoverer_discovers_project_opencode_json(tmp_path):
     """A project-root ``opencode.json`` is picked up when listed in the SQLite db."""
     from agent_scan.agents import OpenCodeDiscoverer

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7879,6 +7879,160 @@ def test_opencode_discoverer_enumerates_uncheckpointed_wal_projects(tmp_path):
     assert {f.as_posix() for f in folders} == {"/repo/checkpointed", "/repo/newest-in-wal"}
 
 
+def test_opencode_discoverer_enumerates_projects_from_channel_named_db(tmp_path):
+    """opencode names its db ``opencode-<channel>.db`` for any install channel
+    outside ``latest``/``beta``/``prod`` (e.g. a ``local`` dev build). The
+    discoverer globs ``opencode*.db`` so those projects are not missed."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode-local.db"
+    _seed_opencode_db(db_path, ["/Users/alice/local-repo"])
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    assert {f.as_posix() for f in folders} == {"/Users/alice/local-repo"}
+
+
+def test_opencode_discoverer_unions_projects_across_multiple_dbs(tmp_path):
+    """A user who ran several install channels has projects spread across
+    ``opencode.db`` and ``opencode-<channel>.db``; the glob unions them."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    data = tmp_path / ".local" / "share" / "opencode"
+    _seed_opencode_db(data / "opencode.db", ["/repo/a"])
+    _seed_opencode_db(data / "opencode-dev.db", ["/repo/b"])
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    assert {f.as_posix() for f in folders} == {"/repo/a", "/repo/b"}
+
+
+def test_opencode_discoverer_dedupes_worktrees_across_dbs(tmp_path):
+    """A worktree present in more than one db is returned exactly once."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    data = tmp_path / ".local" / "share" / "opencode"
+    _seed_opencode_db(data / "opencode.db", ["/repo/shared"])
+    _seed_opencode_db(data / "opencode-local.db", ["/repo/shared", "/repo/extra"])
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    assert {f.as_posix() for f in folders} == {"/repo/shared", "/repo/extra"}
+    assert len(folders) == 2
+
+
+def test_opencode_discoverer_reads_db_from_opencode_db_env_absolute(tmp_path, monkeypatch):
+    """``$OPENCODE_DB`` may relocate the db to an arbitrary absolute path; it is
+    honored on own-home scans."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / "custom" / "projects.db"
+    _seed_opencode_db(db_path, ["/repo/env-abs"])
+
+    monkeypatch.setenv("OPENCODE_DB", str(db_path))
+    _force_home(monkeypatch, tmp_path)
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    assert {f.as_posix() for f in folders} == {"/repo/env-abs"}
+
+
+def test_opencode_discoverer_reads_db_from_opencode_db_env_relative(tmp_path, monkeypatch):
+    """A relative ``$OPENCODE_DB`` is joined to the data dir (as opencode does).
+    The filename here deliberately does NOT match ``opencode*.db``, so it can
+    only be found via the relative-env resolution."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / ".local" / "share" / "opencode" / "myname.db"
+    _seed_opencode_db(db_path, ["/repo/env-rel"])
+
+    monkeypatch.setenv("OPENCODE_DB", "myname.db")
+    _force_home(monkeypatch, tmp_path)
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    assert {f.as_posix() for f in folders} == {"/repo/env-rel"}
+
+
+def test_opencode_discoverer_ignores_opencode_db_env_when_not_own_home(tmp_path, monkeypatch):
+    """``$OPENCODE_DB`` reflects the scanning process's env; under
+    ``--scan-all-users`` it must not be applied to another user's home."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / "custom" / "projects.db"
+    _seed_opencode_db(db_path, ["/repo/should-not-appear"])
+
+    monkeypatch.setenv("OPENCODE_DB", str(db_path))
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    _force_home(monkeypatch, other_home)
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    assert "/repo/should-not-appear" not in {f.as_posix() for f in folders}
+
+
+def test_opencode_discoverer_opencode_db_memory_is_noop(tmp_path, monkeypatch):
+    """``$OPENCODE_DB=:memory:`` has no backing file, so it is skipped (never
+    handed to ``as_uri()``/``is_file()``); the default ``opencode.db`` glob still
+    works."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, ["/repo/default"])
+
+    monkeypatch.setenv("OPENCODE_DB", ":memory:")
+    _force_home(monkeypatch, tmp_path)
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    assert {f.as_posix() for f in folders} == {"/repo/default"}
+
+
+def test_opencode_discoverer_skips_channel_named_fifo_db_without_hanging(tmp_path):
+    """The ``opencode*.db`` glob also matches a hostile channel-named FIFO (e.g.
+    ``opencode-x.db``). The per-candidate ``is_file()`` guard must reject it
+    before ``sqlite3.connect`` so the scan never hangs on a FIFO open(). Runs in
+    a worker thread with a join timeout so a regression surfaces as a fast
+    failure rather than a hung suite."""
+    import os
+    import threading
+
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("os.mkfifo not available on this platform")
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_dir = tmp_path / ".local" / "share" / "opencode"
+    db_dir.mkdir(parents=True)
+    os.mkfifo(db_dir / "opencode-x.db")
+
+    result: list = []
+    error: list = []
+
+    def run():
+        try:
+            result.append(OpenCodeDiscoverer(tmp_path)._discover_project_folders())
+        except BaseException as e:  # pragma: no cover - only on regression
+            error.append(e)
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive(), "discoverer hung opening a channel-named FIFO db (missing is_file guard)"
+    assert not error, f"discoverer raised on FIFO db: {error}"
+    assert result[0] == []
+
+
 def test_opencode_discoverer_discovers_project_opencode_json(tmp_path):
     """A project-root ``opencode.json`` is picked up when listed in the SQLite db."""
     from agent_scan.agents import OpenCodeDiscoverer

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -8250,8 +8250,9 @@ def test_opencode_discoverer_scans_skills_paths_with_absolute_path(tmp_path):
 
 
 def test_opencode_discoverer_scans_skills_paths_relative_to_config_dir(tmp_path):
-    """Relative ``skills.paths`` resolve against the containing config file's directory,
-    matching opencode's loader."""
+    """Relative ``skills.paths`` resolve against an opened-project worktree
+    (opencode's instance directory). With a single opened project whose config
+    declares the relative entry, that worktree is the resolution base."""
     from agent_scan.agents import OpenCodeDiscoverer
 
     _opencode_install(tmp_path)
@@ -8292,6 +8293,53 @@ def test_opencode_discoverer_skips_skills_paths_when_field_missing(tmp_path):
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
     assert skills_dirs == {}
+
+
+def test_opencode_discoverer_scans_skills_paths_relative_against_each_worktree(tmp_path):
+    """opencode resolves a relative ``skills.paths`` entry against the instance/
+    project directory (cwd within the worktree), regardless of which merged
+    config declared it (packages/opencode/src/skill/index.ts:211-214). A relative
+    entry in the *global* config therefore loads ``<project>/entry`` for whichever
+    project is open — so the scanner must resolve it against every opened-project
+    worktree, NOT against ``~/.config/opencode``."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text('{"skills": {"paths": ["./team-skills"]}}')
+    p = tmp_path / "proj-p"
+    q = tmp_path / "proj-q"
+    for proj, name in ((p, "p-skill"), (q, "q-skill")):
+        sd = proj / "team-skills" / name
+        sd.mkdir(parents=True)
+        (sd / "SKILL.md").write_text(f"---\nname: {name}\ndescription: x\n---\nBody\n")
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, [p.as_posix(), q.as_posix()])
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    assert any(k.endswith("/proj-p/team-skills") for k in skills_dirs)
+    assert any(k.endswith("/proj-q/team-skills") for k in skills_dirs)
+    # Must NOT resolve against the global config dir (opencode never loads it there).
+    assert not any(k.endswith("/.config/opencode/team-skills") for k in skills_dirs)
+
+
+def test_opencode_discoverer_skills_paths_relative_records_nothing_without_projects(tmp_path):
+    """With no opened projects there is no instance directory to anchor a relative
+    ``skills.paths`` entry against, so it resolves to nothing — matching that
+    opencode never loads it from the config dir. A literal ``team-skills`` under
+    the global config dir must NOT be picked up."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text('{"skills": {"paths": ["./team-skills"]}}')
+    sd = install / "team-skills" / "should-not-load"
+    sd.mkdir(parents=True)
+    (sd / "SKILL.md").write_text("---\nname: should-not-load\ndescription: x\n---\nBody\n")
+    # No opencode.db -> no opened-project worktrees to anchor against.
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    assert not any("team-skills" in k for k in skills_dirs)
 
 
 # --- OpenCodeDiscoverer: URL-pulled skill cache (~/.cache/opencode/skills/) ---

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7398,6 +7398,19 @@ def _opencode_install(tmp_path):
     return install
 
 
+def _force_home(monkeypatch, home):
+    """Pin both ``$HOME`` and ``Path.home()`` so ``_scans_own_home`` is driven
+    deterministically. ``$HOME`` alone is normally enough on POSIX, but the
+    base class also consults ``pwd.getpwuid(os.getuid()).pw_dir`` as a second
+    candidate; pinning ``Path.home`` directly removes any chance of a
+    pw_dir-vs-$HOME divergence flaking the own-home gating tests.
+    """
+    from pathlib import Path
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+
 # --- OpenCodeDiscoverer: client_exists ---
 
 
@@ -7620,7 +7633,7 @@ def test_opencode_discoverer_reads_opencode_config_env(tmp_path, monkeypatch):
     override_path.write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
 
     monkeypatch.setenv("OPENCODE_CONFIG", str(override_path))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -7643,7 +7656,7 @@ def test_opencode_discoverer_ignores_env_var_when_not_own_home(tmp_path, monkeyp
     # Force ``_scans_own_home`` to False by pointing ``$HOME`` elsewhere.
     other_home = tmp_path / "other-home"
     other_home.mkdir()
-    monkeypatch.setenv("HOME", str(other_home))
+    _force_home(monkeypatch, other_home)
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -7994,7 +8007,7 @@ def test_opencode_discoverer_scans_opencode_config_dir_in_addition_to_default(tm
     )
 
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8014,7 +8027,7 @@ def test_opencode_discoverer_scans_opencode_config_dir_skills(tmp_path, monkeypa
     (sk / "SKILL.md").write_text("---\nname: alt-skill\ndescription: a\n---\nBody\n")
 
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8039,7 +8052,7 @@ def test_opencode_discoverer_ignores_opencode_config_dir_when_not_own_home(tmp_p
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
     other_home = tmp_path / "other-home"
     other_home.mkdir()
-    monkeypatch.setenv("HOME", str(other_home))
+    _force_home(monkeypatch, other_home)
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8245,7 +8258,7 @@ def test_opencode_discoverer_detects_install_via_xdg_config_home(tmp_path, monke
     (xdg_cfg / "opencode").mkdir(parents=True)
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     result = OpenCodeDiscoverer(tmp_path).client_exists()
 
@@ -8266,7 +8279,7 @@ def test_opencode_discoverer_scans_xdg_config_home_mcp(tmp_path, monkeypatch):
     )
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8288,7 +8301,7 @@ def test_opencode_discoverer_scans_xdg_config_home_skills(tmp_path, monkeypatch)
     (sk / "SKILL.md").write_text("---\nname: xdg-skill\ndescription: x\n---\nBody\n")
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8306,7 +8319,7 @@ def test_opencode_discoverer_reads_project_db_at_xdg_data_home(tmp_path, monkeyp
     _seed_opencode_db(db_path, ["/Users/alice/xdg-repo"])
 
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
 
@@ -8324,7 +8337,7 @@ def test_opencode_discoverer_scans_xdg_cache_home_url_skills(tmp_path, monkeypat
     (sk / "SKILL.md").write_text("---\nname: remote-skill\ndescription: x\n---\nBody\n")
 
     monkeypatch.setenv("XDG_CACHE_HOME", str(xdg_cache))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8347,7 +8360,7 @@ def test_opencode_discoverer_ignores_xdg_when_not_own_home(tmp_path, monkeypatch
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
     other_home = tmp_path / "other-home"
     other_home.mkdir()
-    monkeypatch.setenv("HOME", str(other_home))
+    _force_home(monkeypatch, other_home)
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8371,7 +8384,7 @@ def test_opencode_discoverer_xdg_is_additive_default_still_scanned(tmp_path, mon
     )
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _force_home(monkeypatch, tmp_path)
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7620,7 +7620,7 @@ def test_opencode_discoverer_reads_opencode_config_env(tmp_path, monkeypatch):
     override_path.write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
 
     monkeypatch.setenv("OPENCODE_CONFIG", str(override_path))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -7640,10 +7640,10 @@ def test_opencode_discoverer_ignores_env_var_when_not_own_home(tmp_path, monkeyp
     override_path.write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
 
     monkeypatch.setenv("OPENCODE_CONFIG", str(override_path))
-    # Force ``_scans_own_home`` to False by pointing Path.home() elsewhere.
+    # Force ``_scans_own_home`` to False by pointing ``$HOME`` elsewhere.
     other_home = tmp_path / "other-home"
     other_home.mkdir()
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: other_home))
+    monkeypatch.setenv("HOME", str(other_home))
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -7994,7 +7994,7 @@ def test_opencode_discoverer_scans_opencode_config_dir_in_addition_to_default(tm
     )
 
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8014,7 +8014,7 @@ def test_opencode_discoverer_scans_opencode_config_dir_skills(tmp_path, monkeypa
     (sk / "SKILL.md").write_text("---\nname: alt-skill\ndescription: a\n---\nBody\n")
 
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8039,7 +8039,7 @@ def test_opencode_discoverer_ignores_opencode_config_dir_when_not_own_home(tmp_p
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
     other_home = tmp_path / "other-home"
     other_home.mkdir()
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: other_home))
+    monkeypatch.setenv("HOME", str(other_home))
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8245,7 +8245,7 @@ def test_opencode_discoverer_detects_install_via_xdg_config_home(tmp_path, monke
     (xdg_cfg / "opencode").mkdir(parents=True)
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     result = OpenCodeDiscoverer(tmp_path).client_exists()
 
@@ -8266,7 +8266,7 @@ def test_opencode_discoverer_scans_xdg_config_home_mcp(tmp_path, monkeypatch):
     )
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8288,7 +8288,7 @@ def test_opencode_discoverer_scans_xdg_config_home_skills(tmp_path, monkeypatch)
     (sk / "SKILL.md").write_text("---\nname: xdg-skill\ndescription: x\n---\nBody\n")
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8306,7 +8306,7 @@ def test_opencode_discoverer_reads_project_db_at_xdg_data_home(tmp_path, monkeyp
     _seed_opencode_db(db_path, ["/Users/alice/xdg-repo"])
 
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
 
@@ -8324,7 +8324,7 @@ def test_opencode_discoverer_scans_xdg_cache_home_url_skills(tmp_path, monkeypat
     (sk / "SKILL.md").write_text("---\nname: remote-skill\ndescription: x\n---\nBody\n")
 
     monkeypatch.setenv("XDG_CACHE_HOME", str(xdg_cache))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8347,7 +8347,7 @@ def test_opencode_discoverer_ignores_xdg_when_not_own_home(tmp_path, monkeypatch
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
     other_home = tmp_path / "other-home"
     other_home.mkdir()
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: other_home))
+    monkeypatch.setenv("HOME", str(other_home))
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8371,7 +8371,7 @@ def test_opencode_discoverer_xdg_is_additive_default_still_scanned(tmp_path, mon
     )
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -8166,3 +8166,155 @@ def test_opencode_discoverer_scans_multiple_cached_hash_dirs(tmp_path):
 
     matching = [k for k in skills_dirs if "/.cache/opencode/skills/" in k]
     assert len(matching) == 2
+
+
+# --- OpenCodeDiscoverer: XDG_CONFIG_HOME / XDG_DATA_HOME / XDG_CACHE_HOME ---
+
+
+def test_opencode_discoverer_detects_install_via_xdg_config_home(tmp_path, monkeypatch):
+    """When ``$XDG_CONFIG_HOME`` relocates opencode, ``client_exists`` finds it
+    even if ``~/.config/opencode`` is absent. opencode uses ``xdg-basedir`` for
+    every Global.Path location (packages/core/src/global.ts)."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    # No ``~/.config/opencode`` on disk — only an XDG-relocated install.
+    xdg_cfg = tmp_path / "xdg-config"
+    (xdg_cfg / "opencode").mkdir(parents=True)
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    result = OpenCodeDiscoverer(tmp_path).client_exists()
+
+    assert result is not None
+    assert result.endswith("/xdg-config/opencode")
+
+
+def test_opencode_discoverer_scans_xdg_config_home_mcp(tmp_path, monkeypatch):
+    """``$XDG_CONFIG_HOME/opencode/opencode.json`` is scanned for mcp servers."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    xdg_cfg = tmp_path / "xdg-config"
+    install = xdg_cfg / "opencode"
+    install.mkdir(parents=True)
+    (install / "opencode.json").write_text(
+        '{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    matching = [k for k in mcp_configs if k.endswith("/xdg-config/opencode/opencode.json")]
+    assert len(matching) == 1
+    entries = mcp_configs[matching[0]]
+    assert isinstance(entries, list)
+    assert entries[0][0] == "xdg-srv"
+
+
+def test_opencode_discoverer_scans_xdg_config_home_skills(tmp_path, monkeypatch):
+    """``$XDG_CONFIG_HOME/opencode/skills`` is scanned for skills."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    xdg_cfg = tmp_path / "xdg-config"
+    sk = xdg_cfg / "opencode" / "skills" / "xdg-skill"
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text("---\nname: xdg-skill\ndescription: x\n---\nBody\n")
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/xdg-config/opencode/skills")]
+    assert len(matching) == 1
+
+
+def test_opencode_discoverer_reads_project_db_at_xdg_data_home(tmp_path, monkeypatch):
+    """``$XDG_DATA_HOME/opencode/opencode.db`` is consulted for project paths."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    xdg_data = tmp_path / "xdg-data"
+    db_path = xdg_data / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, ["/Users/alice/xdg-repo"])
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    assert {f.as_posix() for f in folders} == {"/Users/alice/xdg-repo"}
+
+
+def test_opencode_discoverer_scans_xdg_cache_home_url_skills(tmp_path, monkeypatch):
+    """``$XDG_CACHE_HOME/opencode/skills/<hash>/`` is scanned for URL-pulled skills."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    xdg_cache = tmp_path / "xdg-cache"
+    sk = xdg_cache / "opencode" / "skills" / "deadbeef" / "remote-skill"
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text("---\nname: remote-skill\ndescription: x\n---\nBody\n")
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(xdg_cache))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/xdg-cache/opencode/skills/deadbeef")]
+    assert len(matching) == 1
+
+
+def test_opencode_discoverer_ignores_xdg_when_not_own_home(tmp_path, monkeypatch):
+    """XDG env vars reflect the scanning process's env; on a non-own-home scan
+    they must not be applied to another user's home."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    xdg_cfg = tmp_path / "xdg-config"
+    (xdg_cfg / "opencode").mkdir(parents=True)
+    (xdg_cfg / "opencode" / "opencode.json").write_text(
+        '{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: other_home))
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert all("xdg-config" not in k for k in mcp_configs)
+
+
+def test_opencode_discoverer_xdg_is_additive_default_still_scanned(tmp_path, monkeypatch):
+    """Both XDG-relocated and default ``~/.config/opencode`` configs surface
+    when both exist (additive, not replacement)."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text(
+        '{"mcp": {"def-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+    xdg_cfg = tmp_path / "xdg-config"
+    xdg_install = xdg_cfg / "opencode"
+    xdg_install.mkdir(parents=True)
+    (xdg_install / "opencode.json").write_text(
+        '{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    names = set()
+    for entry in mcp_configs.values():
+        if isinstance(entry, list):
+            for n, _ in entry:
+                names.add(n)
+    assert {"def-srv", "xdg-srv"} <= names

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -8417,3 +8417,104 @@ def test_opencode_discoverer_xdg_is_additive_default_still_scanned(tmp_path, mon
             for n, _ in entry:
                 names.add(n)
     assert {"def-srv", "xdg-srv"} <= names
+
+
+# --- OpenCodeDiscoverer: relative env values must still yield absolute keys ---
+#
+# opencode resolves XDG_*/OPENCODE_CONFIG[_DIR] via xdg-basedir/Node, which do
+# NOT reject a relative value (XDG spec says compliant apps ignore them, but the
+# package doesn't). The default dirs are absolute (``expand_path``) and the
+# SQLite db path is guarded with ``.absolute()``; the other env-derived paths
+# must match so the "downstream-keyed by absolute path" dedup/attribution
+# invariant the discoverer documents holds regardless of how the env is spelled.
+
+
+def test_opencode_discoverer_relative_xdg_config_home_yields_absolute_keys(tmp_path, monkeypatch):
+    """A relative ``$XDG_CONFIG_HOME`` still produces an absolute config key."""
+    from pathlib import Path
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    install = tmp_path / "rel-xdg-config" / "opencode"
+    install.mkdir(parents=True)
+    (install / "opencode.json").write_text('{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}')
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", "rel-xdg-config")
+    _force_home(monkeypatch, tmp_path)
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    keys = [k for k in mcp_configs if k.endswith("/rel-xdg-config/opencode/opencode.json")]
+    assert len(keys) == 1
+    assert Path(keys[0]).is_absolute()
+    assert keys[0] == (install / "opencode.json").as_posix()
+
+
+def test_opencode_discoverer_relative_opencode_config_dir_yields_absolute_keys(tmp_path, monkeypatch):
+    """A relative ``$OPENCODE_CONFIG_DIR`` still produces an absolute config key."""
+    from pathlib import Path
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    override = tmp_path / "rel-config-dir"
+    override.mkdir()
+    (override / "opencode.json").write_text('{"mcp": {"alt-srv": {"type": "local", "command": ["echo"]}}}')
+
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", "rel-config-dir")
+    _force_home(monkeypatch, tmp_path)
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    keys = [k for k in mcp_configs if k.endswith("/rel-config-dir/opencode.json")]
+    assert len(keys) == 1
+    assert Path(keys[0]).is_absolute()
+
+
+def test_opencode_discoverer_relative_xdg_cache_home_yields_absolute_skill_keys(tmp_path, monkeypatch):
+    """A relative ``$XDG_CACHE_HOME`` still produces an absolute URL-skills key."""
+    from pathlib import Path
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    sk = tmp_path / "rel-xdg-cache" / "opencode" / "skills" / "deadbeef" / "remote-skill"
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text("---\nname: remote-skill\ndescription: x\n---\nBody\n")
+
+    monkeypatch.setenv("XDG_CACHE_HOME", "rel-xdg-cache")
+    _force_home(monkeypatch, tmp_path)
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    keys = [k for k in skills_dirs if k.endswith("/rel-xdg-cache/opencode/skills/deadbeef")]
+    assert len(keys) == 1
+    assert Path(keys[0]).is_absolute()
+
+
+def test_opencode_discoverer_relative_opencode_config_file_yields_absolute_key(tmp_path, monkeypatch):
+    """A relative ``$OPENCODE_CONFIG`` file yields an absolute ``client_exists``
+    path and an absolute env-override config key (not a relative one)."""
+    from pathlib import Path
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "rel-custom.json").write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
+
+    monkeypatch.setenv("OPENCODE_CONFIG", "rel-custom.json")
+    _force_home(monkeypatch, tmp_path)
+
+    discoverer = OpenCodeDiscoverer(tmp_path)
+    client_path = discoverer.client_exists()
+    mcp_configs = discoverer.discover_mcp_servers()
+
+    assert client_path is not None
+    assert Path(client_path).is_absolute()
+    env_keys = [k for k in mcp_configs if k.endswith("/rel-custom.json")]
+    assert len(env_keys) == 1
+    assert Path(env_keys[0]).is_absolute()

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7511,8 +7511,7 @@ def test_opencode_discoverer_parses_jsonc(tmp_path):
 
     install = _opencode_install(tmp_path)
     (install / "opencode.jsonc").write_text(
-        "// global opencode config\n"
-        '{"mcp": {"srv": {"type": "local", "command": ["echo"],}}}\n'
+        '// global opencode config\n{"mcp": {"srv": {"type": "local", "command": ["echo"],}}}\n'
     )
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
@@ -7587,10 +7586,9 @@ def test_opencode_discoverer_unknown_type_skips_entry_not_whole_file(tmp_path, c
     assert isinstance(entry, list)
     names = {n for n, _ in entry}
     assert names == {"playwright"}
-    assert any(
-        "future-srv" in record.message and "sse" in record.message
-        for record in caplog.records
-    ), "expected a warning naming the skipped entry and its unrecognized type"
+    assert any("future-srv" in record.message and "sse" in record.message for record in caplog.records), (
+        "expected a warning naming the skipped entry and its unrecognized type"
+    )
 
 
 def test_opencode_discoverer_malformed_known_type_still_raises(tmp_path):
@@ -7601,9 +7599,7 @@ def test_opencode_discoverer_malformed_known_type_still_raises(tmp_path):
     from agent_scan.agents import OpenCodeDiscoverer
 
     install = _opencode_install(tmp_path)
-    (install / "opencode.json").write_text(
-        '{"mcp": {"broken": {"type": "local", "command": []}}}'
-    )
+    (install / "opencode.json").write_text('{"mcp": {"broken": {"type": "local", "command": []}}}')
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -7766,9 +7762,7 @@ def test_opencode_discoverer_discovers_project_opencode_json(tmp_path):
     _opencode_install(tmp_path)
     project = tmp_path / "repo"
     project.mkdir()
-    (project / "opencode.json").write_text(
-        '{"mcp": {"proj-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (project / "opencode.json").write_text('{"mcp": {"proj-srv": {"type": "local", "command": ["echo"]}}}')
     db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
     _seed_opencode_db(db_path, [project.as_posix()])
 
@@ -7812,9 +7806,7 @@ def test_opencode_discoverer_discovers_managed_mcp_servers(tmp_path, monkeypatch
     _opencode_install(tmp_path)
     managed = tmp_path / "managed-opencode"
     managed.mkdir()
-    (managed / "opencode.json").write_text(
-        '{"mcp": {"mgr-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (managed / "opencode.json").write_text('{"mcp": {"mgr-srv": {"type": "local", "command": ["echo"]}}}')
     monkeypatch.setattr(OpenCodeDiscoverer, "_managed_config_dir", lambda self: managed)
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
@@ -7828,7 +7820,8 @@ def test_opencode_discoverer_discovers_managed_mcp_servers(tmp_path, monkeypatch
 
 def test_opencode_discoverer_managed_config_dir_per_os(monkeypatch):
     """Confirms per-OS paths for managed config dir."""
-    from agent_scan.agents import OpenCodeDiscoverer, opencode as opencode_module
+    from agent_scan.agents import OpenCodeDiscoverer
+    from agent_scan.agents import opencode as opencode_module
 
     d = OpenCodeDiscoverer(None)
 
@@ -7853,9 +7846,7 @@ def test_opencode_discoverer_discover_assembles_client(tmp_path, monkeypatch):
     # Disable per-OS managed-config probing so the assertion isn't OS-sensitive.
     monkeypatch.setattr(OpenCodeDiscoverer, "_managed_config_dir", lambda self: None)
     install = _opencode_install(tmp_path)
-    (install / "opencode.json").write_text(
-        '{"mcp": {"srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (install / "opencode.json").write_text('{"mcp": {"srv": {"type": "local", "command": ["echo"]}}}')
 
     cti = OpenCodeDiscoverer(tmp_path).discover()
 
@@ -7996,15 +7987,11 @@ def test_opencode_discoverer_scans_opencode_config_dir_in_addition_to_default(tm
 
     install = _opencode_install(tmp_path)
     # Default-dir entry
-    (install / "opencode.json").write_text(
-        '{"mcp": {"def-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (install / "opencode.json").write_text('{"mcp": {"def-srv": {"type": "local", "command": ["echo"]}}}')
     # Override-dir entry
     override_dir = tmp_path / "alt-opencode"
     override_dir.mkdir()
-    (override_dir / "opencode.json").write_text(
-        '{"mcp": {"alt-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (override_dir / "opencode.json").write_text('{"mcp": {"alt-srv": {"type": "local", "command": ["echo"]}}}')
 
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
     _force_home(monkeypatch, tmp_path)
@@ -8045,9 +8032,7 @@ def test_opencode_discoverer_ignores_opencode_config_dir_when_not_own_home(tmp_p
     _opencode_install(tmp_path)
     override_dir = tmp_path / "alt-opencode"
     override_dir.mkdir()
-    (override_dir / "opencode.json").write_text(
-        '{"mcp": {"alt-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (override_dir / "opencode.json").write_text('{"mcp": {"alt-srv": {"type": "local", "command": ["echo"]}}}')
 
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
     other_home = tmp_path / "other-home"
@@ -8090,9 +8075,7 @@ def test_opencode_discoverer_scans_dot_opencode_home_dir_mcp(tmp_path):
     _opencode_install(tmp_path)
     alt = tmp_path / ".opencode"
     alt.mkdir()
-    (alt / "opencode.json").write_text(
-        '{"mcp": {"home-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (alt / "opencode.json").write_text('{"mcp": {"home-srv": {"type": "local", "command": ["echo"]}}}')
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
@@ -8114,9 +8097,7 @@ def test_opencode_discoverer_scans_skills_paths_with_tilde_expansion(tmp_path):
     team_skills = tmp_path / "team-skills" / "team-skill"
     team_skills.mkdir(parents=True)
     (team_skills / "SKILL.md").write_text("---\nname: team-skill\ndescription: y\n---\nBody\n")
-    (install / "opencode.json").write_text(
-        '{"skills": {"paths": ["~/team-skills"]}}'
-    )
+    (install / "opencode.json").write_text('{"skills": {"paths": ["~/team-skills"]}}')
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8136,9 +8117,7 @@ def test_opencode_discoverer_scans_skills_paths_with_absolute_path(tmp_path):
     skill = abs_root / "abs-skill"
     skill.mkdir(parents=True)
     (skill / "SKILL.md").write_text("---\nname: abs-skill\ndescription: a\n---\nBody\n")
-    (install / "opencode.json").write_text(
-        '{"skills": {"paths": ["' + abs_root.as_posix() + '"]}}'
-    )
+    (install / "opencode.json").write_text('{"skills": {"paths": ["' + abs_root.as_posix() + '"]}}')
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8172,9 +8151,7 @@ def test_opencode_discoverer_skips_non_string_skills_paths(tmp_path):
     from agent_scan.agents import OpenCodeDiscoverer
 
     install = _opencode_install(tmp_path)
-    (install / "opencode.json").write_text(
-        '{"skills": {"paths": [123, null, "", true]}}'
-    )
+    (install / "opencode.json").write_text('{"skills": {"paths": [123, null, "", true]}}')
 
     skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
 
@@ -8274,9 +8251,7 @@ def test_opencode_discoverer_scans_xdg_config_home_mcp(tmp_path, monkeypatch):
     xdg_cfg = tmp_path / "xdg-config"
     install = xdg_cfg / "opencode"
     install.mkdir(parents=True)
-    (install / "opencode.json").write_text(
-        '{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (install / "opencode.json").write_text('{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}')
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
     _force_home(monkeypatch, tmp_path)
@@ -8353,9 +8328,7 @@ def test_opencode_discoverer_ignores_xdg_when_not_own_home(tmp_path, monkeypatch
     _opencode_install(tmp_path)
     xdg_cfg = tmp_path / "xdg-config"
     (xdg_cfg / "opencode").mkdir(parents=True)
-    (xdg_cfg / "opencode" / "opencode.json").write_text(
-        '{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (xdg_cfg / "opencode" / "opencode.json").write_text('{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}')
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
     other_home = tmp_path / "other-home"
@@ -8373,15 +8346,11 @@ def test_opencode_discoverer_xdg_is_additive_default_still_scanned(tmp_path, mon
     from agent_scan.agents import OpenCodeDiscoverer
 
     install = _opencode_install(tmp_path)
-    (install / "opencode.json").write_text(
-        '{"mcp": {"def-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (install / "opencode.json").write_text('{"mcp": {"def-srv": {"type": "local", "command": ["echo"]}}}')
     xdg_cfg = tmp_path / "xdg-config"
     xdg_install = xdg_cfg / "opencode"
     xdg_install.mkdir(parents=True)
-    (xdg_install / "opencode.json").write_text(
-        '{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}'
-    )
+    (xdg_install / "opencode.json").write_text('{"mcp": {"xdg-srv": {"type": "local", "command": ["echo"]}}}')
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
     _force_home(monkeypatch, tmp_path)

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7633,8 +7633,8 @@ def test_opencode_discoverer_reads_opencode_config_env(tmp_path, monkeypatch):
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
-    assert str(override_path) in mcp_configs
-    entries = mcp_configs[str(override_path)]
+    assert override_path.as_posix() in mcp_configs
+    entries = mcp_configs[override_path.as_posix()]
     assert isinstance(entries, list)
     assert entries[0][0] == "env-srv"
 
@@ -7656,7 +7656,7 @@ def test_opencode_discoverer_ignores_env_var_when_not_own_home(tmp_path, monkeyp
 
     mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
 
-    assert str(override_path) not in mcp_configs
+    assert override_path.as_posix() not in mcp_configs
 
 
 def test_opencode_discoverer_detects_install_via_opencode_config_env(tmp_path, monkeypatch):
@@ -7693,7 +7693,7 @@ def test_opencode_discoverer_discover_surfaces_env_only_install(tmp_path, monkey
     cti = OpenCodeDiscoverer(tmp_path).discover()
 
     assert cti is not None
-    assert str(override_path) in cti.mcp_configs
+    assert override_path.as_posix() in cti.mcp_configs
 
 
 def test_opencode_discoverer_ignores_opencode_config_env_for_client_exists_when_not_own_home(tmp_path, monkeypatch):

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -1188,6 +1188,7 @@ def test_DISCOVERERS_registers_claude_code_and_vscode_family():
         "antigravity",
         "codex",
         "claude desktop",
+        "opencode",
     }
 
 
@@ -7383,3 +7384,427 @@ def test_find_discoverers_returns_claude_desktop_when_installed(tmp_path, monkey
     found = find_discoverers(tmp_path)
 
     assert any(isinstance(d, claude_desktop_module.ClaudeDesktopDiscoverer) for d in found)
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeDiscoverer
+# ---------------------------------------------------------------------------
+
+
+def _opencode_install(tmp_path):
+    """Create the minimal ``~/.config/opencode`` install marker; returns its path."""
+    install = tmp_path / ".config" / "opencode"
+    install.mkdir(parents=True)
+    return install
+
+
+# --- OpenCodeDiscoverer: client_exists ---
+
+
+def test_opencode_discoverer_detects_installation(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+
+    result = OpenCodeDiscoverer(tmp_path).client_exists()
+
+    assert result is not None
+    assert result.endswith("/.config/opencode")
+
+
+def test_opencode_discoverer_returns_none_when_absent(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    assert OpenCodeDiscoverer(tmp_path).client_exists() is None
+
+
+# --- OpenCodeDiscoverer: discover_mcp_servers (global) ---
+
+
+def test_opencode_discoverer_parses_local_mcp_server(tmp_path):
+    """``type: "local"`` with array ``command`` -> StdioServer; command[0]/[1:] split."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text(
+        '{"mcp": {"playwright": {"type": "local", '
+        '"command": ["npx", "@playwright/mcp@1.59.1", "--browser", "chromium"], '
+        '"environment": {"FOO": "bar"}}}}'
+    )
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    config_path = next(iter(mcp_configs))
+    assert config_path.endswith("/.config/opencode/opencode.json")
+    entries = mcp_configs[config_path]
+    assert isinstance(entries, list)
+    assert len(entries) == 1
+    name, server = entries[0]
+    assert name == "playwright"
+    assert isinstance(server, StdioServer)
+    assert server.command == "npx"
+    assert server.args == ["@playwright/mcp@1.59.1", "--browser", "chromium"]
+    assert server.env == {"FOO": "bar"}
+
+
+def test_opencode_discoverer_parses_remote_mcp_server(tmp_path):
+    """``type: "remote"`` -> RemoteServer with ``type: "http"`` and headers."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text(
+        '{"mcp": {"upstream": {"type": "remote", '
+        '"url": "https://mcp.example.com/mcp", '
+        '"headers": {"Authorization": "Bearer xyz"}}}}'
+    )
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    config_path = next(iter(mcp_configs))
+    entries = mcp_configs[config_path]
+    assert isinstance(entries, list)
+    name, server = entries[0]
+    assert name == "upstream"
+    assert isinstance(server, RemoteServer)
+    assert server.url == "https://mcp.example.com/mcp"
+    assert server.type == "http"
+    assert server.headers == {"Authorization": "Bearer xyz"}
+
+
+def test_opencode_discoverer_skips_disabled_entries(tmp_path):
+    """``enabled: false`` drops the entry before typed validation -- one survivor."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text(
+        '{"mcp": {'
+        '"on": {"type": "local", "command": ["echo", "hi"]}, '
+        '"off": {"type": "local", "command": ["echo", "bye"], "enabled": false}'
+        "}}"
+    )
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    entries = mcp_configs[next(iter(mcp_configs))]
+    assert isinstance(entries, list)
+    names = {n for n, _ in entries}
+    assert names == {"on"}
+
+
+def test_opencode_discoverer_parses_jsonc(tmp_path):
+    """``.jsonc`` siblings of ``.json`` are read; comments and trailing commas tolerated."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.jsonc").write_text(
+        "// global opencode config\n"
+        '{"mcp": {"srv": {"type": "local", "command": ["echo"],}}}\n'
+    )
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert any(k.endswith("opencode.jsonc") for k in mcp_configs)
+    entries = next(iter(mcp_configs.values()))
+    assert isinstance(entries, list) and entries[0][0] == "srv"
+
+
+def test_opencode_discoverer_skips_config_without_mcp_block(tmp_path):
+    """A valid opencode config that only sets ``permission`` / ``theme`` etc. is
+    skipped silently (not reported as malformed)."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text('{"permission": {"edit": "ask"}}')
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert mcp_configs == {}
+
+
+def test_opencode_discoverer_records_could_not_parse_on_invalid_json(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text("{not valid json")
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entry = next(iter(mcp_configs.values()))
+    assert isinstance(entry, CouldNotParseMCPConfig)
+    assert entry.is_failure is True
+
+
+def test_opencode_discoverer_returns_empty_when_global_config_missing(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+
+    assert OpenCodeDiscoverer(tmp_path).discover_mcp_servers() == {}
+
+
+# --- OpenCodeDiscoverer: $OPENCODE_CONFIG env override ---
+
+
+def test_opencode_discoverer_reads_opencode_config_env(tmp_path, monkeypatch):
+    """``$OPENCODE_CONFIG`` adds an explicitly-named extra config source on own-home scans."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    override_path = tmp_path / "custom.json"
+    override_path.write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
+
+    monkeypatch.setenv("OPENCODE_CONFIG", str(override_path))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert str(override_path) in mcp_configs
+    entries = mcp_configs[str(override_path)]
+    assert isinstance(entries, list)
+    assert entries[0][0] == "env-srv"
+
+
+def test_opencode_discoverer_ignores_env_var_when_not_own_home(tmp_path, monkeypatch):
+    """``$OPENCODE_CONFIG`` reflects the scanning process's environment; under
+    ``--scan-all-users`` the scanner can't apply it to another user's home."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    override_path = tmp_path / "custom.json"
+    override_path.write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
+
+    monkeypatch.setenv("OPENCODE_CONFIG", str(override_path))
+    # Force ``_scans_own_home`` to False by pointing Path.home() elsewhere.
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: other_home))
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert str(override_path) not in mcp_configs
+
+
+# --- OpenCodeDiscoverer: discover_skills ---
+
+
+def test_opencode_discoverer_parses_global_skills(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    skills_dir = install / "skills"
+    skills_dir.mkdir()
+    my_skill = skills_dir / "my-skill"
+    my_skill.mkdir()
+    (my_skill / "SKILL.md").write_text("---\nname: my-skill\ndescription: A test skill\n---\n\nBody.\n")
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    assert len(skills_dirs) == 1
+    dir_path = next(iter(skills_dirs))
+    assert dir_path.endswith("/.config/opencode/skills")
+    skills = skills_dirs[dir_path]
+    assert isinstance(skills, list)
+    name, server = skills[0]
+    assert name == "my-skill"
+    assert isinstance(server, SkillServer)
+
+
+def test_opencode_discoverer_skills_returns_empty_when_dir_missing(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+
+    assert OpenCodeDiscoverer(tmp_path).discover_skills() == {}
+
+
+# --- OpenCodeDiscoverer: project enumeration via SQLite db ---
+
+
+def _seed_opencode_db(db_path, worktrees):
+    """Create an opencode-shaped SQLite db with one ``project`` row per worktree."""
+    import sqlite3
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(db_path))
+    con.execute(
+        "CREATE TABLE project ("
+        "id TEXT PRIMARY KEY, worktree TEXT NOT NULL, vcs TEXT, name TEXT, "
+        "icon_url TEXT, icon_color TEXT, time_created INTEGER NOT NULL, "
+        "time_updated INTEGER NOT NULL, time_initialized INTEGER, sandboxes TEXT NOT NULL)"
+    )
+    for i, worktree in enumerate(worktrees):
+        con.execute(
+            "INSERT INTO project (id, worktree, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?)",
+            (f"id-{i}", worktree, 0, 0, "[]"),
+        )
+    con.commit()
+    con.close()
+
+
+def test_opencode_discoverer_enumerates_projects_from_sqlite_db(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, ["/Users/alice/repo-a", "/Users/alice/repo-b"])
+
+    folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+
+    folder_strs = {f.as_posix() for f in folders}
+    assert folder_strs == {"/Users/alice/repo-a", "/Users/alice/repo-b"}
+
+
+def test_opencode_discoverer_project_folders_empty_when_db_missing(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    # no opencode.db on disk
+
+    assert OpenCodeDiscoverer(tmp_path)._discover_project_folders() == []
+
+
+def test_opencode_discoverer_project_folders_empty_on_schema_drift(tmp_path):
+    """A db with no ``project`` table (e.g. a schema-version mismatch) yields ``[]``,
+    not an unhandled exception that would abort the discoverer."""
+    import sqlite3
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    db_path.parent.mkdir(parents=True)
+    con = sqlite3.connect(str(db_path))
+    con.execute("CREATE TABLE unrelated (x TEXT)")
+    con.close()
+
+    assert OpenCodeDiscoverer(tmp_path)._discover_project_folders() == []
+
+
+def test_opencode_discoverer_discovers_project_opencode_json(tmp_path):
+    """A project-root ``opencode.json`` is picked up when listed in the SQLite db."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "opencode.json").write_text(
+        '{"mcp": {"proj-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, [project.as_posix()])
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    keys = [k for k in mcp_configs if k.endswith("/repo/opencode.json")]
+    assert len(keys) == 1
+    entries = mcp_configs[keys[0]]
+    assert isinstance(entries, list)
+    assert entries[0][0] == "proj-srv"
+
+
+def test_opencode_discoverer_discovers_project_skills_dir(tmp_path):
+    """``<project>/.opencode/skills`` is scanned for each opened project."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    project = tmp_path / "repo"
+    skills_dir = project / ".opencode" / "skills" / "proj-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\nname: proj-skill\ndescription: x\n---\nBody\n")
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, [project.as_posix()])
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/repo/.opencode/skills")]
+    assert len(matching) == 1
+    skills = skills_dirs[matching[0]]
+    assert isinstance(skills, list)
+    assert skills[0][0] == "proj-skill"
+
+
+# --- OpenCodeDiscoverer: managed (system-wide) config ---
+
+
+def test_opencode_discoverer_discovers_managed_mcp_servers(tmp_path, monkeypatch):
+    """Managed dir per OS yields its ``opencode.json`` mcp entries."""
+    from agent_scan.agents import OpenCodeDiscoverer, opencode as opencode_module
+
+    _opencode_install(tmp_path)
+    managed = tmp_path / "managed-opencode"
+    managed.mkdir()
+    (managed / "opencode.json").write_text(
+        '{"mcp": {"mgr-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+    monkeypatch.setattr(OpenCodeDiscoverer, "_managed_config_dir", lambda self: managed)
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    matching = [k for k in mcp_configs if k.endswith("/managed-opencode/opencode.json")]
+    assert len(matching) == 1
+    entries = mcp_configs[matching[0]]
+    assert isinstance(entries, list)
+    assert entries[0][0] == "mgr-srv"
+    assert opencode_module  # silence unused-import lint when running this test alone
+
+
+def test_opencode_discoverer_managed_config_dir_per_os(monkeypatch):
+    """Confirms per-OS paths for managed config dir."""
+    from agent_scan.agents import OpenCodeDiscoverer, opencode as opencode_module
+
+    d = OpenCodeDiscoverer(None)
+
+    monkeypatch.setattr(opencode_module.sys, "platform", "darwin")
+    assert d._managed_config_dir() == __import__("pathlib").Path("/Library/Application Support/opencode")
+
+    monkeypatch.setattr(opencode_module.sys, "platform", "linux")
+    assert d._managed_config_dir() == __import__("pathlib").Path("/etc/opencode")
+
+    monkeypatch.setattr(opencode_module.sys, "platform", "win32")
+    monkeypatch.setenv("PROGRAMDATA", "C:\\ProgramData")
+    assert d._managed_config_dir() == __import__("pathlib").Path("C:\\ProgramData") / "opencode"
+
+
+# --- OpenCodeDiscoverer: full discover() + registry ---
+
+
+def test_opencode_discoverer_discover_assembles_client(tmp_path, monkeypatch):
+    from agent_scan.agents import OpenCodeDiscoverer
+    from agent_scan.models import ClientToInspect
+
+    # Disable per-OS managed-config probing so the assertion isn't OS-sensitive.
+    monkeypatch.setattr(OpenCodeDiscoverer, "_managed_config_dir", lambda self: None)
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text(
+        '{"mcp": {"srv": {"type": "local", "command": ["echo"]}}}'
+    )
+
+    cti = OpenCodeDiscoverer(tmp_path).discover()
+
+    assert isinstance(cti, ClientToInspect)
+    assert cti.name == "opencode"
+    assert cti.client_path.endswith("/.config/opencode")
+
+
+def test_opencode_discoverer_discover_returns_none_when_absent(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    assert OpenCodeDiscoverer(tmp_path).discover() is None
+
+
+def test_DISCOVERERS_registers_opencode():
+    from agent_scan.agents import DISCOVERERS, OpenCodeDiscoverer
+
+    assert DISCOVERERS["opencode"] is OpenCodeDiscoverer
+
+
+def test_find_discoverers_returns_opencode_when_installed(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer, find_discoverers
+
+    _opencode_install(tmp_path)
+
+    found = find_discoverers(tmp_path)
+
+    assert any(isinstance(d, OpenCodeDiscoverer) for d in found)

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7982,3 +7982,187 @@ def test_opencode_discoverer_ignores_opencode_config_dir_when_not_own_home(tmp_p
 
     matching = [k for k in mcp_configs if "alt-opencode" in k]
     assert matching == []
+
+
+# --- OpenCodeDiscoverer: ~/.opencode second global config dir ---
+
+
+def test_opencode_discoverer_scans_dot_opencode_home_dir_skills(tmp_path):
+    """``~/.opencode`` is a second global config dir per opencode's
+    ConfigPaths.directories (packages/opencode/src/config/paths.ts:34-38)."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    alt = tmp_path / ".opencode"
+    sk = alt / "skills" / "home-skill"
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text("---\nname: home-skill\ndescription: x\n---\nBody\n")
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/.opencode/skills") and ".config" not in k]
+    assert len(matching) == 1
+    skills = skills_dirs[matching[0]]
+    assert isinstance(skills, list)
+    assert skills[0][0] == "home-skill"
+
+
+def test_opencode_discoverer_scans_dot_opencode_home_dir_mcp(tmp_path):
+    """``~/.opencode/opencode.json`` is a second global MCP config source."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    alt = tmp_path / ".opencode"
+    alt.mkdir()
+    (alt / "opencode.json").write_text(
+        '{"mcp": {"home-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    matching = [k for k in mcp_configs if k.endswith("/.opencode/opencode.json") and ".config" not in k]
+    assert len(matching) == 1
+    entries = mcp_configs[matching[0]]
+    assert isinstance(entries, list)
+    assert entries[0][0] == "home-srv"
+
+
+# --- OpenCodeDiscoverer: cfg.skills.paths user-declared skill folders ---
+
+
+def test_opencode_discoverer_scans_skills_paths_with_tilde_expansion(tmp_path):
+    """``skills.paths: ["~/team-skills"]`` resolves ``~`` to home_directory."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    team_skills = tmp_path / "team-skills" / "team-skill"
+    team_skills.mkdir(parents=True)
+    (team_skills / "SKILL.md").write_text("---\nname: team-skill\ndescription: y\n---\nBody\n")
+    (install / "opencode.json").write_text(
+        '{"skills": {"paths": ["~/team-skills"]}}'
+    )
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/team-skills")]
+    assert len(matching) == 1
+    skills = skills_dirs[matching[0]]
+    assert isinstance(skills, list)
+    assert skills[0][0] == "team-skill"
+
+
+def test_opencode_discoverer_scans_skills_paths_with_absolute_path(tmp_path):
+    """Absolute ``skills.paths`` entries are taken as-is."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    abs_root = tmp_path / "abs-skill-root"
+    skill = abs_root / "abs-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: abs-skill\ndescription: a\n---\nBody\n")
+    (install / "opencode.json").write_text(
+        '{"skills": {"paths": ["' + abs_root.as_posix() + '"]}}'
+    )
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/abs-skill-root")]
+    assert len(matching) == 1
+
+
+def test_opencode_discoverer_scans_skills_paths_relative_to_config_dir(tmp_path):
+    """Relative ``skills.paths`` resolve against the containing config file's directory,
+    matching opencode's loader."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    project = tmp_path / "repo"
+    project.mkdir()
+    rel_skill = project / "vendor-skills" / "vendor-skill"
+    rel_skill.mkdir(parents=True)
+    (rel_skill / "SKILL.md").write_text("---\nname: vendor-skill\ndescription: v\n---\nBody\n")
+    (project / "opencode.json").write_text('{"skills": {"paths": ["./vendor-skills"]}}')
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, [project.as_posix()])
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/repo/vendor-skills")]
+    assert len(matching) == 1
+
+
+def test_opencode_discoverer_skips_non_string_skills_paths(tmp_path):
+    """Malformed entries are skipped silently (don't blow up the discoverer)."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text(
+        '{"skills": {"paths": [123, null, "", true]}}'
+    )
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    assert skills_dirs == {}
+
+
+def test_opencode_discoverer_skips_skills_paths_when_field_missing(tmp_path):
+    """No ``skills`` block in opencode.json -> no error, no entries."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text('{"mcp": {}}')
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    assert skills_dirs == {}
+
+
+# --- OpenCodeDiscoverer: URL-pulled skill cache (~/.cache/opencode/skills/) ---
+
+
+def test_opencode_discoverer_scans_cached_url_skills(tmp_path):
+    """``~/.cache/opencode/skills/<hash>/<skill>/SKILL.md`` (skills downloaded
+    via ``cfg.skills.urls``) is scanned per hash dir."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    hash_dir = tmp_path / ".cache" / "opencode" / "skills" / "abcd1234"
+    sk = hash_dir / "remote-skill"
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text("---\nname: remote-skill\ndescription: r\n---\nBody\n")
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/.cache/opencode/skills/abcd1234")]
+    assert len(matching) == 1
+    skills = skills_dirs[matching[0]]
+    assert isinstance(skills, list)
+    assert skills[0][0] == "remote-skill"
+
+
+def test_opencode_discoverer_scans_cached_url_skills_returns_empty_when_dir_absent(tmp_path):
+    """No ``~/.cache/opencode/skills/`` -> no extra entries (graceful)."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    # No cache dir on disk
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    assert all("/.cache/opencode/skills" not in k for k in skills_dirs)
+
+
+def test_opencode_discoverer_scans_multiple_cached_hash_dirs(tmp_path):
+    """Multiple hash dirs each become their own skill scope."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    for h in ("hash-a", "hash-b"):
+        sk = tmp_path / ".cache" / "opencode" / "skills" / h / f"{h}-skill"
+        sk.mkdir(parents=True)
+        (sk / "SKILL.md").write_text(f"---\nname: {h}-skill\ndescription: q\n---\nBody\n")
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if "/.cache/opencode/skills/" in k]
+    assert len(matching) == 2

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -8518,3 +8518,37 @@ def test_opencode_discoverer_relative_opencode_config_file_yields_absolute_key(t
     env_keys = [k for k in mcp_configs if k.endswith("/rel-custom.json")]
     assert len(env_keys) == 1
     assert Path(env_keys[0]).is_absolute()
+
+
+# --- OpenCodeDiscoverer: client_exists tolerates non-EACCES OSError per candidate ---
+
+
+def test_opencode_discoverer_client_exists_tolerates_oserror_on_candidate(tmp_path, monkeypatch):
+    """A non-EACCES ``OSError`` (e.g. ESTALE on a stale NFS mount, EIO) from a
+    candidate's ``.exists()`` probe must not abort ``client_exists`` — it should
+    fall through to the next candidate. ``Path.exists()`` re-raises such errors
+    (only ENOENT/ENOTDIR/EBADF/ELOOP are swallowed), and ``find_discoverers``
+    would otherwise treat opencode as "not installed" for the whole scan.
+    Matches the ``(PermissionError, OSError)`` tolerance the SQLite db probe has.
+    """
+    import errno
+    from pathlib import Path
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    # ``~/.opencode`` exists; the default ``~/.config/opencode`` candidate raises.
+    (tmp_path / ".opencode").mkdir()
+
+    real_exists = Path.exists
+
+    def flaky_exists(self, *args, **kwargs):
+        if self.as_posix().endswith("/.config/opencode"):
+            raise OSError(errno.ESTALE, "Stale file handle")
+        return real_exists(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", flaky_exists)
+
+    result = OpenCodeDiscoverer(tmp_path).client_exists()
+
+    assert result is not None
+    assert result.endswith("/.opencode")

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7808,3 +7808,177 @@ def test_find_discoverers_returns_opencode_when_installed(tmp_path):
     found = find_discoverers(tmp_path)
 
     assert any(isinstance(d, OpenCodeDiscoverer) for d in found)
+
+
+# --- OpenCodeDiscoverer: singular subdir variant (backwards-compat) ---
+
+
+def test_opencode_discoverer_scans_singular_skill_global_dir(tmp_path):
+    """``~/.config/opencode/skill/`` (singular) is loaded alongside ``skills/``
+    per https://opencode.ai/docs/config: "Singular names (e.g., ``agent/``) are
+    also supported for backwards compatibility"."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    sing = install / "skill" / "legacy-skill"
+    sing.mkdir(parents=True)
+    (sing / "SKILL.md").write_text("---\nname: legacy-skill\ndescription: y\n---\nBody\n")
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/.config/opencode/skill")]
+    assert len(matching) == 1
+    skills = skills_dirs[matching[0]]
+    assert isinstance(skills, list)
+    assert skills[0][0] == "legacy-skill"
+
+
+def test_opencode_discoverer_scans_singular_skill_project_dir(tmp_path):
+    """``.opencode/skill/`` (singular) is loaded alongside ``.opencode/skills/``."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    project = tmp_path / "repo"
+    skills_dir = project / ".opencode" / "skill" / "legacy-proj"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\nname: legacy-proj\ndescription: x\n---\nBody\n")
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, [project.as_posix()])
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/repo/.opencode/skill")]
+    assert len(matching) == 1
+
+
+# --- OpenCodeDiscoverer: Claude Code compatibility skill paths ---
+
+
+def test_opencode_discoverer_scans_global_claude_compat_skills(tmp_path):
+    """opencode loads ``~/.claude/skills/<name>/SKILL.md`` even when Claude Code
+    itself is not installed (https://opencode.ai/docs/skills lists it under
+    "Global Claude-compatible"). Our discoverer must surface it so a scan of an
+    opencode-only user finds it."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    # No ``~/.claude`` install dir on purpose — only the skills tree below.
+    claude_skill = tmp_path / ".claude" / "skills" / "compat-skill"
+    claude_skill.mkdir(parents=True)
+    (claude_skill / "SKILL.md").write_text("---\nname: compat-skill\ndescription: z\n---\nBody\n")
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/.claude/skills")]
+    assert len(matching) == 1
+    skills = skills_dirs[matching[0]]
+    assert isinstance(skills, list)
+    assert skills[0][0] == "compat-skill"
+
+
+def test_opencode_discoverer_scans_global_agents_compat_skills(tmp_path):
+    """``~/.agents/skills`` cross-agent compat path is scanned."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    agents_skill = tmp_path / ".agents" / "skills" / "shared-skill"
+    agents_skill.mkdir(parents=True)
+    (agents_skill / "SKILL.md").write_text("---\nname: shared-skill\ndescription: q\n---\nBody\n")
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/.agents/skills")]
+    assert len(matching) == 1
+
+
+def test_opencode_discoverer_scans_project_claude_and_agents_compat_skills(tmp_path):
+    """``<project>/.claude/skills`` and ``<project>/.agents/skills`` are scanned per project."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    project = tmp_path / "repo"
+    for rel, name in ((".claude/skills/cc-proj", "cc-proj"), (".agents/skills/ag-proj", "ag-proj")):
+        sd = project / rel
+        sd.mkdir(parents=True)
+        (sd / "SKILL.md").write_text(f"---\nname: {name}\ndescription: q\n---\nBody\n")
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    _seed_opencode_db(db_path, [project.as_posix()])
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    assert any(k.endswith("/repo/.claude/skills") for k in skills_dirs)
+    assert any(k.endswith("/repo/.agents/skills") for k in skills_dirs)
+
+
+# --- OpenCodeDiscoverer: $OPENCODE_CONFIG_DIR env override (additive) ---
+
+
+def test_opencode_discoverer_scans_opencode_config_dir_in_addition_to_default(tmp_path, monkeypatch):
+    """``$OPENCODE_CONFIG_DIR`` is scanned in addition to ``~/.config/opencode``
+    (additive on the scanner side regardless of opencode's own treatment)."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    # Default-dir entry
+    (install / "opencode.json").write_text(
+        '{"mcp": {"def-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+    # Override-dir entry
+    override_dir = tmp_path / "alt-opencode"
+    override_dir.mkdir()
+    (override_dir / "opencode.json").write_text(
+        '{"mcp": {"alt-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    seen = {next(iter(entry))[0] for entry in mcp_configs.values() if isinstance(entry, list)}
+    assert "def-srv" in seen
+    assert "alt-srv" in seen
+
+
+def test_opencode_discoverer_scans_opencode_config_dir_skills(tmp_path, monkeypatch):
+    """``$OPENCODE_CONFIG_DIR/skills`` is scanned for skills too."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    override_dir = tmp_path / "alt-opencode"
+    sk = override_dir / "skills" / "alt-skill"
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text("---\nname: alt-skill\ndescription: a\n---\nBody\n")
+
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: tmp_path))
+
+    skills_dirs = OpenCodeDiscoverer(tmp_path).discover_skills()
+
+    matching = [k for k in skills_dirs if k.endswith("/alt-opencode/skills")]
+    assert len(matching) == 1
+    skills = skills_dirs[matching[0]]
+    assert isinstance(skills, list)
+    assert skills[0][0] == "alt-skill"
+
+
+def test_opencode_discoverer_ignores_opencode_config_dir_when_not_own_home(tmp_path, monkeypatch):
+    """Env var honored only on own-home scans (matches ``$OPENCODE_CONFIG`` policy)."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    override_dir = tmp_path / "alt-opencode"
+    override_dir.mkdir()
+    (override_dir / "opencode.json").write_text(
+        '{"mcp": {"alt-srv": {"type": "local", "command": ["echo"]}}}'
+    )
+
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(override_dir))
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    monkeypatch.setattr("agent_scan.agents.opencode.Path.home", staticmethod(lambda: other_home))
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    matching = [k for k in mcp_configs if "alt-opencode" in k]
+    assert matching == []

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7522,6 +7522,19 @@ def test_opencode_discoverer_skips_config_without_mcp_block(tmp_path):
     assert mcp_configs == {}
 
 
+def test_opencode_discoverer_skips_config_with_empty_mcp_block(tmp_path):
+    """``{"mcp": {}}`` is a valid opencode config (zero servers configured) —
+    must skip silently rather than report ``CouldNotParseMCPConfig``."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text('{"mcp": {}}')
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert mcp_configs == {}
+
+
 def test_opencode_discoverer_records_could_not_parse_on_invalid_json(tmp_path):
     from agent_scan.agents import OpenCodeDiscoverer
 
@@ -7730,7 +7743,7 @@ def test_opencode_discoverer_discovers_project_skills_dir(tmp_path):
 
 def test_opencode_discoverer_discovers_managed_mcp_servers(tmp_path, monkeypatch):
     """Managed dir per OS yields its ``opencode.json`` mcp entries."""
-    from agent_scan.agents import OpenCodeDiscoverer, opencode as opencode_module
+    from agent_scan.agents import OpenCodeDiscoverer
 
     _opencode_install(tmp_path)
     managed = tmp_path / "managed-opencode"
@@ -7747,7 +7760,6 @@ def test_opencode_discoverer_discovers_managed_mcp_servers(tmp_path, monkeypatch
     entries = mcp_configs[matching[0]]
     assert isinstance(entries, list)
     assert entries[0][0] == "mgr-srv"
-    assert opencode_module  # silence unused-import lint when running this test alone
 
 
 def test_opencode_discoverer_managed_config_dir_per_os(monkeypatch):

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7659,6 +7659,60 @@ def test_opencode_discoverer_ignores_env_var_when_not_own_home(tmp_path, monkeyp
     assert str(override_path) not in mcp_configs
 
 
+def test_opencode_discoverer_detects_install_via_opencode_config_env(tmp_path, monkeypatch):
+    """An env-only install — ``$OPENCODE_CONFIG`` pointing at a config file with
+    NO standard global dir present — must register as installed. Otherwise
+    ``client_exists`` returns ``None``, ``discover`` bails, and the env-override
+    MCP servers ``_discover_env_override_mcp_servers`` exists to surface are
+    never scanned."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    # No ``~/.config/opencode`` or ``~/.opencode`` on disk — only the env file.
+    override_path = tmp_path / "custom.json"
+    override_path.write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
+
+    monkeypatch.setenv("OPENCODE_CONFIG", str(override_path))
+    _force_home(monkeypatch, tmp_path)
+
+    result = OpenCodeDiscoverer(tmp_path).client_exists()
+
+    assert result == override_path.as_posix()
+
+
+def test_opencode_discoverer_discover_surfaces_env_only_install(tmp_path, monkeypatch):
+    """The full ``discover()`` path on an env-only install (no standard dir) yields
+    the env-override MCP servers rather than ``None``."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    override_path = tmp_path / "custom.json"
+    override_path.write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
+
+    monkeypatch.setenv("OPENCODE_CONFIG", str(override_path))
+    _force_home(monkeypatch, tmp_path)
+
+    cti = OpenCodeDiscoverer(tmp_path).discover()
+
+    assert cti is not None
+    assert str(override_path) in cti.mcp_configs
+
+
+def test_opencode_discoverer_ignores_opencode_config_env_for_client_exists_when_not_own_home(tmp_path, monkeypatch):
+    """The ``$OPENCODE_CONFIG`` install signal is honored only on own-home scans,
+    matching the env-override MCP policy — under ``--scan-all-users`` it reflects
+    the scanning process's env, not the scanned user's."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    override_path = tmp_path / "custom.json"
+    override_path.write_text('{"mcp": {"env-srv": {"type": "local", "command": ["echo"]}}}')
+
+    monkeypatch.setenv("OPENCODE_CONFIG", str(override_path))
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    _force_home(monkeypatch, other_home)
+
+    assert OpenCodeDiscoverer(tmp_path).client_exists() is None
+
+
 # --- OpenCodeDiscoverer: discover_skills ---
 
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7848,6 +7848,37 @@ def test_opencode_discoverer_project_folders_skips_fifo_db_without_hanging(tmp_p
     assert result[0] == []
 
 
+def test_opencode_discoverer_enumerates_uncheckpointed_wal_projects(tmp_path):
+    """opencode keeps a long-lived WAL connection and checkpoints lazily, so the
+    newest ``project`` rows live only in ``opencode.db-wal``. The discoverer must
+    read them (a ``mode=ro`` open is WAL-aware) rather than an ``immutable=1``
+    snapshot of just the main db file, which ignores the ``-wal`` and would drop
+    the most-recently-opened projects."""
+    import sqlite3
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    _opencode_install(tmp_path)
+    db_path = tmp_path / ".local" / "share" / "opencode" / "opencode.db"
+    db_path.parent.mkdir(parents=True)
+
+    writer = sqlite3.connect(str(db_path))
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("CREATE TABLE project (worktree TEXT)")
+        writer.execute("INSERT INTO project VALUES ('/repo/checkpointed')")
+        writer.commit()
+        writer.execute("PRAGMA wal_checkpoint(FULL)")  # flush that row into the main .db
+        writer.execute("INSERT INTO project VALUES ('/repo/newest-in-wal')")
+        writer.commit()  # committed, but only in -wal; writer stays open so no checkpoint
+
+        folders = OpenCodeDiscoverer(tmp_path)._discover_project_folders()
+    finally:
+        writer.close()
+
+    assert {f.as_posix() for f in folders} == {"/repo/checkpointed", "/repo/newest-in-wal"}
+
+
 def test_opencode_discoverer_discovers_project_opencode_json(tmp_path):
     """A project-root ``opencode.json`` is picked up when listed in the SQLite db."""
     from agent_scan.agents import OpenCodeDiscoverer

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -7549,6 +7549,57 @@ def test_opencode_discoverer_records_could_not_parse_on_invalid_json(tmp_path):
     assert entry.is_failure is True
 
 
+def test_opencode_discoverer_unknown_type_skips_entry_not_whole_file(tmp_path, caplog):
+    """An unknown ``type`` (e.g. a transport added in a future opencode release)
+    drops only that one entry; parseable siblings in the same file still surface.
+    Without this tolerance, a single forward-looking ``type: "sse"`` entry would
+    sink every other MCP server in the user's opencode.json."""
+    import logging
+
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text(
+        '{"mcp": {'
+        '"playwright": {"type": "local", "command": ["echo", "hi"]}, '
+        '"future-srv": {"type": "sse", "url": "https://example.com/sse"}'
+        "}}"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entry = next(iter(mcp_configs.values()))
+    assert isinstance(entry, list)
+    names = {n for n, _ in entry}
+    assert names == {"playwright"}
+    assert any(
+        "future-srv" in record.message and "sse" in record.message
+        for record in caplog.records
+    ), "expected a warning naming the skipped entry and its unrecognized type"
+
+
+def test_opencode_discoverer_malformed_known_type_still_raises(tmp_path):
+    """Tolerance applies ONLY to unknown ``type``. A known type with a missing
+    or malformed required field (e.g. ``local`` with no ``command``) must still
+    fail loudly — that's a real config bug worth surfacing, not a
+    forward-compat case."""
+    from agent_scan.agents import OpenCodeDiscoverer
+
+    install = _opencode_install(tmp_path)
+    (install / "opencode.json").write_text(
+        '{"mcp": {"broken": {"type": "local", "command": []}}}'
+    )
+
+    mcp_configs = OpenCodeDiscoverer(tmp_path).discover_mcp_servers()
+
+    assert len(mcp_configs) == 1
+    entry = next(iter(mcp_configs.values()))
+    assert isinstance(entry, CouldNotParseMCPConfig)
+    assert entry.is_failure is True
+
+
 def test_opencode_discoverer_returns_empty_when_global_config_missing(tmp_path):
     from agent_scan.agents import OpenCodeDiscoverer
 


### PR DESCRIPTION
## Summary

- Adds `OpenCodeDiscoverer` covering opencode's global, per-project, managed, and `$OPENCODE_CONFIG` scopes. Phase B (the discoverer) replaces what the empty `opencode` stub in `well_known_clients.py` would have done; the stub itself stays empty pending the broader `well_known_clients` retirement on `feature/agent-discoverer-remove-well-known`.
- Adds `OpenCodeConfigFile` Pydantic model translating opencode's `{"mcp": {name: {type:"local|remote", command:[...], environment, headers, enabled}}}` shape into the canonical `StdioServer` / `RemoteServer` types (handles array `command`, `environment` vs `env`, `local` vs `stdio`, and drops `enabled:false` entries before validation).
- Project enumeration reads the `worktree` column from the `project` table in `~/.local/share/opencode/opencode.db` over a read-only immutable SQLite connection — `sqlite3` is stdlib, so no new dependency. Missing db / schema drift / lock contention all yield an empty list rather than aborting the discoverer.
- Out of scope: opencode's `agents/` markdown subagent directory.

