### PR TITLE
docs: add CLI reference and refresh JSON output docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ If you want to include Agent Scan results in your own project or registry, pleas
 
 ## Documentation
 
-- [Scanning](docs/scanning.md) — How scanning works, CLI parameters, and usage examples.
+- [CLI reference](docs/cli-reference.md) — All commands, flags, options, and environment variables.
+- [Scanning](docs/scanning.md) — How scanning works and usage examples.
 - [Issue Codes](docs/issue-codes.md) — Reference for all security issues detected by Agent Scan.
 
 ## Further Reading

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ If you want to include Agent Scan results in your own project or registry, pleas
 
 - [CLI reference](docs/cli-reference.md) — All commands, flags, options, and environment variables.
 - [Scanning](docs/scanning.md) — How scanning works and usage examples.
+- [JSON output](docs/json-output.md) — JSON schema and programmatic parsing.
 - [Issue Codes](docs/issue-codes.md) — Reference for all security issues detected by Agent Scan.
 
 ## Further Reading

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ This is the documentation for [Agent Scan](https://github.com/snyk/agent-scan). 
 
 - **[CLI reference](cli-reference.md)** — All commands, flags, options, environment variables, and exit codes.
 - **[Scanning](scanning.md)** — How scanning works and usage examples.
+- **[JSON output](json-output.md)** — JSON schema, CI integration, and programmatic parsing.
 - **[Issue Codes](issue-codes.md)** — Reference for all security issues, warnings, toxic flows, and system codes detected by Agent Scan.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,6 @@ This is the documentation for [Agent Scan](https://github.com/snyk/agent-scan). 
 
 ## Contents
 
-- **[Scanning](scanning.md)** — How scanning works, CLI parameters, and usage examples.
+- **[CLI reference](cli-reference.md)** — All commands, flags, options, environment variables, and exit codes.
+- **[Scanning](scanning.md)** — How scanning works and usage examples.
 - **[Issue Codes](issue-codes.md)** — Reference for all security issues, warnings, toxic flows, and system codes detected by Agent Scan.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,381 @@
+# Agent Scan CLI reference
+
+Complete reference for **Agent Scan** command-line flags and options. Agent Scan ships in two forms:
+
+| Entrypoint | Command | Notes |
+| --- | --- | --- |
+| **Standalone CLI** | `snyk-agent-scan` (or `uvx snyk-agent-scan@latest`) | Python package; primary surface documented below |
+| **Snyk CLI extension** | `snyk agent-scan --experimental` | Go wrapper that downloads a pinned binary and forwards flags — see [Snyk CLI extension flags](#snyk-cli-extension-flags) |
+
+Unless noted, flags apply to the standalone CLI. When no subcommand is given, **`scan` is assumed**.
+
+> **Experimental output.** Issue codes, JSON field names, and human-readable output may change between releases. See the [project README](../README.md) for the stability notice.
+
+---
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| `scan` | Scan MCP configs, agents, and skills for security issues (default) |
+| `inspect` | List tools, prompts, and resources without running security analysis |
+| `help` | Print top-level help |
+| `evo` | Interactive flow: mint a push key, scan, upload to Snyk Evo, revoke the key |
+| `guard` | Install, uninstall, or show status of Agent Guard hooks |
+
+### Positional arguments
+
+Most scan-like commands accept optional config paths:
+
+```bash
+snyk-agent-scan [scan] [CONFIG_FILE ...]
+snyk-agent-scan inspect [CONFIG_FILE ...]
+snyk-agent-scan evo [CONFIG_FILE ...]
+```
+
+| Argument | Applies to | Description |
+| --- | --- | --- |
+| `CONFIG_FILE ...` | `scan`, `inspect`, `evo` | One or more MCP config files, `SKILL.md` files, or directories to scan. If omitted, well-known agent config locations on the machine are discovered automatically. |
+
+---
+
+## Global options (scan, inspect, evo)
+
+These flags are shared by `scan`, `inspect`, and `evo`.
+
+### Output and logging
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--json` | boolean | `false` | Emit results as JSON on stdout instead of rich text. Non-JSON status lines are suppressed during the scan. See [JSON output](json-output.md). |
+| `--verbose` | boolean | `false` | Enable debug logging to stderr. |
+| `--print-errors` | boolean | `false` | Show error details and tracebacks in the human-readable report. |
+| `--print-full-descriptions` | boolean | `false` | Show full tool/skill descriptions in output (not truncated). |
+
+### Discovery and scope
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--skills` / `--no-skills` | boolean | `--skills` (enabled) | Include agent skills in the scan. Use `--no-skills` to scan MCP servers only. |
+| `--scan-all-users` | boolean | `false` | Scan all readable user home directories on the machine (and WSL profiles on Windows), not just the current user. Also expands the control-server bootstrap payload to list those homes. |
+
+### Analysis and upload
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--storage-file FILE` | string | `~/.mcp-scan` | Path for local scan state and cached results. |
+| `--analysis-url URL` | string | `https://api.snyk.io/hidden/mcp-scan/analysis-machine?version=2025-09-02` | Analysis API endpoint. With `SNYK_TOKEN`, the CLI rewrites this to the `/cli/analysis-machine` variant automatically. |
+| `--verification-H HEADER` | repeatable | — | Extra HTTP header for the analysis request. Format: `Name: value` (repeat for multiple headers). |
+| `--skip-ssl-verify` | boolean | `false` | Disable TLS certificate verification for analysis and upload HTTP calls. |
+| `--mcp-oauth-tokens-path PATH` | string | — | JSON file containing MCP OAuth tokens (`TokenAndClientInfoList` schema) used when connecting to OAuth-protected remote MCP servers. |
+
+### Control server (enterprise upload)
+
+Upload analyzed results to one or more control servers (typically Snyk Evo).
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--control-server URL` | repeatable | — | Upload destination URL. Each block **must** include a matching `--control-identifier`. Can be specified multiple times for multi-tenant upload. |
+| `--control-server-H HEADER` | repeatable | — | HTTP header for the **current** `--control-server` block (e.g. `x-client-id: <push-key>`). Repeat within a block for multiple headers. |
+| `--control-identifier ID` | repeatable | — | Non-anonymous machine identifier for the **current** `--control-server` block (email, hostname, serial number, etc.). **Required** for every `--control-server`. |
+| `--no-bootstrap` | boolean | `false` | Skip the one-shot startup bootstrap request to the first control server. |
+
+**Control-server block syntax** — options after a `--control-server` apply only to that server until the next `--control-server`:
+
+```bash
+snyk-agent-scan scan \
+  --control-server https://api.snyk.io/hidden/mcp-scan/push?version=2025-08-28 \
+  --control-server-H "x-client-id: <push-key>" \
+  --control-identifier user@example.com \
+  --control-server https://other.example/push \
+  --control-server-H "Authorization: Bearer token2" \
+  --control-identifier serial-123
+```
+
+**Push key and stdio MCP servers (`scan` only).** Enterprise uploads include an `x-client-id` push key in `--control-server-H`. Agent Scan treats that as an **unattended** run — there is no one at the terminal to answer y/n consent prompts.
+
+On `scan`, that changes stdio MCP behavior as follows:
+
+| `--dangerously-run-mcp-servers` | Consent prompts | Stdio MCP subprocesses |
+| --- | --- | --- |
+| not set (default) | skipped | **not started** — servers stay in the report as configured but not live-inspected; remote MCP servers and skills are still scanned |
+| set | skipped | **started** for every stdio server in the scanned configs |
+
+Add `--dangerously-run-mcp-servers` when a fleet or CI job must actually execute stdio MCP commands (typical for trusted MDM policies). This is the same flag required by `--ci` in non-interactive environments.
+
+`inspect` is unaffected: it always runs interactively (consent prompts when applicable), even if a push key is configured. See [MCP server options](#mcp-server-options) for the full handshake matrix.
+
+Bootstrap behavior is described in the [README — Control Server Bootstrap](../README.md#control-server-bootstrap).
+
+### CI mode
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--ci` | boolean | `false` | Exit with code **1** if any analysis issues or runtime failure codes remain after the scan. Requires `--dangerously-run-mcp-servers` in non-interactive environments. |
+| `--ignore-issues-codes CODES` | string | — | Comma-separated issue/failure codes to ignore for `--ci` exit status (e.g. `W001,W015,X001`). **Only valid with `--ci`.** Ignored codes are also removed from JSON output in CI mode. |
+
+**Exit codes (scan / inspect with `--ci`):**
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success; no remaining issues or failures (after ignores) |
+| `1` | `--ci`: findings or unignored runtime failures present |
+| `2` | Invalid flag combination (e.g. `--ignore-issues-codes` without `--ci`, or `--ci` without `--dangerously-run-mcp-servers`) |
+
+---
+
+## MCP server options
+
+Applies to: `scan`, `inspect`, `evo`.
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--server-timeout SECONDS` | float | `10` | Timeout for MCP server connections (stdio handshake and remote servers). |
+| `--suppress-mcpserver-io BOOL` | boolean | see below | Suppress **stderr** from stdio MCP servers. Stdout is always consumed as JSON-RPC and never shown. Accepted values: `true`, `false`, `1`, `0`, `yes`, `no`, `y`, `n`, `t`, `f`. |
+| `--dangerously-run-mcp-servers` | boolean | `false` | Skip interactive per-server consent and start every stdio MCP server listed in scanned configs. **Required with `--ci` in CI/CD.** Use only in trusted environments. |
+
+**Default for `--suppress-mcpserver-io`:**
+
+| Run type | Default |
+| --- | --- |
+| Interactive (`inspect`, or `scan` without push key) | `false` — stderr streamed with a `[server-name]` prefix |
+| Unattended (push-key scan, `evo`, etc.) | `true` — stderr hidden |
+
+**Handshake and consent matrix** (stdio MCP servers):
+
+| Command | Push key | `--dangerously-run-mcp-servers` | Start servers | Consent prompt |
+| --- | --- | --- | --- | --- |
+| `inspect` | — | no | yes | yes |
+| `inspect` | — | yes | yes | no |
+| `scan` | no | no | yes | yes |
+| `scan` | no | yes | yes | no |
+| `scan` | yes | no | no | no |
+| `scan` | yes | yes | yes | no |
+| `evo` | yes (auto) | no | no | no |
+
+> Scanning MCP configs **executes** the commands defined in them. Review consent prompts carefully or run inside a sandbox. See [Security Warning](../README.md#security-warning) in the README.
+
+---
+
+## `scan`-only options
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--checks-per-server NUM` | integer | `1` | Number of analysis passes per MCP server. |
+
+`scan` runs the full pipeline: discover → inspect → redact → analyze → (optional) upload.
+
+---
+
+## `inspect`
+
+Same global and MCP options as `scan`, but **no security analysis** — only discovery and MCP handshake to print tool/prompt/resource metadata.
+
+When `--control-server` is set, `inspect` still sends the startup bootstrap request (unless `--no-bootstrap`). It does not call the analysis API unless you use `scan`.
+
+---
+
+## `evo`
+
+Uses the same flags as `scan`. Additionally:
+
+1. Prompts interactively for **tenant ID** (from the Snyk app URL) and **API token** (from https://app.snyk.io/account).
+2. Mints a short-lived push key (`x-client-id` header).
+3. Runs `scan` with the Snyk push endpoint configured automatically.
+4. Revokes the push key when finished.
+
+No extra flags beyond the shared scan options.
+
+---
+
+## `guard`
+
+Manage [Agent Guard](https://evo.ai.snyk.io) hooks for Claude Code, Cursor, and Codex.
+
+```bash
+snyk-agent-scan guard [install|uninstall] [OPTIONS]
+snyk-agent-scan guard              # show installation status (default)
+```
+
+### `guard install`
+
+```bash
+snyk-agent-scan guard install {claude,cursor,codex,all} [OPTIONS]
+```
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--url URL` | string | `https://api.snyk.io` | Remote hooks base URL for the Snyk API environment. |
+| `--tenant-id ID` | string | — | Snyk tenant UUID. Required when minting a push key; not needed if `PUSH_KEY` is already set. |
+| `--file PATH` | string | — | Override the client config file path (default: client-specific well-known path). |
+| `--managed` | boolean | `false` | Install to the admin/MDM managed config path instead of the user-level path. |
+| `--test` | boolean | `false` | **Deprecated.** No-op. |
+
+### `guard uninstall`
+
+```bash
+snyk-agent-scan guard uninstall {claude,cursor,codex,all} [OPTIONS]
+```
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--file PATH` | string | — | Override the config file path. |
+| `--managed` | boolean | `false` | Uninstall from the managed (admin/MDM) path. |
+
+### Guard environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `PUSH_KEY` | Pre-provisioned push key; skips minting when set |
+| `TENANT_ID` | Tenant UUID (alternative to `--tenant-id`) |
+| `SNYK_TOKEN` | Required to mint/revoke push keys and to verify Guard is enabled for the tenant |
+
+---
+
+## Environment variables
+
+| Variable | Used by | Description |
+| --- | --- | --- |
+| `SNYK_TOKEN` | Standalone CLI | Snyk API token for analysis (`Authorization: token …`). Required for `scan`/`evo` unless a push key is configured via `--control-server-H`. Get a token at https://app.snyk.io/account. |
+| `SNYK_CLI_USE` | Standalone binary via Snyk CLI | Set to `true` by the Snyk CLI extension so analysis uses the proxy-authenticated `/cli/analysis-machine` endpoint without embedding the token in env. |
+| `SNYK_API` | Standalone CLI | Override Snyk API base URL (local dev / custom regions). |
+| `SNYK_TENANT_ID` | Snyk CLI extension | Alternative to `--tenant-id` for the Go wrapper. |
+| `AGENT_SCAN_ENVIRONMENT` | Bootstrap, analysis | Environment label sent as `X-Environment` (default: `production`). Also accepts legacy `MCP_SCAN_ENVIRONMENT`. |
+| `AGENT_SCAN_CI_HOSTNAME` | Bootstrap, upload | When `AGENT_SCAN_ENVIRONMENT=ci`, use this hostname instead of the machine node name. |
+| `PUSH_KEY` | `guard install` | Pre-provisioned push key for hook installation |
+| `TENANT_ID` | `guard install` | Tenant UUID for hook installation |
+| `HOOK_VERSION` | Agent Guard hooks | Override the hook/API line version baked into Guard artifacts |
+
+---
+
+## Snyk CLI extension flags
+
+The Snyk CLI command `snyk agent-scan` is implemented by **cli-extension-agent-scan**. It requires `--experimental` and delegates to the embedded Agent Scan binary.
+
+```bash
+snyk agent-scan --experimental [EXTENSION_FLAGS] [AGENT_SCAN_ARGS...]
+```
+
+### Extension-only flags
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--experimental` | boolean | `false` | **Required.** Enables the agent-scan workflow. |
+| `--tenant-id UUID` | string | — | Snyk tenant ID. Required when using `--json` without a client ID; otherwise resolved interactively or from `SNYK_TENANT_ID`. Must be a valid UUID. |
+| `--client-id UUID` | string | — | Push-key client ID passed as `x-client-id` to the control server. If omitted (and not using `--no-upload`), the extension mints one via the authenticated Snyk CLI session. Must be a valid UUID when provided. |
+| `--no-upload` | boolean | `false` | Scan and analyze locally without uploading to Evo. Requires Snyk CLI authentication (`snyk auth`). |
+| `--json` | boolean | `false` | Forwarded to the Agent Scan binary. |
+| `--skills [PATH]` | string / boolean | — | Forwarded to the binary. `--skills` alone enables skills; `--skills /path` enables skills and passes `/path` as a scan target. |
+
+### Snyk CLI flags consumed by the extension
+
+| Snyk CLI flag | Effect on Agent Scan |
+| --- | --- |
+| `--insecure` | Adds `--skip-ssl-verify` to the binary |
+| `--debug` / `-d` | Adds `--verbose` to the binary |
+
+### What the extension adds automatically
+
+When uploading (default, without `--no-upload`):
+
+- Prepends `scan` if no subcommand or config path is given
+- Sets `--analysis-url` from `SNYK_API` / configured API URL
+- Appends `--control-server`, `--control-server-H "x-client-id: …"`, and `--control-identifier <hostname>`
+- Starts a local MITM proxy for Snyk CLI credential injection
+
+When `--no-upload` is set:
+
+- Requires `snyk auth`; no control-server arguments are added
+- Analysis still runs through the authenticated proxy
+
+### Deprecated alias
+
+`snyk mcp-scan` is deprecated. The extension prints a warning and treats it like `agent-scan`.
+
+---
+
+## Examples
+
+### Standalone
+
+```bash
+# Full machine scan (default command is scan)
+uvx snyk-agent-scan@latest
+
+# MCP only, no skills
+uvx snyk-agent-scan@latest --no-skills
+
+# Specific config or skill directory
+uvx snyk-agent-scan@latest ~/.cursor/mcp.json
+uvx snyk-agent-scan@latest ~/.claude/skills
+
+# Inspect without analysis
+uvx snyk-agent-scan@latest inspect
+
+# JSON for CI parsing
+uvx snyk-agent-scan@latest --json --no-skills ./my-skill
+
+# CI pipeline (non-interactive)
+uvx snyk-agent-scan@latest --ci --dangerously-run-mcp-servers --json
+
+# CI with ignored warnings
+uvx snyk-agent-scan@latest --ci --dangerously-run-mcp-servers \
+  --ignore-issues-codes W001,W015
+
+# All users on a shared machine
+uvx snyk-agent-scan@latest --scan-all-users
+
+# Enterprise upload with push key
+export SNYK_TOKEN=...   # not required when push key is in control-server headers
+uvx snyk-agent-scan@latest scan \
+  --control-server "https://api.snyk.io/hidden/mcp-scan/push?version=2025-08-28" \
+  --control-server-H "x-client-id: <push-key>" \
+  --control-identifier "$(hostname)"
+```
+
+### Snyk CLI extension
+
+```bash
+# Authenticated scan with upload to Evo
+snyk auth
+snyk agent-scan --experimental
+
+# Explicit tenant and client IDs
+snyk agent-scan --experimental \
+  --tenant-id "<tenant-uuid>" \
+  --client-id "<client-uuid>"
+
+# Local scan only, no upload
+snyk agent-scan --experimental --no-upload
+
+# JSON output
+snyk agent-scan --experimental --json --tenant-id "<tenant-uuid>"
+
+# Scan a specific path
+snyk agent-scan --experimental --skills ~/.claude/skills
+```
+
+### Agent Guard
+
+```bash
+# Check hook status
+snyk-agent-scan guard
+
+# Install for all supported clients (user-level)
+SNYK_TOKEN=... snyk-agent-scan guard install all --tenant-id "<tenant-uuid>"
+
+# MDM managed install
+PUSH_KEY=... snyk-agent-scan guard install cursor --managed
+
+# Uninstall
+snyk-agent-scan guard uninstall all
+```
+
+---
+
+## Related documentation
+
+- [Scanning overview](scanning.md) — how discovery and analysis work
+- [Issue codes](issue-codes.md) — security finding reference
+- [JSON output](json-output.md) — programmatic output schema
+- [Developer guide — entrypoints](https://github.com/snyk/agent-scan-dev-guide/blob/main/agent-scan-entrypoints-and-release.md) — standalone vs Snyk CLI vs MDM paths

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -123,7 +123,7 @@ Bootstrap behavior is described in the [README — Control Server Bootstrap](../
 | --- | --- |
 | `0` | Success; no remaining issues or failures (after ignores) |
 | `1` | `--ci`: findings or unignored runtime failures present |
-| `2` | Invalid flag combination (e.g. `--ignore-issues-codes` without `--ci`, or `--ci` without `--dangerously-run-mcp-servers`) |
+| `2` | Invalid flag combination |
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -72,9 +72,9 @@ These flags are shared by `scan`, `inspect`, and `evo`.
 | `--skip-ssl-verify` | boolean | `false` | Disable TLS certificate verification for analysis and upload HTTP calls. |
 | `--mcp-oauth-tokens-path PATH` | string | — | JSON file containing MCP OAuth tokens (`TokenAndClientInfoList` schema) used when connecting to OAuth-protected remote MCP servers. |
 
-### Control server (enterprise upload)
+### Control server (enterprise upload, **on deprecation path**)
 
-Upload analyzed results to one or more control servers (typically Snyk Evo).
+Upload analyzed results to one or more control servers (typically Snyk Evo). Will be replaced soon.
 
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,8 +56,11 @@ These flags are shared by `scan`, `inspect`, and `evo`.
 
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
-| `--skills` / `--no-skills` | boolean | `--skills` (enabled) | Include agent skills in the scan. Use `--no-skills` to scan MCP servers only. |
+| `--no-skills` | boolean | off | Scan MCP servers only — skip agent skill discovery and analysis. Skills are **included by default** on every scan/inspect/evo invocation; you normally do not need to pass anything to enable them. |
+| `--skills` | boolean | on (implicit) | **Deprecated / no-op.** Accepted for backward compatibility (`BooleanOptionalAction`) but redundant because skills are already enabled by default. Prefer omitting it; use `--no-skills` to opt out. |
 | `--scan-all-users` | boolean | `false` | Scan all readable user home directories on the machine (and WSL profiles on Windows), not just the current user. Also expands the control-server bootstrap payload to list those homes. |
+
+**Behavior:** `scan_skills` flows from the CLI into discovery and inspection — with `--no-skills`, explicit skill paths, skill directories, and auto-discovered agent skills are all skipped (see `client_to_inspect_from_path` and `inspect_client` in the codebase). E2E tests assert that `--no-skills` produces no skill servers even when a skill path is passed as a positional argument.
 
 ### Analysis and upload
 
@@ -267,7 +270,7 @@ snyk agent-scan --experimental [EXTENSION_FLAGS] [AGENT_SCAN_ARGS...]
 | `--client-id UUID` | string | — | Push-key client ID passed as `x-client-id` to the control server. If omitted (and not using `--no-upload`), the extension mints one via the authenticated Snyk CLI session. Must be a valid UUID when provided. |
 | `--no-upload` | boolean | `false` | Skip uploading results to Evo (analysis still runs). When omitted on a default scan invocation, the extension uploads by configuring `--control-server` automatically. |
 | `--json` | boolean | `false` | Forwarded to the Agent Scan binary. |
-| `--skills [PATH]` | string / boolean | — | Forwarded to the binary. `--skills` alone enables skills; `--skills /path` enables skills and passes `/path` as a scan target. |
+| `--skills [PATH]` | string / boolean | skills on | **Deprecated** when used alone (`--skills` without a path) — skills are already enabled by default in the embedded binary. Still supported by the extension: `--skills /path/to/skills` forwards `/path/to/skills` as a scan target (equivalent to passing the path as a positional argument). |
 
 ### Snyk CLI flags consumed by the extension
 
@@ -316,8 +319,11 @@ uvx snyk-agent-scan@latest ~/.claude/skills
 # Inspect without analysis
 uvx snyk-agent-scan@latest inspect
 
-# JSON for CI parsing
-uvx snyk-agent-scan@latest --json --no-skills ./my-skill
+# JSON for CI parsing (skill path — skills included by default)
+uvx snyk-agent-scan@latest --json ./my-skill
+
+# JSON for MCP-only scan
+uvx snyk-agent-scan@latest --json --no-skills ~/.cursor/mcp.json
 
 # CI pipeline (non-interactive)
 uvx snyk-agent-scan@latest --ci --dangerously-run-mcp-servers --json
@@ -355,8 +361,8 @@ snyk agent-scan --experimental --no-upload
 # JSON output
 snyk agent-scan --experimental --json --tenant-id "<tenant-uuid>"
 
-# Scan a specific path
-snyk agent-scan --experimental --skills ~/.claude/skills
+# Scan a specific path (skills included by default)
+snyk agent-scan --experimental ~/.claude/skills
 ```
 
 ### Agent Guard

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -250,7 +250,9 @@ snyk-agent-scan guard uninstall {claude,cursor,codex,all} [OPTIONS]
 
 ## Snyk CLI extension flags
 
-The Snyk CLI command `snyk agent-scan` is implemented by **cli-extension-agent-scan**. It requires `--experimental` and delegates to the embedded Agent Scan binary.
+The Snyk CLI command `snyk agent-scan` is implemented by [**cli-extension-agent-scan**](https://github.com/snyk/cli-extension-agent-scan). It requires `--experimental` and delegates to the embedded Agent Scan binary.
+
+**Authentication:** Run `snyk auth` before using the extension. Analysis always goes through the Snyk API via a local credential proxy, so a valid Snyk CLI session is required in every mode — including `--no-upload`.
 
 ```bash
 snyk agent-scan --experimental [EXTENSION_FLAGS] [AGENT_SCAN_ARGS...]
@@ -263,7 +265,7 @@ snyk agent-scan --experimental [EXTENSION_FLAGS] [AGENT_SCAN_ARGS...]
 | `--experimental` | boolean | `false` | **Required.** Enables the agent-scan workflow. |
 | `--tenant-id UUID` | string | — | Snyk tenant ID. Required when using `--json` without a client ID; otherwise resolved interactively or from `SNYK_TENANT_ID`. Must be a valid UUID. |
 | `--client-id UUID` | string | — | Push-key client ID passed as `x-client-id` to the control server. If omitted (and not using `--no-upload`), the extension mints one via the authenticated Snyk CLI session. Must be a valid UUID when provided. |
-| `--no-upload` | boolean | `false` | Scan and analyze locally without uploading to Evo. Requires Snyk CLI authentication (`snyk auth`). |
+| `--no-upload` | boolean | `false` | Skip uploading results to Evo (analysis still runs). When omitted on a default scan invocation, the extension uploads by configuring `--control-server` automatically. |
 | `--json` | boolean | `false` | Forwarded to the Agent Scan binary. |
 | `--skills [PATH]` | string / boolean | — | Forwarded to the binary. `--skills` alone enables skills; `--skills /path` enables skills and passes `/path` as a scan target. |
 
@@ -276,17 +278,19 @@ snyk agent-scan --experimental [EXTENSION_FLAGS] [AGENT_SCAN_ARGS...]
 
 ### What the extension adds automatically
 
-When uploading (default, without `--no-upload`):
+**Default scan invocation** (`snyk agent-scan --experimental` with no explicit subcommand such as `inspect` or `help`, and without `--no-upload`):
 
-- Prepends `scan` if no subcommand or config path is given
-- Sets `--analysis-url` from `SNYK_API` / configured API URL
-- Appends `--control-server`, `--control-server-H "x-client-id: …"`, and `--control-identifier <hostname>`
+- Prepends `scan` if no config path is given
+- Sets `--analysis-url` from the configured Snyk API URL
+- Mints or reuses a push key and appends `--control-server`, `--control-server-H "x-client-id: …"`, and `--control-identifier <hostname>` so results upload to Evo (unless `--client-id` was supplied)
 - Starts a local MITM proxy for Snyk CLI credential injection
 
-When `--no-upload` is set:
+**With `--no-upload`:**
 
-- Requires `snyk auth`; no control-server arguments are added
+- Does not mint a client ID or add control-server arguments
 - Analysis still runs through the authenticated proxy
+
+**Explicit subcommands** (`inspect`, `help`, `guard`, etc.): no upload is configured, regardless of `--no-upload` (the flag is effectively irrelevant for those commands).
 
 ### Deprecated alias
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -1,83 +1,204 @@
-# JSON Output Reference for `mcp-scan`
+# JSON output reference for `snyk-agent-scan`
 
-The `mcp-scan` CLI provides a structured JSON output that allows for programmatic verification of skill scans. This is particularly useful for CI/CD pipelines or automated auditing tools.
+The `snyk-agent-scan` CLI can emit structured JSON for programmatic consumption — useful in CI/CD pipelines, catalog validation, and custom auditing tools.
 
-To generate this output, run the scan with the `--json` flag:
+Enable JSON mode with `--json`:
 
 ```bash
-uvx mcp-scan --skills <path-to-skill-directory> --json
+uvx snyk-agent-scan@latest --json
+uvx snyk-agent-scan@latest --json ~/.claude/skills
+uvx snyk-agent-scan@latest inspect --json ~/.vscode/mcp.json
 ```
 
-## JSON Structure Overview
+**Output behavior**
 
-The output is a dictionary where keys are file paths and values are `ScanPathResult` objects.
+- With `--json`, stdout contains **only** the JSON document (the version banner and rich-text report are suppressed).
+- Debug logging still goes to stderr when `--verbose` is set.
+- Skills are included by default; pass `--no-skills` for MCP-only scans.
+- For native pass/fail exit codes in CI, prefer [`--ci`](cli-reference.md#ci-mode) over custom `jq` parsing.
+
+> **Experimental output.** Field names, issue codes, and schema details may change between releases. See the [project README](../README.md) stability notice.
+
+---
+
+## JSON structure overview
+
+The root object is a map from **scan path** (absolute path string) to a `ScanPathResult`:
 
 ```json
 {
-  "/absolute/path/to/skill": {
-    "path": "/absolute/path/to/skill",
+  "/Users/me/.claude/skills/my-skill": {
+    "client": "claude-code",
+    "path": "/Users/me/.claude/skills/my-skill",
     "error": null,
     "servers": [
       {
-        "name": "skill-name",
-        "type": "skill",
-        "error": null,
-        "signature": { ... }
+        "name": "my-skill",
+        "config_path": "/Users/me/.claude/skills",
+        "server": {
+          "path": "/Users/me/.claude/skills/my-skill/SKILL.md",
+          "type": "skill"
+        },
+        "signature": {
+          "metadata": { "...": "..." },
+          "tools": [],
+          "prompts": [],
+          "resources": [],
+          "resource_templates": []
+        },
+        "error": null
       }
     ],
     "issues": [
       {
-        "code": "E001",
-        "message": "Description of the error",
-        "reference": [0, 1]
+        "code": "E004",
+        "message": "Description of the finding",
+        "reference": [0, null],
+        "extra_data": null
       }
-    ]
+    ],
+    "labels": []
   }
 }
 ```
 
-## 1. Checking for Execution Failures
+### Top-level fields (`ScanPathResult`)
 
-Before looking for policy violations, ensure the scanner successfully ran on the target.
+| Field | Type | Description |
+| --- | --- | --- |
+| `client` | string \| null | Agent client that owns this path (e.g. `cursor`, `claude-code`). |
+| `path` | string | Absolute path for this scan result (config file, skill directory, etc.). |
+| `error` | object \| null | Path-level error when discovery/parsing failed for this path. See [Execution failures](#1-checking-for-execution-failures). |
+| `servers` | array \| null | Inspected MCP servers and skills. `null` when the config could not be read at all. |
+| `issues` | array | Security findings from analysis (`E*`, `W*`). Empty in `inspect` mode. |
+| `labels` | array | Per-tool risk label scores from analysis (MCP scans). Often empty for skills-only paths. |
 
-### Path-level Failure
-Check the top-level `error` field in the result object.
-*   **If `error` is not `null`**: The scan failed completely (e.g., file not found, permission denied).
-*   **Action**: Read `error.message` for details.
+### Server entries (`ServerScanResult`)
 
-### Server-level Failure
-A skill directory might contain multiple "servers" (or parts). Check the `servers` array.
-*   Iterate through each item in `servers`.
-*   **If `servers[i].error` is not `null`**: That specific part of the skill failed to start or run.
-*   **Action**: Read `servers[i].error.message`.
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string \| null | Server or skill name from the config. |
+| `config_path` | string \| null | Absolute path of the config file this entry came from. |
+| `server` | object | Underlying config: stdio MCP (`command`, `args`, `type: "stdio"`), remote MCP (`url`, `type: "sse"` \| `"http"`), or skill (`path`, `type: "skill"`). |
+| `signature` | object \| null | Live tool/prompt/resource catalog when inspection succeeded. |
+| `error` | object \| null | Server-level error when startup or inspection failed. |
 
-## 2. Checking for Policy Violations
+### Issue entries (`Issue`)
 
-If the scan executed successfully, look at the `issues` array to find policy violations.
+| Field | Type | Description |
+| --- | --- | --- |
+| `code` | string | Finding code (e.g. `E001`, `W015`). See [Issue codes](issue-codes.md). |
+| `message` | string | Human-readable description. |
+| `reference` | array \| null | `(server_index, entity_index)` into `servers` / entity lists, or `[server_index, null]` for server-scoped issues. |
+| `extra_data` | object \| null | Optional structured context from analysis. |
 
-| Code Prefix | Meaning | Severity | Example |
-| :--- | :--- | :--- | :--- |
-| **`E`** | **Error** | **High** | `E001`: Critical security flaw |
-| **`W`** | **Warning** | **Medium** | `W001`: Best practice violation |
-| **`X`** | **Analysis Error** | **Variable** | `X001`: API analysis failed |
-| **`X002`** | **Whitelisted** | **Safe** | Explicitly allowed by user |
+### Error objects (`ScanError`)
 
-### Internal Warnings
-The JSON output is verbose and may include internal warnings (codes `W003`, `W004`, `W005`, `W006`) that are typically hidden in the text output. These usually relate to internal scanner states or non-critical hints and can often be ignored for compliance checks.
+| Field | Type | Description |
+| --- | --- | --- |
+| `message` | string \| null | Short error description. |
+| `exception` | string \| null | Serialized exception message. |
+| `traceback` | string \| null | Stack trace when captured. |
+| `is_failure` | boolean | Whether this error should count as a runtime failure (see CI below). |
+| `category` | string \| null | Structured category (e.g. `server_startup`, `file_not_found`). |
+| `server_output` | string \| null | Captured MCP traffic / stderr for startup failures. |
 
-## Practical Example: Filtering with `jq`
+---
 
-You can use `jq` to parse the output and determine if a skill passes or fails your criteria.
+## 1. Checking for execution failures
 
-### Basic Check: Any Errors?
-To check if there are any critical errors (`E` codes) or execution failures:
+Check failures **before** policy violations.
+
+### Path-level errors
+
+Inspect `error` on each `ScanPathResult`.
+
+- **`error` is not `null`:** Discovery or parsing failed for that path.
+- Read `error.message` (and `error.category`) for details.
+- **`error.is_failure`:** When `false`, the path was skipped benignly (e.g. `file_not_found`, `unknown_config`). When `true`, treat as a hard failure (e.g. `parse_error`).
+
+### Server-level errors
+
+Iterate `servers[]`:
+
+- **`servers[i].error` is not `null`:** That MCP server or skill failed to inspect (startup error, HTTP error, skill scan error, user declined consent, etc.).
+- Check `servers[i].error.is_failure` the same way as path-level errors.
+- A server with `signature: null` and `error: null` was **configured but not live-inspected** (common for stdio MCP on unattended push-key scans without `--dangerously-run-mcp-servers`).
+
+### Runtime failure codes (`X*`)
+
+Operational failures map to `X*` codes (via `error.category`, or occasionally in `issues`):
+
+| Code | Category | Typical `is_failure` |
+| --- | --- | --- |
+| `X001` | `server_startup` | true |
+| `X002` | `skill_scan_error` | true |
+| `X003` | `file_not_found` | false |
+| `X004` | `unknown_config` | false |
+| `X005` | `parse_error` | true |
+| `X006` | `server_http_error` | true |
+| `X007` | `analysis_error` | true |
+| `X008` | (uncategorized) | true |
+| `X009` | `user_declined` | true |
+| `X010` | `skipped_by_runtime_config` | true |
+
+---
+
+## 2. Checking for policy violations
+
+When inspection and analysis succeeded, read the `issues` array.
+
+| Prefix | Meaning | Example |
+| --- | --- | --- |
+| **`E`** | Error — high-severity security finding | `E001` prompt injection in MCP tool |
+| **`W`** | Warning — lower-severity or informational finding | `W001` suspicious words in tool description |
+
+Full reference: [Issue codes](issue-codes.md).
+
+### Internal warnings (`W003`–`W006`)
+
+The human-readable CLI hides `W003`, `W004`, `W005`, and `W006` unless `--verbose` is set. **JSON output includes all issues unchanged.**
+
+These codes are legacy internal hints. If you want JSON parsing to mirror the default text report, filter them out in post-processing (examples below).
+
+---
+
+## CI/CD integration
+
+### Built-in exit codes (recommended)
+
+Use `--ci` for a native non-zero exit when findings or runtime failures remain:
 
 ```bash
-uvx mcp-scan --skills ./my-skill --json | jq '
+uvx snyk-agent-scan@latest \
+  --ci \
+  --dangerously-run-mcp-servers \
+  --json \
+  ~/.claude/skills
+```
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Clean (no remaining issues or failures) |
+| `1` | Issues or unignored runtime failures present |
+| `2` | Invalid flags (e.g. `--ci` without `--dangerously-run-mcp-servers`) |
+
+Ignore specific codes in CI with `--ignore-issues-codes W001,W015` (requires `--ci`). Ignored codes are removed from the JSON payload before the exit check.
+
+See [CLI reference — CI mode](cli-reference.md#ci-mode).
+
+---
+
+## Practical examples with `jq`
+
+### Any critical findings or failures?
+
+```bash
+uvx snyk-agent-scan@latest --json ./my-skill | jq '
   [ .[] ] | map(
     select(
-      .error != null or
-      (.servers[]? | .error != null) or
+      (.error != null and .error.is_failure) or
+      (.servers[]? | .error != null and .error.is_failure) or
       (
         (.issues // []) | map(select(.code | startswith("E"))) | length > 0
       )
@@ -85,35 +206,35 @@ uvx mcp-scan --skills ./my-skill --json | jq '
   ) | length > 0
 '
 ```
-*   Returns `true` if there are failures or critical errors.
-*   Returns `false` if the scan is clean of errors.
 
-### Advanced Check: Filter Internal Warnings
-To get a list of "real" issues (ignoring internal warnings `W003`-`W006` and whitelisted items `X002`):
+Returns `true` when hard failures or `E*` findings exist.
+
+### Filter internal warnings
+
+Match the default text output by excluding `W003`–`W006`:
 
 ```bash
-uvx mcp-scan --skills ./my-skill --json | jq '
+uvx snyk-agent-scan@latest --json ./my-skill | jq '
   .[] | (.issues // [])[] |
   select(
-    .code as $c | ["W003", "W004", "W005", "W006", "X002"] | index($c) | not
+    .code as $c | ["W003", "W004", "W005", "W006"] | index($c) | not
   )
 '
 ```
 
-### Complete Compliance Check
-A strict check that fails if there are **any** errors or warnings (excluding internal ones), or if the scan itself failed:
+### Strict compliance check
+
+Fail on any remaining issue (excluding internal warnings) or any `is_failure` error:
 
 ```bash
-uvx mcp-scan --skills ./my-skill --json | jq '
+uvx snyk-agent-scan@latest --json ./my-skill | jq '
   [ .[] ] | map(
     select(
-      # Check for execution errors (path or server level)
-      (.error != null) or (.servers[]? | .error != null) or
-
-      # Check for policy issues, excluding internal warnings and whitelisted items
+      (.error != null and .error.is_failure) or
+      (.servers[]? | .error != null and .error.is_failure) or
       (
         (.issues // []) | map(select(
-          .code as $c | ["W003", "W004", "W005", "W006", "X002"] | index($c) | not
+          .code as $c | ["W003", "W004", "W005", "W006"] | index($c) | not
         )) | length > 0
       )
     )
@@ -121,68 +242,76 @@ uvx mcp-scan --skills ./my-skill --json | jq '
 '
 ```
 
-If the output is `true`, the skill **failed** the check.
+If the result is `true`, the target **failed** the check.
 
-## One-Liner for CI/CD
+### One-liner exit code via `jq`
 
-If you need a concise command for scripts or CI/CD pipelines that simply passes (exit 0) or fails (exit 1) based on policy violations:
+When you cannot use `--ci`, derive an exit code from issue codes:
 
 ```bash
-uvx mcp-scan --skills . --json | jq -e '[.[].issues[].code] - ["W003","W004","W005","W006","X002"] == []' > /dev/null
+uvx snyk-agent-scan@latest --json . | jq -e '
+  [
+    .[] | (.issues // [])[].code
+  ] | map(select(. as $c | ["W003","W004","W005","W006"] | index($c) | not)) | length == 0
+' > /dev/null
 ```
 
-### Why this works:
-1. `[.[].issues[].code]` collects all found issue codes into a single array.
-2. `- ["W003", ...]` removes the internal/whitelisted codes from that array.
-3. `== []` checks if any "real" issues remain.
-4. `jq -e` sets the shell exit code based on the truthiness of the result (`true` -> 0, `false` -> 1).
-5. `> /dev/null` suppresses the output so you only get the exit code.
+- `jq -e` maps `true` → exit `0`, `false` → exit `1`.
+- This checks **issues only**; combine with failure checks above for full coverage.
 
-## Node.js Integration
+---
 
-If you are integrating `mcp-scan` into a Node.js tool, you can use the following pattern to detect failures and policy violations programmatically.
+## Node.js integration
 
 ```javascript
-const { execSync } = require('child_process');
+const { execSync } = require("child_process");
 
-function checkSkillSecurity(targetPath) {
-  try {
-    const scanOutput = execSync(`uvx mcp-scan@latest --skills ${targetPath} --json`).toString();
-    const scanResult = JSON.parse(scanOutput);
+const IGNORE_CODES = new Set(["W003", "W004", "W005", "W006"]);
 
-    // Internal codes to ignore
-    const IGNORE_CODES = ["W003", "W004", "W005", "W006", "X002"];
+function checkAgentScan(targetPath) {
+  const scanOutput = execSync(
+    `uvx snyk-agent-scan@latest --json ${JSON.stringify(targetPath)}`,
+    { encoding: "utf8" }
+  );
+  const scanResult = JSON.parse(scanOutput);
 
-    // 1. Check for top-level execution failures
-    for (const [path, result] of Object.entries(scanResult)) {
-      if (result.error) {
-        throw new Error(`Scan failed for ${path}: ${result.error.message}`);
-      }
+  for (const [path, result] of Object.entries(scanResult)) {
+    if (result.error?.is_failure) {
+      throw new Error(`Scan failed for ${path}: ${result.error.message}`);
+    }
 
-      // 2. Check for server-level startup failures
-      const startupError = result.servers?.find(s => s.error)?.error;
-      if (startupError) {
-        throw new Error(`Server failed to start: ${startupError.message}`);
-      }
-
-      // 3. Filter for real policy violations (Errors or Warnings)
-      const violations = result.issues.filter(issue => !IGNORE_CODES.includes(issue.code));
-
-      if (violations.length > 0) {
-        const messages = violations.map(v => `[${v.code}] ${v.message}`).join(', ');
-        throw new Error(`Security policy violations found: ${messages}`);
+    for (const server of result.servers ?? []) {
+      if (server.error?.is_failure) {
+        throw new Error(
+          `Inspection failed for ${server.name ?? path}: ${server.error.message}`
+        );
       }
     }
 
-    return true; // Scan passed and is clean
-  } catch (error) {
-    // Handle or rethrow for your UI/Spinner
-    throw error;
+    const violations = (result.issues ?? []).filter(
+      (issue) => !IGNORE_CODES.has(issue.code)
+    );
+
+    if (violations.length > 0) {
+      const messages = violations.map((v) => `[${v.code}] ${v.message}`).join(", ");
+      throw new Error(`Security findings: ${messages}`);
+    }
   }
+
+  return true;
 }
 ```
 
-### Key Integration Points:
-*   **Object.entries**: Remember that the root of the JSON is an object keyed by file paths.
-*   **Issue Filtering**: Always filter out `W003`-`W006` and `X002` if you want to match the standard "clean" output of the CLI.
-*   **Server Errors**: Don't forget to check `result.servers[].error`. A skill might be "invalid" because it failed to execute, even if it has no security `issues` reported yet.
+**Integration notes**
+
+- The root JSON object is keyed by absolute paths — iterate with `Object.entries`.
+- Check `error.is_failure` and `servers[].error.is_failure`, not just presence of `error`.
+- Filter `W003`–`W006` when mirroring the default text report.
+- For CI pipelines, prefer `--ci --dangerously-run-mcp-servers --json` over reimplementing exit logic.
+
+---
+
+## Related documentation
+
+- [CLI reference](cli-reference.md) — all flags, including `--json`, `--ci`, and `--ignore-issues-codes`
+- [Issue codes](issue-codes.md) — security finding reference

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -71,7 +71,7 @@ The root object is a map from **scan path** (absolute path string) to a `ScanPat
 | `error` | object \| null | Path-level error when discovery/parsing failed for this path. See [Execution failures](#1-checking-for-execution-failures). |
 | `servers` | array \| null | Inspected MCP servers and skills. `null` when the config could not be read at all. |
 | `issues` | array | Security findings from analysis (`E*`, `W*`). Empty in `inspect` mode. |
-| `labels` | array | **Deprecated — do not rely on this field.** Kept for schema compatibility. After analysis it is usually a nested array of all-zero risk scores (`is_public_sink`, `destructive`, `untrusted_content`, `private_data` = 0) aligned to each entity; before analysis or in `inspect` mode it is often `[]`. Real findings live in `issues`. |
+| `labels` | array | **Deprecated — do not rely on this field.** Kept for schema compatibility. Real findings live in `issues`. |
 
 ### Server entries (`ServerScanResult`)
 
@@ -140,7 +140,8 @@ Operational failures map to `X*` codes (via `error.category`, or occasionally in
 | `X007` | `analysis_error` | true |
 | `X008` | (uncategorized) | true |
 | `X009` | `user_declined` | true |
-| `X010` | `skipped_by_runtime_config` | true |
+
+These nine codes match `FAILURE_CATEGORY_TO_CODE` in the CLI source; there is no `X010`.
 
 ---
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -71,7 +71,7 @@ The root object is a map from **scan path** (absolute path string) to a `ScanPat
 | `error` | object \| null | Path-level error when discovery/parsing failed for this path. See [Execution failures](#1-checking-for-execution-failures). |
 | `servers` | array \| null | Inspected MCP servers and skills. `null` when the config could not be read at all. |
 | `issues` | array | Security findings from analysis (`E*`, `W*`). Empty in `inspect` mode. |
-| `labels` | array | Per-tool risk label scores from analysis (MCP scans). Often empty for skills-only paths. |
+| `labels` | array | **Deprecated — do not rely on this field.** Kept for schema compatibility. After analysis it is usually a nested array of all-zero risk scores (`is_public_sink`, `destructive`, `untrusted_content`, `private_data` = 0) aligned to each entity; before analysis or in `inspect` mode it is often `[]`. Real findings live in `issues`. |
 
 ### Server entries (`ServerScanResult`)
 
@@ -89,7 +89,7 @@ The root object is a map from **scan path** (absolute path string) to a `ScanPat
 | --- | --- | --- |
 | `code` | string | Finding code (e.g. `E001`, `W015`). See [Issue codes](issue-codes.md). |
 | `message` | string | Human-readable description. |
-| `reference` | array \| null | `(server_index, entity_index)` into `servers` / entity lists, or `[server_index, null]` for server-scoped issues. |
+| `reference` | array \| null | Index pair into the result: `[server_index, entity_index]`. **`server_index`** selects an entry in `servers[]` (an MCP server *or* a skill). **`entity_index`** selects an item within that entry's catalog — an MCP **tool** (or prompt/resource) for servers, or a **file** within a skill bundle; `null` as the second element means the issue applies to the whole server/skill, not one entity. |
 | `extra_data` | object \| null | Optional structured context from analysis. |
 
 ### Error objects (`ScanError`)

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -10,10 +10,10 @@ Agent Scan operates in two main modes which can be used jointly or separately:
 
 ## Quick Start
 
-To run a full scan of your machine (auto-discovers agents, MCP servers, skills), run:
+To run a full scan of your machine (auto-discovers agents, MCP servers, and skills), run:
 
 ```bash
-uvx snyk-agent-scan@latest --skills
+uvx snyk-agent-scan@latest
 ```
 
 This will scan for security vulnerabilities in servers, skills, tools, prompts, and resources. It will automatically discover a variety of agent configurations, including Claude Code/Desktop, Cursor, Gemini CLI, and Windsurf.
@@ -21,19 +21,21 @@ This will scan for security vulnerabilities in servers, skills, tools, prompts, 
 You can also scan particular configuration files or skills:
 
 ```bash
-# scan mcp configurations
+# scan an MCP configuration
 uvx snyk-agent-scan@latest ~/.vscode/mcp.json
 # scan a single agent skill
-uvx snyk-agent-scan@latest  --skills ~/path/to/my/SKILL.md
+uvx snyk-agent-scan@latest ~/path/to/my/SKILL.md
 # scan all claude skills
-uvx snyk-agent-scan@latest  --skills ~/.claude/skills
+uvx snyk-agent-scan@latest ~/.claude/skills
+# MCP only (skip skills)
+uvx snyk-agent-scan@latest --no-skills
 ```
 
 ## How It Works
 
 ![Scanning overview](assets/scan.svg)
 
-Agent Scan searches through your local agent's configuration files to find agents, skills, and MCP servers. For MCP, it connects to servers and retrieves tool descriptions. Omit `--skills` to skip skill analysis.
+Agent Scan searches through your local agent's configuration files to find agents, skills, and MCP servers. For MCP, it connects to servers and retrieves tool descriptions. Skills are scanned by default; use `--no-skills` to skip skill analysis.
 
 It then validates the components, both with local checks and by invoking the Agent Scan API. For this, skills, agent applications, tool names, and descriptions are shared with Snyk. By using Agent Scan, you agree to the Snyk [terms of use for Agent Scan](../TERMS.md).
 
@@ -47,7 +49,7 @@ Quick summary:
 
 - **Default command:** `scan` (omit the subcommand to scan well-known agent configs)
 - **`inspect`:** discovery and MCP handshake only — no security analysis
-- **`--skills` / `--no-skills`:** skills are scanned by default; use `--no-skills` for MCP-only
+- **Skills:** included by default; use `--no-skills` for MCP-only (`--skills` is deprecated — see [CLI reference](cli-reference.md))
 - **`--ci`:** non-zero exit on findings (requires `--dangerously-run-mcp-servers` in CI)
 - **`--json`:** machine-readable output — see [JSON output](json-output.md)
 
@@ -59,6 +61,9 @@ snyk-agent-scan
 
 # Scan a specific config file
 snyk-agent-scan ~/custom/config.json
+
+# MCP only
+snyk-agent-scan --no-skills
 
 # Just inspect tools without verification
 snyk-agent-scan inspect

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -41,71 +41,20 @@ Agent Scan does not store or log any usage data, i.e. the contents and results o
 
 ## CLI Parameters
 
-```
-snyk-agent-scan - Security scanner for agents, MCP servers, and skills
-```
+For the complete, up-to-date list of commands, flags, options, environment variables, and exit codes, see **[CLI reference](cli-reference.md)**.
 
-### Common Options
+Quick summary:
 
-These options are available for all commands:
-
-```
---storage-file FILE    Path to store scan results and scanner state (default: ~/.mcp-scan)
---base-url URL         Base URL for the verification server
---verbose              Enable detailed logging output
---print-errors         Show error details and tracebacks
---full-toxic-flows     Show all tools that could take part in toxic flow. By default only the top 3 are shown.
---json                 Output results in JSON format instead of rich text
-```
-
-### Commands
-
-#### scan (default)
-
-Scan MCP configurations for security vulnerabilities in tools, prompts, and resources.
-
-```
-snyk-agent-scan scan [CONFIG_FILE...]
-```
-
-Options:
-
-```
---checks-per-server NUM           Number of checks to perform on each server (default: 1)
---server-timeout SECONDS          Seconds to wait before timing out server connections (default: 10)
---suppress-mcpserver-io BOOL      Suppress stdout/stderr from MCP servers (default: True)
---skills                          Autodetects and analyzes skills
---skills PATH_TO_SKILL_MD_FILE    Analyzes the specific skill
---skills PATHS_TO_DIRECTORY       Recursively detects and analyzes all skills in the directory
-```
-
-#### inspect
-
-Print descriptions of tools, prompts, and resources without verification.
-
-```
-snyk-agent-scan inspect [CONFIG_FILE...]
-```
-
-Options:
-
-```
---server-timeout SECONDS      Seconds to wait before timing out server connections (default: 10)
---suppress-mcpserver-io BOOL  Suppress stdout/stderr from MCP servers (default: True)
-```
-
-#### help
-
-Display detailed help information and examples.
-
-```bash
-snyk-agent-scan help
-```
+- **Default command:** `scan` (omit the subcommand to scan well-known agent configs)
+- **`inspect`:** discovery and MCP handshake only — no security analysis
+- **`--skills` / `--no-skills`:** skills are scanned by default; use `--no-skills` for MCP-only
+- **`--ci`:** non-zero exit on findings (requires `--dangerously-run-mcp-servers` in CI)
+- **`--json`:** machine-readable output — see [JSON output](json-output.md)
 
 ### Examples
 
 ```bash
-# Scan all known MCP configs
+# Scan all known MCP configs and agent skills
 snyk-agent-scan
 
 # Scan a specific config file
@@ -113,4 +62,7 @@ snyk-agent-scan ~/custom/config.json
 
 # Just inspect tools without verification
 snyk-agent-scan inspect
+
+# CI mode
+snyk-agent-scan --ci --dangerously-run-mcp-servers
 ```


### PR DESCRIPTION
## Summary
- Add `docs/cli-reference.md` — full reference for standalone `snyk-agent-scan` and `snyk agent-scan --experimental` (commands, flags, env vars, exit codes, handshake/consent matrix).
- Refresh `docs/json-output.md` for current `snyk-agent-scan` naming, JSON schema, runtime failure codes (`X001`–`X010`), and native `--ci` guidance.
- Replace outdated CLI parameter lists in `docs/scanning.md` with links to the new reference.
- Clarify Snyk CLI extension behavior: auth required for all modes, upload-to-Evo is the default for scan invocations, and `--no-upload` only skips the push.

## Test plan
- [x] Verified CLI help output against `docs/cli-reference.md`
- [x] Reviewed JSON field names against `ScanPathResult` / `ServerScanResult` models
- [x] Cross-checked Snyk CLI extension upload/auth logic against `cli-extension-agent-scan`
- [ ] Docs-only change — no runtime tests required