### PR TITLE
chore: enable parallel tests, add uv caching, validate builds on all platforms [ADS-739]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Print hostname
         run: hostname
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - uses: pre-commit/action@v3.0.1
   test:
     runs-on: ${{ matrix.os }}
@@ -23,7 +25,12 @@ jobs:
       AGENT_SCAN_CI_HOSTNAME: ${{ secrets.AGENT_SCAN_CI_HOSTNAME }}
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     strategy:
-      max-parallel: 1
+      # Run tests and ensure binary can be built for all supported platforms.
+      # ubuntu-latest: x86_64
+      # ubuntu-24.04-arm: ARM64
+      # windows-latest: x86_64
+      # macos-latest: ARM64
+      # macos-15-intel: x86_64
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-15-intel]
     steps:
@@ -34,26 +41,24 @@ jobs:
           echo "AGENT_SCAN_CI_HOSTNAME=${{ env.AGENT_SCAN_CI_HOSTNAME }}"
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-      - name: Create venv
-        run: uv venv
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: Run tests
-        run: make ci
-      # build and store whl as artifact
-      - name: Build and store whl
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          make build
-          mkdir -p ${{ github.workspace }}/artifacts
-          cp dist/*.whl ${{ github.workspace }}/artifacts/
-      - name: Build and store binary
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          make binary
-          mkdir -p ${{ github.workspace }}/artifacts
-          cp dist/agent-scan ${{ github.workspace }}/artifacts/
-      - name: Upload whl artifact for this build
-        if: matrix.os == 'ubuntu-latest'
+        run: uv run --frozen make ci
+      - name: Upload binary artifact
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
-          name: agent-scan-latest.whl
-          path: ${{ github.workspace }}/artifacts/*.whl
+          name: agent-scan-${{ matrix.os }}-binary
+          path: dist/agent-scan*
+          if-no-files-found: error
+      - name: Build wheel
+        run: uv run --frozen make build
+      - name: Upload wheel artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-scan-${{ matrix.os }}.whl
+          path: dist/*.whl
+          if-no-files-found: error


### PR DESCRIPTION
* Enables parallel testing across all platforms by removing `max-parallel: 1`
* Adds uv dependency caching subsequent runs on the same branch run faster.
* Builds both the wheel and the binary on every platform for sanity (previously ubuntu-only)
* Uploads the built artifacts (binary + wheel) only from the main branch and not on PRs
