### PR TITLE
fix(tls): trust CA certs from SSL_CERT_FILE/REQUESTS_CA_BUNDLE/NODE_EXTRA_CA_CERTS so Snyk CLI proxied calls work without --insecure

### DIFF
--- a/src/agent_scan/verify_api.py
+++ b/src/agent_scan/verify_api.py
@@ -112,12 +112,47 @@ def setup_aiohttp_debug_logging(verbose: bool) -> list[aiohttp.TraceConfig]:
     return [trace_config]
 
 
+# Environment variables that may point to an additional CA certificate (or bundle)
+# to trust. The Snyk CLI runs agent-scan behind a local authenticating reverse proxy
+# and exports these variables pointing at the proxy's self-signed certificate. Loading
+# them lets proxied TLS calls succeed without requiring --skip-ssl-verify.
+_CA_CERT_ENV_VARS = ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "NODE_EXTRA_CA_CERTS")
+
+
+def load_extra_ca_certs(ssl_context: ssl.SSLContext) -> None:
+    """Trust additional CA certificates referenced by environment variables.
+
+    Certificates are added on top of the existing (certifi) trust store rather than
+    replacing it, so both public endpoints and the Snyk CLI's proxy are trusted.
+    Missing or invalid files are logged and skipped rather than raising.
+    """
+    loaded: set[str] = set()
+    for env_var in _CA_CERT_ENV_VARS:
+        cert_path = os.environ.get(env_var)
+        if not cert_path:
+            continue
+        real_path = os.path.realpath(cert_path)
+        if real_path in loaded:
+            continue
+        if not os.path.isfile(real_path):
+            logger.warning("Ignoring %s: certificate file not found at %s", env_var, cert_path)
+            continue
+        try:
+            ssl_context.load_verify_locations(cafile=real_path)
+            loaded.add(real_path)
+            logger.debug("Loaded extra CA certificate from %s (%s)", env_var, cert_path)
+        except ssl.SSLError as exc:
+            logger.warning("Failed to load CA certificate from %s (%s): %s", env_var, cert_path, exc)
+
+
 def setup_tcp_connector(skip_ssl_verify: bool = False) -> aiohttp.TCPConnector:
     """
     Setup a TCP connector with SSL settings.
 
     When skip_ssl_verify is True, disable SSL verification and hostname checking.
-    Otherwise, use a secure default SSL context with certifi CA and TLSv1.2+.
+    Otherwise, use a secure default SSL context with certifi CA and TLSv1.2+, extended
+    with any additional CA certificates referenced by the environment (see
+    load_extra_ca_certs) so calls proxied through the Snyk CLI are trusted.
     """
     if skip_ssl_verify:
         # Disable SSL verification at the connector level
@@ -125,6 +160,7 @@ def setup_tcp_connector(skip_ssl_verify: bool = False) -> aiohttp.TCPConnector:
 
     ssl_context = ssl.create_default_context(cafile=certifi.where())
     ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+    load_extra_ca_certs(ssl_context)
     connector = aiohttp.TCPConnector(ssl=ssl_context, enable_cleanup_closed=True)
     return connector
 

--- a/src/agent_scan/verify_api.py
+++ b/src/agent_scan/verify_api.py
@@ -141,7 +141,7 @@ def load_extra_ca_certs(ssl_context: ssl.SSLContext) -> None:
             ssl_context.load_verify_locations(cafile=real_path)
             loaded.add(real_path)
             logger.debug("Loaded extra CA certificate from %s (%s)", env_var, cert_path)
-        except ssl.SSLError as exc:
+        except (ssl.SSLError, OSError) as exc:
             logger.warning("Failed to load CA certificate from %s (%s): %s", env_var, cert_path, exc)
 
 

--- a/tests/unit/test_verify_api.py
+++ b/tests/unit/test_verify_api.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import ssl
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -16,7 +17,7 @@ from agent_scan.models import (
     ServerSignature,
     StdioServer,
 )
-from agent_scan.verify_api import analyze_machine, setup_tcp_connector
+from agent_scan.verify_api import analyze_machine, load_extra_ca_certs, setup_tcp_connector
 
 
 class TestProxySupport:
@@ -216,6 +217,91 @@ class TestProxySupport:
             call_kwargs = mock_connector.call_args[1]
             assert call_kwargs["ssl"] is False  # SSL verification disabled
             assert call_kwargs["enable_cleanup_closed"] is True
+
+    def test_setup_tcp_connector_loads_extra_ca_certs(self):
+        """When verifying, setup_tcp_connector augments the context with env CA certs."""
+        with (
+            patch("agent_scan.verify_api.aiohttp.TCPConnector"),
+            patch("agent_scan.verify_api.load_extra_ca_certs") as mock_load,
+        ):
+            setup_tcp_connector(skip_ssl_verify=False)
+            mock_load.assert_called_once()
+            assert isinstance(mock_load.call_args[0][0], ssl.SSLContext)
+
+    def test_setup_tcp_connector_skips_extra_ca_certs_when_insecure(self):
+        """When skip_ssl_verify is True, there is no context to augment."""
+        with (
+            patch("agent_scan.verify_api.aiohttp.TCPConnector"),
+            patch("agent_scan.verify_api.load_extra_ca_certs") as mock_load,
+        ):
+            setup_tcp_connector(skip_ssl_verify=True)
+            mock_load.assert_not_called()
+
+
+class TestLoadExtraCaCerts:
+    """The Snyk CLI proxy exports SSL_CERT_FILE / REQUESTS_CA_BUNDLE / NODE_EXTRA_CA_CERTS
+    pointing at its self-signed certificate; these must be trusted additively."""
+
+    _CERT_ENV_VARS = ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "NODE_EXTRA_CA_CERTS")
+
+    def _clear_cert_env(self):
+        for var in self._CERT_ENV_VARS:
+            os.environ.pop(var, None)
+
+    @pytest.mark.parametrize("env_var", _CERT_ENV_VARS)
+    def test_loads_cert_from_each_env_var(self, tmp_path, env_var):
+        cert = tmp_path / "proxy.pem"
+        cert.write_text("dummy")
+        ctx = MagicMock(spec=ssl.SSLContext)
+
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_cert_env()
+            os.environ[env_var] = str(cert)
+            load_extra_ca_certs(ctx)
+
+        ctx.load_verify_locations.assert_called_once_with(cafile=os.path.realpath(str(cert)))
+
+    def test_deduplicates_when_vars_point_to_same_file(self, tmp_path):
+        cert = tmp_path / "proxy.pem"
+        cert.write_text("dummy")
+        ctx = MagicMock(spec=ssl.SSLContext)
+
+        with patch.dict(os.environ, {var: str(cert) for var in self._CERT_ENV_VARS}, clear=False):
+            load_extra_ca_certs(ctx)
+
+        ctx.load_verify_locations.assert_called_once()
+
+    def test_missing_file_is_skipped(self, tmp_path):
+        ctx = MagicMock(spec=ssl.SSLContext)
+
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_cert_env()
+            os.environ["SSL_CERT_FILE"] = str(tmp_path / "does-not-exist.pem")
+            load_extra_ca_certs(ctx)
+
+        ctx.load_verify_locations.assert_not_called()
+
+    def test_no_env_vars_is_noop(self):
+        ctx = MagicMock(spec=ssl.SSLContext)
+
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_cert_env()
+            load_extra_ca_certs(ctx)
+
+        ctx.load_verify_locations.assert_not_called()
+
+    def test_invalid_cert_is_logged_not_raised(self, tmp_path):
+        cert = tmp_path / "bad.pem"
+        cert.write_text("not a certificate")
+        ctx = MagicMock(spec=ssl.SSLContext)
+        ctx.load_verify_locations.side_effect = ssl.SSLError("bad certificate")
+
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_cert_env()
+            os.environ["SSL_CERT_FILE"] = str(cert)
+            load_extra_ca_certs(ctx)  # must not raise
+
+        ctx.load_verify_locations.assert_called_once()
 
 
 class TestAnalyzeMachineRetries:

--- a/tests/unit/test_verify_api.py
+++ b/tests/unit/test_verify_api.py
@@ -290,11 +290,23 @@ class TestLoadExtraCaCerts:
 
         ctx.load_verify_locations.assert_not_called()
 
-    def test_invalid_cert_is_logged_not_raised(self, tmp_path):
+    @pytest.mark.parametrize(
+        "error",
+        [
+            ssl.SSLError("bad certificate"),
+            OSError("permission denied"),
+            PermissionError("EACCES"),
+            FileNotFoundError("removed after isfile check"),
+        ],
+        ids=["ssl_error", "os_error", "permission_error", "file_not_found"],
+    )
+    def test_load_failure_is_logged_not_raised(self, tmp_path, error):
+        """load_verify_locations failures (bad cert or runtime OS errors) must be
+        swallowed so the connector still gets built and falls back to certifi/OS trust."""
         cert = tmp_path / "bad.pem"
         cert.write_text("not a certificate")
         ctx = MagicMock(spec=ssl.SSLContext)
-        ctx.load_verify_locations.side_effect = ssl.SSLError("bad certificate")
+        ctx.load_verify_locations.side_effect = error
 
         with patch.dict(os.environ, {}, clear=False):
             self._clear_cert_env()


### PR DESCRIPTION
Error that we get through the CLI extension: 

```
aiohttp.client_exceptions.ClientConnectorCertificateError: Cannot connect to host api.snyk.io:443 
ssl:True [SSLCertVerificationError: ('“snyk-embedded-proxy” certificate is not trusted',)]
```

We export the env vars in the CLI extension here: https://github.com/snyk/cli-extension-agent-scan/blob/60bbaa7edee45fc6bc03833c1fabcfdc59101195/pkg/mcpscan/runner/runner.go#L289-L291

